### PR TITLE
Weakpoint combat prototype

### DIFF
--- a/server-minestom/src/main/kotlin/dev/projects/server/FixedAttackTester.kt
+++ b/server-minestom/src/main/kotlin/dev/projects/server/FixedAttackTester.kt
@@ -16,6 +16,17 @@ enum class FixedAttackType(
     ;
 }
 
+enum class FixedWeakpoint {
+    HEAD,
+    BACK,
+    ;
+}
+
+data class FixedWeakpointSelection(
+    val weakpoint: FixedWeakpoint,
+    val center: Point,
+)
+
 data class FixedAttackTarget(val id: UUID, val position: Point)
 
 sealed interface FixedAttackEvent {
@@ -138,6 +149,11 @@ class FixedAttackTester(
         const val FORWARD_SLAM_MIN_FORWARD = 0.5
         const val FORWARD_SLAM_HALF_WIDTH = 1.0
         const val VERTICAL_RANGE = 2.0
+        const val WEAKPOINT_RADIUS = 0.45
+        private const val HEAD_FORWARD_OFFSET = 0.55
+        private const val BACK_FORWARD_OFFSET = -0.55
+        private const val HEAD_HEIGHT = 2.0
+        private const val BACK_HEIGHT = 1.45
 
         fun isInAttackRegion(attack: FixedAttackType, origin: Point, direction: Vec, target: Point): Boolean {
             val offsetX = target.x() - origin.x()
@@ -169,6 +185,82 @@ class FixedAttackTester(
             val length = sqrt(direction.x() * direction.x() + direction.z() * direction.z())
             return if (length > 1.0e-9) {
                 Vec(direction.x() / length, 0.0, direction.z() / length)
+            } else {
+                Vec(0.0, 0.0, 1.0)
+            }
+        }
+
+        fun weakpointCenter(origin: Point, facing: Vec, weakpoint: FixedWeakpoint): Point {
+            val forward = normalizeHorizontal(facing)
+            val forwardOffset = when (weakpoint) {
+                FixedWeakpoint.HEAD -> HEAD_FORWARD_OFFSET
+                FixedWeakpoint.BACK -> BACK_FORWARD_OFFSET
+            }
+            val height = when (weakpoint) {
+                FixedWeakpoint.HEAD -> HEAD_HEIGHT
+                FixedWeakpoint.BACK -> BACK_HEIGHT
+            }
+            return origin.add(forward.x() * forwardOffset, height, forward.z() * forwardOffset)
+        }
+
+        /** Selects one server-owned weakpoint from the player's current forward ray. */
+        fun selectWeakpoint(
+            playerPosition: Point,
+            playerDirection: Vec,
+            testerOrigin: Point,
+            testerFacing: Vec,
+            weaponRange: Double,
+            weakpointRadius: Double = WEAKPOINT_RADIUS,
+        ): FixedWeakpointSelection? {
+            require(weaponRange >= 0.0) { "Weapon range must not be negative" }
+            require(weakpointRadius >= 0.0) { "Weakpoint radius must not be negative" }
+
+            val ray = normalize(playerDirection)
+            val radiusSquared = weakpointRadius * weakpointRadius
+            val rangeSquared = weaponRange * weaponRange
+            data class Candidate(
+                val selection: FixedWeakpointSelection,
+                val rayDistanceSquared: Double,
+                val playerDistanceSquared: Double,
+            )
+
+            val candidates = FixedWeakpoint.entries.mapNotNull { weakpoint ->
+                val center = weakpointCenter(testerOrigin, testerFacing, weakpoint)
+                val offsetX = center.x() - playerPosition.x()
+                val offsetY = center.y() - playerPosition.y()
+                val offsetZ = center.z() - playerPosition.z()
+                val projection = offsetX * ray.x() + offsetY * ray.y() + offsetZ * ray.z()
+                if (projection < 0.0) return@mapNotNull null
+
+                val closestX = offsetX - ray.x() * projection
+                val closestY = offsetY - ray.y() * projection
+                val closestZ = offsetZ - ray.z() * projection
+                val rayDistanceSquared =
+                    closestX * closestX + closestY * closestY + closestZ * closestZ
+                val playerDistanceSquared = offsetX * offsetX + offsetY * offsetY + offsetZ * offsetZ
+                if (playerDistanceSquared > rangeSquared || rayDistanceSquared > radiusSquared) {
+                    return@mapNotNull null
+                }
+                Candidate(
+                    FixedWeakpointSelection(weakpoint, center),
+                    rayDistanceSquared,
+                    playerDistanceSquared,
+                )
+            }
+
+            return candidates.minWithOrNull(
+                compareBy<Candidate> { it.rayDistanceSquared }.thenBy { it.playerDistanceSquared },
+            )?.selection
+        }
+
+        private fun normalize(direction: Vec): Vec {
+            val length = sqrt(
+                direction.x() * direction.x() +
+                    direction.y() * direction.y() +
+                    direction.z() * direction.z(),
+            )
+            return if (length > 1.0e-9) {
+                Vec(direction.x() / length, direction.y() / length, direction.z() / length)
             } else {
                 Vec(0.0, 0.0, 1.0)
             }

--- a/server-minestom/src/main/kotlin/dev/projects/server/FixedAttackTester.kt
+++ b/server-minestom/src/main/kotlin/dev/projects/server/FixedAttackTester.kt
@@ -150,8 +150,9 @@ class FixedAttackTester(
         const val FORWARD_SLAM_HALF_WIDTH = 1.0
         const val VERTICAL_RANGE = 2.0
         const val WEAKPOINT_RADIUS = 0.45
-        private const val HEAD_FORWARD_OFFSET = 0.55
-        private const val BACK_FORWARD_OFFSET = -0.55
+        // Keep the hit centers just outside the Ravager model so the marker is not occluded.
+        private const val HEAD_FORWARD_OFFSET = 0.9
+        private const val BACK_FORWARD_OFFSET = -0.9
         private const val HEAD_HEIGHT = 2.0
         private const val BACK_HEIGHT = 1.45
 

--- a/server-minestom/src/main/kotlin/dev/projects/server/ProjectSServer.kt
+++ b/server-minestom/src/main/kotlin/dev/projects/server/ProjectSServer.kt
@@ -316,17 +316,19 @@ private fun showWeakpointMarkers(player: net.minestom.server.entity.Player, orig
     val right = Vec(-forward.z(), 0.0, forward.x())
     for (weakpoint in FixedWeakpoint.entries) {
         val center = FixedAttackTester.weakpointCenter(origin, forward, weakpoint)
-        sendTesterParticle(player, Particle.END_ROD, center)
-        sendTesterParticle(
-            player,
-            Particle.END_ROD,
-            center.add(right.x() * 0.14, 0.08, right.z() * 0.14),
-        )
-        sendTesterParticle(
-            player,
-            Particle.END_ROD,
-            center.add(-right.x() * 0.14, -0.08, -right.z() * 0.14),
-        )
+        for (step in 0..5) {
+            val angle = step * Math.PI / 3.0
+            val radial = Vec(
+                right.x() * kotlin.math.cos(angle) + forward.x() * kotlin.math.sin(angle),
+                0.0,
+                right.z() * kotlin.math.cos(angle) + forward.z() * kotlin.math.sin(angle),
+            )
+            sendTesterParticle(
+                player,
+                Particle.GLOW,
+                center.add(radial.x() * 0.18, kotlin.math.cos(angle) * 0.08, radial.z() * 0.18),
+            )
+        }
     }
 }
 

--- a/server-minestom/src/main/kotlin/dev/projects/server/ProjectSServer.kt
+++ b/server-minestom/src/main/kotlin/dev/projects/server/ProjectSServer.kt
@@ -32,6 +32,9 @@ import net.minestom.server.item.Material
 import net.minestom.server.network.packet.server.common.PluginMessagePacket
 import net.minestom.server.network.packet.server.play.ParticlePacket
 import net.minestom.server.particle.Particle
+import net.minestom.server.sound.SoundEvent
+import net.kyori.adventure.sound.Sound
+import net.kyori.adventure.key.Key
 import java.nio.charset.StandardCharsets
 import java.util.UUID
 import kotlin.math.floor
@@ -63,6 +66,7 @@ fun main() {
     val dodgeVelocityActive = mutableMapOf<UUID, Boolean>()
     val attackSpeeds = mutableMapOf<UUID, Double>()
     var dummy: Entity? = null
+    var testerMarkerTick = 0L
     val fixedTester = FixedAttackTester()
 
     val speedArgument = ArgumentType.Double("speed")
@@ -104,12 +108,17 @@ fun main() {
                 ItemStack.builder(Material.BLAZE_ROD).customName(Component.text("Twin Rods")).build(),
             )
             if (dummy == null) {
-                dummy = Entity(EntityType.PIG).apply {
+                dummy = Entity(EntityType.RAVAGER).apply {
                     customName = Component.text("Fixed Attack Tester")
                     isCustomNameVisible = true
                     setNoGravity(true)
                     setHasPhysics(false)
-                    setInstance(instance, event.player.position.add(event.player.position.direction().mul(3.0)))
+                    setInstance(
+                        instance,
+                        event.player.position
+                            .add(event.player.position.direction().mul(3.0))
+                            .withDirection(event.player.position),
+                    )
                 }
             }
             event.player.sendPacket(
@@ -128,16 +137,31 @@ fun main() {
         val dodge = dodgeStates[event.player.uuid] ?: return@addListener
         val twinRodsAir = twinRodsAirStates[event.player.uuid] ?: return@addListener
         if (event.player == instance.players.firstOrNull()) {
-            tickFixedTester(instance, dummy, fixedTester)
+            tickFixedTester(instance, dummy, fixedTester, testerMarkerTick++)
         }
         twinRodsAir.tick(event.player.isOnGround)
         if (dodge.hasPending) state.deferAttackRestart()
-        val targets = dummy?.takeIf { it.instance == event.player.instance && !it.isRemoved }
-            ?.let { listOf(CombatTarget(it.uuid, it.position)) }
-            ?: emptyList()
+        val tester = dummy?.takeIf { it.instance == event.player.instance && !it.isRemoved }
+        val testerId = tester?.uuid
+        val weakpoint = tester?.let {
+            val weapon = state.activeProfile?.weapon ?: weaponFor(event.player)
+            val range = state.activeProfile?.range
+                ?: weapon.profile(attackSpeeds[event.player.uuid] ?: DEFAULT_ATTACK_SPEED).range
+            FixedAttackTester.selectWeakpoint(
+                playerPosition = event.player.position,
+                playerDirection = event.player.position.direction(),
+                testerOrigin = it.position,
+                testerFacing = it.position.direction(),
+                weaponRange = range,
+            )
+        }
+        val targets = tester?.let { listOf(CombatTarget(it.uuid, weakpoint?.center ?: it.position)) } ?: emptyList()
         val combatEvents = state.tick(event.player.position, event.player.position.direction(), targets)
         combatEvents.filterIsInstance<CombatEvent.HitConfirmed>().forEach { hit ->
             twinRodsAir.onAttackHit(hit.weapon, event.player.isOnGround, hit.attackExecutionId)
+        }
+        if (weakpoint != null && combatEvents.any { it is CombatEvent.HitConfirmed && it.targetId == testerId }) {
+            showWeakpointHit(event.player, weakpoint)
         }
         publishCombatEvents(event.player, combatEvents)
         val currentWeapon = weaponFor(event.player)
@@ -234,10 +258,14 @@ private fun weaponFor(player: net.minestom.server.entity.Player): WeaponType = w
     else -> WeaponType.HEAVY_BLADE
 }
 
-private fun tickFixedTester(instance: Instance, testerEntity: Entity?, tester: FixedAttackTester) {
+private fun tickFixedTester(instance: Instance, testerEntity: Entity?, tester: FixedAttackTester, markerTick: Long) {
     if (testerEntity == null || testerEntity.isRemoved || testerEntity.instance != instance) return
     val players = instance.players.filter { it.isOnline }
     if (players.isEmpty()) return
+    if (markerTick % 2L == 0L) {
+        val weakpointFacing = testerEntity.position.direction()
+        players.forEach { player -> showWeakpointMarkers(player, testerEntity.position, weakpointFacing) }
+    }
     val targets = players.map { FixedAttackTarget(it.uuid, it.position) }
     val facing = players.firstOrNull()?.let { directionFrom(testerEntity.position, it.position) }
         ?: testerEntity.position.direction()
@@ -281,6 +309,68 @@ private fun tickFixedTester(instance: Instance, testerEntity: Entity?, tester: F
             }
         }
     }
+}
+
+private fun showWeakpointMarkers(player: net.minestom.server.entity.Player, origin: Pos, facing: Vec) {
+    val forward = FixedAttackTester.normalizeHorizontal(facing)
+    val right = Vec(-forward.z(), 0.0, forward.x())
+    for (weakpoint in FixedWeakpoint.entries) {
+        val center = FixedAttackTester.weakpointCenter(origin, forward, weakpoint)
+        sendTesterParticle(player, Particle.END_ROD, center)
+        sendTesterParticle(
+            player,
+            Particle.END_ROD,
+            center.add(right.x() * 0.14, 0.08, right.z() * 0.14),
+        )
+        sendTesterParticle(
+            player,
+            Particle.END_ROD,
+            center.add(-right.x() * 0.14, -0.08, -right.z() * 0.14),
+        )
+    }
+}
+
+private fun showWeakpointHit(
+    player: net.minestom.server.entity.Player,
+    selection: FixedWeakpointSelection,
+) {
+    val center = selection.center
+    player.sendMessage(Component.text("[Tester] WEAKPOINT: ${selection.weakpoint}"))
+    player.sendPacket(
+        ParticlePacket(
+            Particle.CRIT,
+            center.x(),
+            center.y(),
+            center.z(),
+            0.45f,
+            0.45f,
+            0.45f,
+            0.18f,
+            18,
+        ),
+    )
+    player.sendPacket(
+        ParticlePacket(
+            Particle.DAMAGE_INDICATOR,
+            center.x(),
+            center.y(),
+            center.z(),
+            0.2f,
+            0.2f,
+            0.2f,
+            0.1f,
+            10,
+        ),
+    )
+    player.playSound(
+        Sound.sound(
+            requireNotNull(SoundEvent.fromKey(Key.key("minecraft", "entity.player.attack.crit"))),
+            Sound.Source.PLAYER,
+            1.0f,
+            1.2f,
+        ),
+        center,
+    )
 }
 
 private fun directionFrom(origin: Pos, target: Pos): Vec =

--- a/server-minestom/src/main/kotlin/dev/projects/server/ProjectSServer.kt
+++ b/server-minestom/src/main/kotlin/dev/projects/server/ProjectSServer.kt
@@ -148,7 +148,7 @@ fun main() {
             val range = state.activeProfile?.range
                 ?: weapon.profile(attackSpeeds[event.player.uuid] ?: DEFAULT_ATTACK_SPEED).range
             FixedAttackTester.selectWeakpoint(
-                playerPosition = event.player.position,
+                playerPosition = event.player.position.add(0.0, event.player.eyeHeight, 0.0),
                 playerDirection = event.player.position.direction(),
                 testerOrigin = it.position,
                 testerFacing = it.position.direction(),

--- a/server-minestom/src/main/kotlin/dev/projects/server/ProjectSServer.kt
+++ b/server-minestom/src/main/kotlin/dev/projects/server/ProjectSServer.kt
@@ -113,11 +113,11 @@ fun main() {
                     isCustomNameVisible = true
                     setNoGravity(true)
                     setHasPhysics(false)
+                    val spawnPos = event.player.position
+                        .add(event.player.position.direction().mul(3.0))
                     setInstance(
                         instance,
-                        event.player.position
-                            .add(event.player.position.direction().mul(3.0))
-                            .withDirection(event.player.position),
+                        spawnPos.withDirection(directionFrom(spawnPos, event.player.position)),
                     )
                 }
             }
@@ -373,7 +373,7 @@ private fun showWeakpointHit(
     )
 }
 
-private fun directionFrom(origin: Pos, target: Pos): Vec =
+internal fun directionFrom(origin: Pos, target: Pos): Vec =
     FixedAttackTester.normalizeHorizontal(
         Vec(target.x() - origin.x(), 0.0, target.z() - origin.z()),
     )

--- a/server-minestom/src/test/kotlin/dev/projects/server/CombatTest.kt
+++ b/server-minestom/src/test/kotlin/dev/projects/server/CombatTest.kt
@@ -24,6 +24,22 @@ class CombatTest {
     }
 
     @Test
+    fun `weakpoint target position still hits only once per execution`() {
+        val combat = CombatState(sequence())
+        val selection = FixedAttackTester.selectWeakpoint(
+            playerPosition = Pos(0.0, 2.0, 3.0),
+            playerDirection = Vec(0.0, 0.0, -1.0),
+            testerOrigin = origin,
+            testerFacing = forward,
+            weaponRange = 4.5,
+        )
+        val target = CombatTarget(targetId, selection!!.center)
+
+        combat.input(AttackInputState.PRESS)
+        assertEquals(listOf(targetId), finishAttack(combat, listOf(target)))
+    }
+
+    @Test
     fun `out of range and behind targets miss`() {
         val combat = CombatState(sequence())
         val targets = listOf(

--- a/server-minestom/src/test/kotlin/dev/projects/server/FixedAttackTesterTest.kt
+++ b/server-minestom/src/test/kotlin/dev/projects/server/FixedAttackTesterTest.kt
@@ -152,6 +152,14 @@ class FixedAttackTesterTest {
         assertEquals(0.0, back.z())
     }
 
+    @Test
+    fun `direction from origin to target is horizontal and normalized`() {
+        assertEquals(Vec(0.0, 0.0, 1.0), directionFrom(origin, Pos(0.0, 9.0, 4.0)))
+        assertEquals(Vec(0.0, 0.0, -1.0), directionFrom(origin, Pos(0.0, -9.0, -4.0)))
+        assertEquals(Vec(1.0, 0.0, 0.0), directionFrom(origin, Pos(4.0, 9.0, 0.0)))
+        assertEquals(Vec(-1.0, 0.0, 0.0), directionFrom(origin, Pos(-4.0, -9.0, 0.0)))
+    }
+
     private fun inRegion(attack: FixedAttackType, target: Pos): Boolean =
         FixedAttackTester.isInAttackRegion(attack, origin, forward, target)
 

--- a/server-minestom/src/test/kotlin/dev/projects/server/FixedAttackTesterTest.kt
+++ b/server-minestom/src/test/kotlin/dev/projects/server/FixedAttackTesterTest.kt
@@ -146,8 +146,8 @@ class FixedAttackTesterTest {
         val head = FixedAttackTester.weakpointCenter(origin, Vec(1.0, 0.0, 0.0), FixedWeakpoint.HEAD)
         val back = FixedAttackTester.weakpointCenter(origin, Vec(1.0, 0.0, 0.0), FixedWeakpoint.BACK)
 
-        assertEquals(0.55, head.x())
-        assertEquals(-0.55, back.x())
+        assertEquals(0.9, head.x())
+        assertEquals(-0.9, back.x())
         assertEquals(0.0, head.z())
         assertEquals(0.0, back.z())
     }

--- a/server-minestom/src/test/kotlin/dev/projects/server/FixedAttackTesterTest.kt
+++ b/server-minestom/src/test/kotlin/dev/projects/server/FixedAttackTesterTest.kt
@@ -75,6 +75,83 @@ class FixedAttackTesterTest {
         assertEquals(FixedAttackType.FORWARD_SLAM, next.filterIsInstance<FixedAttackEvent.Started>().single().attack)
     }
 
+    @Test
+    fun `ray through head selects head`() {
+        val selection = FixedAttackTester.selectWeakpoint(
+            playerPosition = Pos(0.0, 2.0, 3.0),
+            playerDirection = Vec(0.0, 0.0, -1.0),
+            testerOrigin = origin,
+            testerFacing = forward,
+            weaponRange = 4.5,
+        )
+
+        assertEquals(FixedWeakpoint.HEAD, selection?.weakpoint)
+    }
+
+    @Test
+    fun `aiming outside head radius falls back to body`() {
+        val selection = FixedAttackTester.selectWeakpoint(
+            playerPosition = Pos(1.0, 2.0, 3.0),
+            playerDirection = Vec(0.0, 0.0, -1.0),
+            testerOrigin = origin,
+            testerFacing = forward,
+            weaponRange = 4.5,
+        )
+
+        assertEquals(null, selection)
+    }
+
+    @Test
+    fun `ray from behind selects back`() {
+        val selection = FixedAttackTester.selectWeakpoint(
+            playerPosition = Pos(0.0, 1.45, -3.0),
+            playerDirection = forward,
+            testerOrigin = origin,
+            testerFacing = forward,
+            weaponRange = 4.5,
+        )
+
+        assertEquals(FixedWeakpoint.BACK, selection?.weakpoint)
+    }
+
+    @Test
+    fun `weakpoint outside range falls back to body`() {
+        val selection = FixedAttackTester.selectWeakpoint(
+            playerPosition = Pos(0.0, 2.0, 6.0),
+            playerDirection = Vec(0.0, 0.0, -1.0),
+            testerOrigin = origin,
+            testerFacing = forward,
+            weaponRange = 2.0,
+        )
+
+        assertEquals(null, selection)
+    }
+
+    @Test
+    fun `overlapping weakpoints choose only the ray closest candidate`() {
+        val selection = FixedAttackTester.selectWeakpoint(
+            playerPosition = Pos(0.0, 1.7, -3.0),
+            playerDirection = forward,
+            testerOrigin = origin,
+            testerFacing = forward,
+            weaponRange = 5.0,
+            weakpointRadius = 1.0,
+        )
+
+        assertEquals(FixedWeakpoint.BACK, selection?.weakpoint)
+    }
+
+    @Test
+    fun `weakpoint center rotates with tester facing`() {
+        val head = FixedAttackTester.weakpointCenter(origin, Vec(1.0, 0.0, 0.0), FixedWeakpoint.HEAD)
+        val back = FixedAttackTester.weakpointCenter(origin, Vec(1.0, 0.0, 0.0), FixedWeakpoint.BACK)
+
+        assertEquals(0.55, head.x())
+        assertEquals(-0.55, back.x())
+        assertEquals(0.0, head.z())
+        assertEquals(0.0, back.z())
+    }
+
     private fun inRegion(attack: FixedAttackType, target: Pos): Boolean =
         FixedAttackTester.isInAttackRegion(attack, origin, forward, target)
 


### PR DESCRIPTION
穿龍棍で大型敵の弱点を追う最小prototypeをmainへ統合します。

含むもの:
- Ravager Fixed Attack Tester
- HEAD / BACK weakpoint
- ray + sphere近似によるServer-side弱点選択
- Player eye position基準の照準ray
- Tester facing修正
- 常時見えるGLOW marker
- Weakpoint専用Hit feedback
- 既存1 attack execution = 1 hit保証維持

#30〜#33はSol Review済み、Test/Build成功、Manual SmokeもPASS。