### PR TITLE
First boss combat loop

### DIFF
--- a/server-minestom/src/main/kotlin/dev/projects/server/Combat.kt
+++ b/server-minestom/src/main/kotlin/dev/projects/server/Combat.kt
@@ -98,6 +98,16 @@ class CombatState(
         if (phase != null) deferAttackRestart = true
     }
 
+    fun reset() {
+        held = false
+        phase = null
+        phaseTicks = 0
+        executionId = 0L
+        deferAttackRestart = false
+        hitTargets.clear()
+        activeProfile = null
+    }
+
     fun tick(position: Point, direction: Vec, targets: Collection<CombatTarget>): List<CombatEvent> {
         if (phase == null) {
             if (held) return startAttack()
@@ -243,6 +253,13 @@ class DodgeState {
     internal fun stop() {
         active = false
         elapsedTicks = DURATION_TICKS
+    }
+
+    fun reset() {
+        active = false
+        elapsedTicks = 0
+        direction = Vec.ZERO
+        pendingInput = null
     }
 
     companion object {

--- a/server-minestom/src/main/kotlin/dev/projects/server/FixedAttackTester.kt
+++ b/server-minestom/src/main/kotlin/dev/projects/server/FixedAttackTester.kt
@@ -10,9 +10,10 @@ enum class FixedAttackType(
     val telegraphTicks: Int,
     val activeTicks: Int,
     val recoveryTicks: Int,
+    val damage: Int,
 ) {
-    SIDE_SWEEP(14, 2, 18),
-    FORWARD_SLAM(18, 2, 22),
+    SIDE_SWEEP(14, 2, 18, 6),
+    FORWARD_SLAM(18, 2, 22, 8),
     ;
 }
 
@@ -49,7 +50,11 @@ sealed interface FixedAttackEvent {
         val direction: Vec,
     ) : FixedAttackEvent
 
-    data class HitConfirmed(val executionId: Long, val targetId: UUID) : FixedAttackEvent
+    data class HitConfirmed(
+        val executionId: Long,
+        val targetId: UUID,
+        val attack: FixedAttackType,
+    ) : FixedAttackEvent
 }
 
 private enum class TesterPhase {
@@ -107,7 +112,7 @@ class FixedAttackTester(
                 for (target in targets) {
                     if (target.id !in hitTargets && isInAttackRegion(attack, origin, attackDirection, target.position)) {
                         hitTargets += target.id
-                        events += FixedAttackEvent.HitConfirmed(executionId, target.id)
+                        events += FixedAttackEvent.HitConfirmed(executionId, target.id, attack)
                     }
                 }
                 phaseTicks--
@@ -140,6 +145,15 @@ class FixedAttackTester(
         phaseTicks = nextAttack.telegraphTicks
         hitTargets.clear()
         events += FixedAttackEvent.Started(executionId, nextAttack, attackDirection)
+    }
+
+    fun reset() {
+        phase = TesterPhase.PAUSE
+        phaseTicks = initialPauseTicks
+        nextAttack = FixedAttackType.SIDE_SWEEP
+        executionId = 0L
+        attackDirection = Vec(0.0, 0.0, 1.0)
+        hitTargets.clear()
     }
 
     companion object {

--- a/server-minestom/src/main/kotlin/dev/projects/server/ProjectSServer.kt
+++ b/server-minestom/src/main/kotlin/dev/projects/server/ProjectSServer.kt
@@ -236,7 +236,10 @@ fun main() {
                 weakpoint = weakpoint?.weakpoint,
             )
             twinRodsAir.onAttackHit(hit.weapon, event.player.isOnGround, hit.attackExecutionId)
-            if (damage > 0 && weakpoint != null) showWeakpointHit(event.player, weakpoint)
+            if (damage > 0) {
+                updateBossBar()
+                if (weakpoint != null) showWeakpointHit(event.player, weakpoint)
+            }
         }
         publishCombatEvents(event.player, combatEvents)
         if (!prototypeBoss.isActive) {
@@ -381,7 +384,7 @@ private fun tickFixedTester(
                 instance.getPlayerByUuid(event.targetId)?.let { player ->
                     val damage = bossState.applyBossAttack(player.uuid, event.executionId, event.attack)
                     if (damage == 0) return@let
-                    player.setHealth(bossState.playerHealth(player.uuid).toFloat())
+                    player.setHealth(bossState.playerEntityHealth(player.uuid))
                     player.sendMessage(Component.text("[Tester] HIT"))
                     player.sendPacket(
                         ParticlePacket(

--- a/server-minestom/src/main/kotlin/dev/projects/server/ProjectSServer.kt
+++ b/server-minestom/src/main/kotlin/dev/projects/server/ProjectSServer.kt
@@ -11,6 +11,7 @@ import dev.projects.protocol.ProtocolHello
 import dev.projects.protocol.ProtocolHelloAck
 import dev.projects.protocol.ProtocolVersion
 import net.kyori.adventure.text.Component
+import net.kyori.adventure.bossbar.BossBar
 import net.minestom.server.Auth
 import net.minestom.server.MinecraftServer
 import net.minestom.server.ServerFlag
@@ -65,9 +66,66 @@ fun main() {
     val twinRodsAirStates = mutableMapOf<UUID, TwinRodsAirState>()
     val dodgeVelocityActive = mutableMapOf<UUID, Boolean>()
     val attackSpeeds = mutableMapOf<UUID, Double>()
+    val prototypeBoss = PrototypeBossState()
+    val bossBar = BossBar.bossBar(
+        Component.text("Prototype Hunt Boss ${prototypeBoss.currentHealth} / ${prototypeBoss.maxHealth}"),
+        prototypeBoss.healthProgress,
+        BossBar.Color.RED,
+        BossBar.Overlay.PROGRESS,
+    )
     var dummy: Entity? = null
     var testerMarkerTick = 0L
     val fixedTester = FixedAttackTester()
+
+    fun updateBossBar() {
+        val status = when {
+            prototypeBoss.isVictory -> "VICTORY"
+            prototypeBoss.isDefeat -> "DEFEAT"
+            else -> null
+        }
+        val label = buildString {
+            append("Prototype Hunt Boss")
+            if (status != null) append(" - $status")
+            append(" ${prototypeBoss.currentHealth} / ${prototypeBoss.maxHealth}")
+        }
+        bossBar.name(Component.text(label))
+        bossBar.progress(prototypeBoss.healthProgress)
+    }
+
+    fun stopPlayerActions() {
+        combatStates.values.forEach { it.reset() }
+        dodgeStates.values.forEach { it.reset() }
+        twinRodsAirStates.values.forEach { it.tick(true) }
+        instance.players.forEach { player ->
+            player.setVelocity(Vec.ZERO)
+        }
+        dodgeVelocityActive.clear()
+    }
+
+    fun resetPlayers() {
+        stopPlayerActions()
+        instance.players.forEach { player ->
+            player.setHealth(prototypeBoss.playerMaxHealth.toFloat())
+            player.teleport(player.respawnPoint)
+            player.showBossBar(bossBar)
+        }
+    }
+
+    fun finishEncounter() {
+        fixedTester.reset()
+        stopPlayerActions()
+        updateBossBar()
+        val result = if (prototypeBoss.isVictory) "VICTORY" else "DEFEAT"
+        instance.players.forEach { it.sendMessage(Component.text(result)) }
+    }
+
+    fun resetEncounter() {
+        prototypeBoss.reset()
+        fixedTester.reset()
+        resetPlayers()
+        updateBossBar()
+        instance.players.forEach { it.sendMessage(Component.text("Prototype Hunt Boss reset")) }
+    }
 
     val speedArgument = ArgumentType.Double("speed")
     fun handleAttackSpeed(sender: CommandSender, context: CommandContext) {
@@ -87,12 +145,19 @@ fun main() {
     MinecraftServer.getCommandManager().register(
         Command("as").apply { addSyntax(::handleAttackSpeed, speedArgument) },
     )
+    MinecraftServer.getCommandManager().register(
+        Command("bossreset").apply { setDefaultExecutor { _, _ -> resetEncounter() } },
+    )
 
     events.addListener(AsyncPlayerConfigurationEvent::class.java) { event ->
         event.spawningInstance = instance
         event.player.respawnPoint = Pos(0.0, 41.0, 0.0)
     }
     events.addListener(PlayerSpawnEvent::class.java) { event ->
+        prototypeBoss.registerPlayer(event.player.uuid)
+        event.player.setHealth(prototypeBoss.playerMaxHealth.toFloat())
+        updateBossBar()
+        event.player.showBossBar(bossBar)
         if (event.isFirstSpawn) {
             attackSpeeds[event.player.uuid] = DEFAULT_ATTACK_SPEED
             combatStates[event.player.uuid] = CombatState(
@@ -109,7 +174,7 @@ fun main() {
             )
             if (dummy == null) {
                 dummy = Entity(EntityType.RAVAGER).apply {
-                    customName = Component.text("Fixed Attack Tester")
+                    customName = Component.text("Prototype Hunt Boss")
                     isCustomNameVisible = true
                     setNoGravity(true)
                     setHasPhysics(false)
@@ -137,8 +202,15 @@ fun main() {
         val dodge = dodgeStates[event.player.uuid] ?: return@addListener
         val twinRodsAir = twinRodsAirStates[event.player.uuid] ?: return@addListener
         if (event.player == instance.players.firstOrNull()) {
-            tickFixedTester(instance, dummy, fixedTester, testerMarkerTick++)
+            if (prototypeBoss.isActive) {
+                tickFixedTester(instance, dummy, fixedTester, prototypeBoss, testerMarkerTick++)
+                if (!prototypeBoss.isActive) {
+                    finishEncounter()
+                    return@addListener
+                }
+            }
         }
+        if (!prototypeBoss.isActive) return@addListener
         twinRodsAir.tick(event.player.isOnGround)
         if (dodge.hasPending) state.deferAttackRestart()
         val tester = dummy?.takeIf { it.instance == event.player.instance && !it.isRemoved }
@@ -158,12 +230,19 @@ fun main() {
         val targets = tester?.let { listOf(CombatTarget(it.uuid, weakpoint?.center ?: it.position)) } ?: emptyList()
         val combatEvents = state.tick(event.player.position, event.player.position.direction(), targets)
         combatEvents.filterIsInstance<CombatEvent.HitConfirmed>().forEach { hit ->
+            val damage = prototypeBoss.applyPlayerAttack(
+                attackExecutionId = hit.attackExecutionId,
+                weapon = hit.weapon,
+                weakpoint = weakpoint?.weakpoint,
+            )
             twinRodsAir.onAttackHit(hit.weapon, event.player.isOnGround, hit.attackExecutionId)
-        }
-        if (weakpoint != null && combatEvents.any { it is CombatEvent.HitConfirmed && it.targetId == testerId }) {
-            showWeakpointHit(event.player, weakpoint)
+            if (damage > 0 && weakpoint != null) showWeakpointHit(event.player, weakpoint)
         }
         publishCombatEvents(event.player, combatEvents)
+        if (!prototypeBoss.isActive) {
+            finishEncounter()
+            return@addListener
+        }
         val currentWeapon = weaponFor(event.player)
         if (currentWeapon != WeaponType.TWIN_RODS) twinRodsAir.clearAirJump()
         val velocityWasApplied = dodgeVelocityActive[event.player.uuid] == true
@@ -198,10 +277,12 @@ fun main() {
                     println("ProjectS handshake complete for ${event.player.username}")
                 }
                 is AttackInput -> {
+                    if (!prototypeBoss.isActive) return@addListener
                     val state = combatStates[event.player.uuid] ?: return@addListener
                     publishCombatEvents(event.player, state.input(message.state))
                 }
                 is DodgeInput -> {
+                    if (!prototypeBoss.isActive) return@addListener
                     val state = combatStates[event.player.uuid] ?: return@addListener
                     val dodge = dodgeStates[event.player.uuid] ?: return@addListener
                     val twinRodsAir = twinRodsAirStates[event.player.uuid] ?: return@addListener
@@ -219,6 +300,7 @@ fun main() {
                     )
                 }
                 is AirJumpInput -> {
+                    if (!prototypeBoss.isActive) return@addListener
                     val twinRodsAir = twinRodsAirStates[event.player.uuid] ?: return@addListener
                     if (!event.player.isOnGround &&
                         weaponFor(event.player) == WeaponType.TWIN_RODS &&
@@ -258,7 +340,13 @@ private fun weaponFor(player: net.minestom.server.entity.Player): WeaponType = w
     else -> WeaponType.HEAVY_BLADE
 }
 
-private fun tickFixedTester(instance: Instance, testerEntity: Entity?, tester: FixedAttackTester, markerTick: Long) {
+private fun tickFixedTester(
+    instance: Instance,
+    testerEntity: Entity?,
+    tester: FixedAttackTester,
+    bossState: PrototypeBossState,
+    markerTick: Long,
+) {
     if (testerEntity == null || testerEntity.isRemoved || testerEntity.instance != instance) return
     val players = instance.players.filter { it.isOnline }
     if (players.isEmpty()) return
@@ -291,6 +379,9 @@ private fun tickFixedTester(instance: Instance, testerEntity: Entity?, tester: F
             }
             is FixedAttackEvent.HitConfirmed -> {
                 instance.getPlayerByUuid(event.targetId)?.let { player ->
+                    val damage = bossState.applyBossAttack(player.uuid, event.executionId, event.attack)
+                    if (damage == 0) return@let
+                    player.setHealth(bossState.playerHealth(player.uuid).toFloat())
                     player.sendMessage(Component.text("[Tester] HIT"))
                     player.sendPacket(
                         ParticlePacket(

--- a/server-minestom/src/main/kotlin/dev/projects/server/PrototypeBossState.kt
+++ b/server-minestom/src/main/kotlin/dev/projects/server/PrototypeBossState.kt
@@ -50,6 +50,8 @@ class PrototypeBossState(
 
     fun playerHealth(playerId: UUID): Int = playerHealth[playerId] ?: playerMaxHealth
 
+    fun playerEntityHealth(playerId: UUID): Float = playerHealth(playerId).coerceAtLeast(1).toFloat()
+
     /** Applies one explicit boss attack to one player, once per execution. */
     fun applyBossAttack(playerId: UUID, executionId: Long, attack: FixedAttackType): Int {
         if (!isActive) return 0

--- a/server-minestom/src/main/kotlin/dev/projects/server/PrototypeBossState.kt
+++ b/server-minestom/src/main/kotlin/dev/projects/server/PrototypeBossState.kt
@@ -1,0 +1,100 @@
+package dev.projects.server
+
+import java.util.UUID
+import kotlin.math.roundToInt
+
+enum class PrototypeEncounterState {
+    ACTIVE,
+    VICTORY,
+    DEFEAT,
+}
+
+/** Small encounter state for the first playable boss loop. */
+class PrototypeBossState(
+    val maxHealth: Int = DEFAULT_MAX_HEALTH,
+    val playerMaxHealth: Int = DEFAULT_PLAYER_MAX_HEALTH,
+) {
+    init {
+        require(maxHealth > 0) { "Boss max health must be positive" }
+        require(playerMaxHealth > 0) { "Player max health must be positive" }
+    }
+
+    var currentHealth: Int = maxHealth
+        private set
+
+    var encounterState: PrototypeEncounterState = PrototypeEncounterState.ACTIVE
+        private set
+
+    private val playerHealth = mutableMapOf<UUID, Int>()
+    private val playerDamageExecutions = mutableMapOf<UUID, MutableSet<Long>>()
+    private val bossDamageExecutions = mutableSetOf<Long>()
+
+    val isActive: Boolean
+        get() = encounterState == PrototypeEncounterState.ACTIVE
+
+    val isVictory: Boolean
+        get() = encounterState == PrototypeEncounterState.VICTORY
+
+    val isDefeat: Boolean
+        get() = encounterState == PrototypeEncounterState.DEFEAT
+
+    val isDefeated: Boolean
+        get() = currentHealth == 0
+
+    val healthProgress: Float
+        get() = currentHealth.toFloat() / maxHealth
+
+    fun registerPlayer(playerId: UUID) {
+        playerHealth.putIfAbsent(playerId, playerMaxHealth)
+    }
+
+    fun playerHealth(playerId: UUID): Int = playerHealth[playerId] ?: playerMaxHealth
+
+    /** Applies one explicit boss attack to one player, once per execution. */
+    fun applyBossAttack(playerId: UUID, executionId: Long, attack: FixedAttackType): Int {
+        if (!isActive) return 0
+        registerPlayer(playerId)
+        val executions = playerDamageExecutions.getOrPut(playerId) { mutableSetOf() }
+        if (!executions.add(executionId)) return 0
+
+        val remainingHealth = (playerHealth(playerId) - attack.damage).coerceAtLeast(0)
+        playerHealth[playerId] = remainingHealth
+        if (remainingHealth == 0) encounterState = PrototypeEncounterState.DEFEAT
+        return attack.damage
+    }
+
+    /** Applies the server-confirmed player hit to the single prototype boss. */
+    fun applyPlayerAttack(
+        attackExecutionId: Long,
+        weapon: WeaponType,
+        weakpoint: FixedWeakpoint? = null,
+    ): Int {
+        if (!isActive || !bossDamageExecutions.add(attackExecutionId)) return 0
+
+        val bodyDamage = when (weapon) {
+            WeaponType.HEAVY_BLADE -> HEAVY_BLADE_BODY_DAMAGE
+            WeaponType.TWIN_RODS -> TWIN_RODS_BODY_DAMAGE
+        }
+        val damage = if (weakpoint == null) bodyDamage else (bodyDamage * WEAKPOINT_MULTIPLIER).roundToInt()
+        currentHealth = (currentHealth - damage).coerceAtLeast(0)
+        if (currentHealth == 0) encounterState = PrototypeEncounterState.VICTORY
+        return damage
+    }
+
+    /** Restores the prototype encounter and every registered player to its test-start state. */
+    fun reset() {
+        currentHealth = maxHealth
+        encounterState = PrototypeEncounterState.ACTIVE
+        bossDamageExecutions.clear()
+        playerDamageExecutions.clear()
+        playerHealth.keys.toList().forEach { playerHealth[it] = playerMaxHealth }
+    }
+
+    companion object {
+        const val DEFAULT_MAX_HEALTH = 300
+        const val DEFAULT_PLAYER_MAX_HEALTH = 20
+        const val HEAVY_BLADE_BODY_DAMAGE = 20
+        const val TWIN_RODS_BODY_DAMAGE = 10
+        const val WEAKPOINT_MULTIPLIER = 1.5
+    }
+}

--- a/server-minestom/src/test/kotlin/dev/projects/server/PrototypeBossStateTest.kt
+++ b/server-minestom/src/test/kotlin/dev/projects/server/PrototypeBossStateTest.kt
@@ -1,0 +1,75 @@
+package dev.projects.server
+
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class PrototypeBossStateTest {
+    private val playerId = UUID.randomUUID()
+
+    @Test
+    fun `body damage uses weapon values`() {
+        val boss = PrototypeBossState()
+
+        assertEquals(20, boss.applyPlayerAttack(1L, WeaponType.HEAVY_BLADE))
+        assertEquals(10, boss.applyPlayerAttack(2L, WeaponType.TWIN_RODS))
+        assertEquals(270, boss.currentHealth)
+    }
+
+    @Test
+    fun `head and back weakpoints both multiply body damage`() {
+        val boss = PrototypeBossState()
+
+        assertEquals(30, boss.applyPlayerAttack(1L, WeaponType.HEAVY_BLADE, FixedWeakpoint.HEAD))
+        assertEquals(15, boss.applyPlayerAttack(2L, WeaponType.TWIN_RODS, FixedWeakpoint.BACK))
+        assertEquals(255, boss.currentHealth)
+    }
+
+    @Test
+    fun `same player attack execution damages boss once and clamps victory`() {
+        val boss = PrototypeBossState()
+
+        assertEquals(20, boss.applyPlayerAttack(1L, WeaponType.HEAVY_BLADE))
+        assertEquals(0, boss.applyPlayerAttack(1L, WeaponType.HEAVY_BLADE))
+        repeat(14) { executionId ->
+            boss.applyPlayerAttack(executionId + 2L, WeaponType.HEAVY_BLADE, FixedWeakpoint.HEAD)
+        }
+
+        assertEquals(0, boss.currentHealth)
+        assertTrue(boss.isVictory)
+        assertTrue(boss.isDefeated)
+        assertEquals(0, boss.applyPlayerAttack(99L, WeaponType.TWIN_RODS))
+    }
+
+    @Test
+    fun `boss attack damages player once per execution with attack values`() {
+        val boss = PrototypeBossState()
+
+        assertEquals(6, boss.applyBossAttack(playerId, 1L, FixedAttackType.SIDE_SWEEP))
+        assertEquals(0, boss.applyBossAttack(playerId, 1L, FixedAttackType.SIDE_SWEEP))
+        assertEquals(8, boss.applyBossAttack(playerId, 2L, FixedAttackType.FORWARD_SLAM))
+        assertEquals(6, boss.playerHealth(playerId))
+    }
+
+    @Test
+    fun `player defeat stops attacks and reset restores encounter`() {
+        val boss = PrototypeBossState()
+
+        boss.applyBossAttack(playerId, 1L, FixedAttackType.SIDE_SWEEP)
+        boss.applyBossAttack(playerId, 2L, FixedAttackType.FORWARD_SLAM)
+        boss.applyBossAttack(playerId, 3L, FixedAttackType.SIDE_SWEEP)
+
+        assertEquals(0, boss.playerHealth(playerId))
+        assertTrue(boss.isDefeat)
+        assertFalse(boss.isActive)
+        assertEquals(0, boss.applyBossAttack(playerId, 4L, FixedAttackType.FORWARD_SLAM))
+
+        boss.reset()
+
+        assertTrue(boss.isActive)
+        assertEquals(boss.maxHealth, boss.currentHealth)
+        assertEquals(boss.playerMaxHealth, boss.playerHealth(playerId))
+    }
+}

--- a/server-minestom/src/test/kotlin/dev/projects/server/PrototypeBossStateTest.kt
+++ b/server-minestom/src/test/kotlin/dev/projects/server/PrototypeBossStateTest.kt
@@ -54,6 +54,19 @@ class PrototypeBossStateTest {
     }
 
     @Test
+    fun `defeat keeps entity health above zero while logical health reaches zero`() {
+        val boss = PrototypeBossState()
+
+        boss.applyBossAttack(playerId, 1L, FixedAttackType.SIDE_SWEEP)
+        boss.applyBossAttack(playerId, 2L, FixedAttackType.FORWARD_SLAM)
+        boss.applyBossAttack(playerId, 3L, FixedAttackType.SIDE_SWEEP)
+
+        assertEquals(0, boss.playerHealth(playerId))
+        assertEquals(1.0f, boss.playerEntityHealth(playerId))
+        assertTrue(boss.isDefeat)
+    }
+
+    @Test
     fun `player defeat stops attacks and reset restores encounter`() {
         val boss = PrototypeBossState()
 


### PR DESCRIPTION
最小Boss戦の勝敗ループをmainへ統合します。

含むもの:
- Boss HP / BossBar
- Heavy Blade / Twin RodsのServer-confirmed damage
- Weakpoint 1.5x damage
- Side Sweep / Forward SlamのPlayer damage
- VICTORY / DEFEAT
- `/bossreset`
- DEFEAT時にMinestom death stateへ入らない安全なlogical HP処理
- Combat/Dodge/Tester reset

#35 / #36 はSol Review済み、Test/Build成功、Manual SmokeもPASS。