### PR TITLE
Dev workflow: Manual Smoke autolaunch

### DIFF
--- a/.opencode/commands/issue.md
+++ b/.opencode/commands/issue.md
@@ -17,7 +17,7 @@ ProjectS v2 の GitHub Issue #$1 を実装してください。
 7. Issue指定の自動Test / Buildを実行する。
 8. Issueがcommitを要求している場合はcommitする。
 9. Test / Build成功後、そのTask専用の現在branchへ通常pushする。`main`への直接pushやforce pushはしない。
-10. Issue本文にManual Smoke対象がある場合、実装、Test、Build、push成功後に同じworktreeで `scripts/manual-smoke-launch.sh` を実行し、Server + Fabric Clientを起動する。起動失敗は実装commitの失敗にはせず、`Manual Smoke launch: BLOCKED` と理由・log pathを報告する。
+10. Issue本文にManual Smoke対象がある場合、実装、Test、Build、push成功後に同じworktreeで `scripts/manual-smoke-launch.sh` を実行し、Server + Fabric Clientを起動する。ただし `PROJECTS_V2_SUPPRESS_MANUAL_SMOKE=1` が設定されている場合は子Taskとして自動起動せず、親オーケストレーターへ委譲したことを報告する。起動失敗は実装commitの失敗にはせず、`Manual Smoke launch: BLOCKED` と理由・log pathを報告する。
 
 重要:
 - Issue外の機能を追加しない。

--- a/.opencode/commands/issue.md
+++ b/.opencode/commands/issue.md
@@ -17,12 +17,13 @@ ProjectS v2 の GitHub Issue #$1 を実装してください。
 7. Issue指定の自動Test / Buildを実行する。
 8. Issueがcommitを要求している場合はcommitする。
 9. Test / Build成功後、そのTask専用の現在branchへ通常pushする。`main`への直接pushやforce pushはしない。
+10. Issue本文にManual Smoke対象がある場合、実装、Test、Build、push成功後に同じworktreeで `scripts/manual-smoke-launch.sh` を実行し、Server + Fabric Clientを起動する。起動失敗は実装commitの失敗にはせず、`Manual Smoke launch: BLOCKED` と理由・log pathを報告する。
 
 重要:
 - Issue外の機能を追加しない。
 - Generic Frameworkを先に作らない。
 - 固定済みProtocol等の共有境界を変更する必要が出たら、独断で変更せず理由を報告して止める。
-- Minecraft Client等のGUI Manual Smokeを自動操作しない。
+- Minecraft Client等のGUIやゲーム内Manual Smokeを自動操作しない。Server/Clientの起動・停止はManual Smoke準備として許可される。
 
 最後の報告は日本語で:
 1. 何を変更したか

--- a/.opencode/commands/parallel.md
+++ b/.opencode/commands/parallel.md
@@ -26,9 +26,9 @@ ProjectS v2 の GitHub Issues `$ARGUMENTS` を、Userが追加操作しなくて
    - 推奨Modelを一意に解決できる場合のみ `--model` を付ける。
    - 推論強度/variantを安全に一意解決できる場合のみ `--variant` を付ける。
    - 解決が曖昧な場合は、Model選択のために全体を止めず、その子TaskはOpenCodeの現在/default Modelで実行し、最終報告に明記する。
-8. 各Issueを別々の `opencode run` プロセスとして、同時に開始する。
+8. 各Issueを別々の `opencode run` プロセスとして、同時に開始する。子Taskには必ず `PROJECTS_V2_SUPPRESS_MANUAL_SMOKE=1` を明示的に設定し、子 `/issue` が自動起動せず親だけが起動を担当する。
    - `--dir <worktree>` を必ず使う。
-   - `--command issue` を使い、Issue番号を引数として渡す。
+   - `PROJECTS_V2_SUPPRESS_MANUAL_SMOKE=1 opencode run --dir <worktree> --command issue <Issue番号>` の形で起動し、Issue番号を引数として渡す。
    - 非対話実行なので `--auto` を使ってよい。ただし設定でdenyされている操作は迂回しない。
    - 各プロセスのstdout/stderrは `/tmp/projects-v2-opencode/issue-<番号>.log` へ分離する。
    - 1つのIssueが失敗しても他Issueは止めない。
@@ -39,7 +39,7 @@ ProjectS v2 の GitHub Issues `$ARGUMENTS` を、Userが追加操作しなくて
    - remoteへ通常push済みか
    - Test / Build結果が子Task報告に含まれているか
 11. merge / cherry-pick / main更新はしない。統合はSol Review後。
-12. 引数が1つだけで、Issue本文にManual Smoke対象があり、子Taskの実装、Test、Build、commit、pushが成功した場合は、成功した子Taskの同じworktreeで `scripts/manual-smoke-launch.sh` を実行する。起動失敗は実装commitの失敗にはせず、`Manual Smoke launch: BLOCKED` と理由・log pathを報告する。複数IssueではMinecraft Clientを自動起動しない。
+12. 全子Taskの終了後、引数が1つだけで、Issue本文にManual Smoke対象があり、子Taskの実装、Test、Build、commit、pushが成功した場合に限り、成功した子Taskの同じworktreeで `scripts/manual-smoke-launch.sh` を1回だけ実行する。起動失敗は実装commitの失敗にはせず、`Manual Smoke launch: BLOCKED` と理由・log pathを報告する。複数IssueではMinecraft Clientを自動起動せず、起動試行は0回とする。
 
 並列実行の原則:
 - 1 Branch = 1 worktree = 1 editing OpenCode process。

--- a/.opencode/commands/parallel.md
+++ b/.opencode/commands/parallel.md
@@ -39,7 +39,7 @@ ProjectS v2 の GitHub Issues `$ARGUMENTS` を、Userが追加操作しなくて
    - remoteへ通常push済みか
    - Test / Build結果が子Task報告に含まれているか
 11. merge / cherry-pick / main更新はしない。統合はSol Review後。
-12. 全子Taskの終了後、引数が1つだけで、Issue本文にManual Smoke対象があり、子Taskの実装、Test、Build、commit、pushが成功した場合に限り、成功した子Taskの同じworktreeで `scripts/manual-smoke-launch.sh` を1回だけ実行する。起動失敗は実装commitの失敗にはせず、`Manual Smoke launch: BLOCKED` と理由・log pathを報告する。複数IssueではMinecraft Clientを自動起動せず、起動試行は0回とする。
+12. 全子Taskの終了後、引数が1つだけで、Issue本文にManual Smoke対象があり、子Taskの実装、Test、Build、commit、pushが成功した場合に限り、成功した子Taskのworktree pathを解決し、**このオーケストレーター側worktreeの** `scripts/manual-smoke-launch.sh --worktree <成功した子Taskのworktree>` を1回だけ実行する。target worktree内のlauncher scriptは参照・要求しない。Server/Clientのbuild/runはlauncherに渡したtarget worktreeから行う。起動失敗は実装commitの失敗にはせず、`Manual Smoke launch: BLOCKED` と理由・log pathを報告する。複数IssueではMinecraft Clientを自動起動せず、起動試行は0回とする。
 
 並列実行の原則:
 - 1 Branch = 1 worktree = 1 editing OpenCode process。

--- a/.opencode/commands/parallel.md
+++ b/.opencode/commands/parallel.md
@@ -39,6 +39,7 @@ ProjectS v2 の GitHub Issues `$ARGUMENTS` を、Userが追加操作しなくて
    - remoteへ通常push済みか
    - Test / Build結果が子Task報告に含まれているか
 11. merge / cherry-pick / main更新はしない。統合はSol Review後。
+12. 引数が1つだけで、Issue本文にManual Smoke対象があり、子Taskの実装、Test、Build、commit、pushが成功した場合は、成功した子Taskの同じworktreeで `scripts/manual-smoke-launch.sh` を実行する。起動失敗は実装commitの失敗にはせず、`Manual Smoke launch: BLOCKED` と理由・log pathを報告する。複数IssueではMinecraft Clientを自動起動しない。
 
 並列実行の原則:
 - 1 Branch = 1 worktree = 1 editing OpenCode process。
@@ -47,7 +48,7 @@ ProjectS v2 の GitHub Issues `$ARGUMENTS` を、Userが追加操作しなくて
 - 親オーケストレーターはコードを書かない。
 - 子Taskは既存 `/issue` のScope、Test、commit、作業Branchへの通常push規則に従う。
 - `main` へのpush、force push、mergeは禁止。
-- GUI Manual SmokeはUserが行う。
+- GUIやゲーム内Manual SmokeはUserが行う。Server/Clientプロセスの起動・停止はManual Smoke準備として許可される。
 
 最後に日本語で、Issueごとに以下だけをまとめてください。
 - Issue番号 / Branch / worktree

--- a/.opencode/commands/smoke.md
+++ b/.opencode/commands/smoke.md
@@ -1,0 +1,11 @@
+---
+description: Start Manual Smoke processes for an existing ProjectS issue worktree
+agent: build
+---
+
+ProjectS v2 の GitHub Issue #$1 用に、既存worktreeのManual Smokeを準備してください。
+
+1. `AGENTS.md` を読み、`gh issue view $1 --repo retardedgyai/Projects-V2` でIssue本文を取得する。
+2. Issue本文の作業Branchを解決し、`git worktree list --porcelain` から対応する既存worktreeを探す。worktreeが無い場合やBranchが曖昧な場合は停止して報告する。
+3. 対象worktreeの `scripts/manual-smoke-launch.sh` を実行する。launcherが同じworktreeのServerとFabric Clientを起動する。
+4. Minecraft GUIやゲーム内操作は行わない。起動失敗は `Manual Smoke launch: BLOCKED`、理由、log pathを報告する。

--- a/.opencode/commands/smoke.md
+++ b/.opencode/commands/smoke.md
@@ -7,5 +7,5 @@ ProjectS v2 の GitHub Issue #$1 用に、既存worktreeのManual Smokeを準備
 
 1. `AGENTS.md` を読み、`gh issue view $1 --repo retardedgyai/Projects-V2` でIssue本文を取得する。
 2. Issue本文の作業Branchを解決し、`git worktree list --porcelain` から対応する既存worktreeを探す。worktreeが無い場合やBranchが曖昧な場合は停止して報告する。
-3. 対象worktreeの `scripts/manual-smoke-launch.sh` を実行する。launcherが同じworktreeのServerとFabric Clientを起動する。
+3. このオーケストレーター側worktreeの `scripts/manual-smoke-launch.sh --worktree <解決した対象worktree>` を実行する。target worktree内にlauncher scriptが存在することは要求しない。launcherは渡されたtarget worktreeからServerとFabric Clientをbuild/runする。
 4. Minecraft GUIやゲーム内操作は行わない。起動失敗は `Manual Smoke launch: BLOCKED`、理由、log pathを報告する。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ OpenCodeはこのRepositoryでは「実装端末」として使う。全体設�
 - Kotlin-first。
 - ServerがDamage / Hit / Reward / Progressionの最終判定を持つ。
 - Clientから「Hitした対象」を信用しない。
-- GUIやMinecraft内Manual SmokeはUserが行う。Agentはコード、静的確認、自動Test、Buildまで。
+- Minecraft内Manual Smokeの操作と最終判定はUserだけが行う。Manual Smoke準備のServer/Clientプロセス起動・停止はAgentが行ってよい。Issueの実装、Test、Build、pushが成功した場合、可能なら対象worktreeを起動済みにしてUserへ渡す。
 - Task完了後は、そのTask専用の作業branchへの通常`git push`まで行ってよい。
 - `main`への直接pushは禁止。
 - force push（`--force` / `--force-with-lease`）は禁止。

--- a/scripts/manual-smoke-launch-test.sh
+++ b/scripts/manual-smoke-launch-test.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT_DIR=$(git rev-parse --show-toplevel)
+REPO_ROOT="$ROOT_DIR"
+export MANUAL_SMOKE_LAUNCH_SOURCE_ONLY=1
+# shellcheck disable=SC1091
+source "$ROOT_DIR/scripts/manual-smoke-launch.sh"
+
+test_dir=$(mktemp -d)
+old_worktree="$test_dir/issue-39"
+new_worktree="$test_dir/issue-41"
+mkdir -p "$old_worktree" "$new_worktree"
+
+cleanup() {
+    if [[ -n "${managed_pid:-}" ]]; then
+        kill -KILL -- "-$managed_pid" 2>/dev/null || true
+    fi
+    if [[ -n "${unmanaged_pid:-}" ]]; then
+        kill -KILL -- "-$unmanaged_pid" 2>/dev/null || true
+    fi
+    rm -rf "$test_dir"
+}
+trap cleanup EXIT
+
+BRANCH=$(printf '%s' test)
+COMMIT=$(printf '%s' test)
+ROOT_DIR="$new_worktree"
+
+setsid bash -c "cd \"\$1\"; exec -a ProjectSServerKt sleep 60" bash "$old_worktree" &
+managed_pid=$!
+managed_pid_file="$test_dir/server.pid"
+ROOT_DIR="$old_worktree"
+write_pid_file "$managed_pid_file" server "$managed_pid"
+ROOT_DIR="$new_worktree"
+
+[[ "$(read_pid_field "$managed_pid_file" worktree)" == "$old_worktree" ]]
+managed_process_matches server "$managed_pid" "$old_worktree"
+stop_managed_process server "$managed_pid_file"
+if kill -0 "$managed_pid" 2>/dev/null; then
+    exit 1
+fi
+
+setsid bash -c "cd \"\$1\"; exec -a UnrelatedServer sleep 60" bash "$old_worktree" &
+unmanaged_pid=$!
+unmanaged_pid_file="$test_dir/unmanaged.pid"
+ROOT_DIR="$old_worktree"
+write_pid_file "$unmanaged_pid_file" server "$unmanaged_pid"
+ROOT_DIR="$new_worktree"
+stop_managed_process server "$unmanaged_pid_file"
+kill -0 "$unmanaged_pid" 2>/dev/null
+
+# These functions are intentionally overridden to test the PID ownership check.
+# shellcheck disable=SC2329
+port_occupants() { printf '123\n'; }
+server_port_ready 123
+port_occupants() { printf '999\n'; }
+if server_port_ready 123; then
+    printf 'server_port_ready accepted the wrong listener PID\n' >&2
+    exit 1
+fi
+
+issue_command=$(<"$REPO_ROOT/.opencode/commands/issue.md")
+parallel_command=$(<"$REPO_ROOT/.opencode/commands/parallel.md")
+case "$issue_command" in
+    *'PROJECTS_V2_SUPPRESS_MANUAL_SMOKE=1'*) ;;
+    *) printf 'issue command does not suppress child Manual Smoke launch\n' >&2; exit 1 ;;
+esac
+case "$parallel_command" in
+    *'PROJECTS_V2_SUPPRESS_MANUAL_SMOKE=1'*'1回だけ'*'起動試行は0回'*) ;;
+    *) printf 'parallel command does not state the single/multi launch policy\n' >&2; exit 1 ;;
+esac
+
+printf 'manual smoke launcher safety and autolaunch policy tests passed\n'

--- a/scripts/manual-smoke-launch-test.sh
+++ b/scripts/manual-smoke-launch-test.sh
@@ -10,7 +10,10 @@ source "$ROOT_DIR/scripts/manual-smoke-launch.sh"
 test_dir=$(mktemp -d)
 old_worktree="$test_dir/issue-39"
 new_worktree="$test_dir/issue-41"
-mkdir -p "$old_worktree" "$new_worktree"
+mkdir -p "$new_worktree"
+
+git worktree add --detach "$old_worktree" HEAD >/dev/null
+rm -f "$old_worktree/scripts/manual-smoke-launch.sh"
 
 cleanup() {
     if [[ -n "${managed_pid:-}" ]]; then
@@ -19,6 +22,7 @@ cleanup() {
     if [[ -n "${unmanaged_pid:-}" ]]; then
         kill -KILL -- "-$unmanaged_pid" 2>/dev/null || true
     fi
+    git worktree remove --force "$old_worktree" >/dev/null 2>&1 || true
     rm -rf "$test_dir"
 }
 trap cleanup EXIT
@@ -26,6 +30,22 @@ trap cleanup EXIT
 BRANCH=$(printf '%s' test)
 COMMIT=$(printf '%s' test)
 ROOT_DIR="$new_worktree"
+
+dry_run_output=$(MANUAL_SMOKE_LAUNCH_SOURCE_ONLY=0 "$REPO_ROOT/scripts/manual-smoke-launch.sh" --dry-run --worktree "$old_worktree")
+case "$dry_run_output" in
+    *"Manual Smoke worktree: $old_worktree"*"$old_worktree/gradlew"*"$old_worktree/server-minestom/build/install/server-minestom/bin/server-minestom"*) ;;
+    *)
+        printf 'dry-run did not resolve the launcherless target worktree\n' >&2
+        printf '%s\n' "$dry_run_output" >&2
+        exit 1
+        ;;
+esac
+case "$dry_run_output" in
+    *"$old_worktree/scripts/manual-smoke-launch.sh"*)
+        printf 'dry-run incorrectly required a target launcher script\n' >&2
+        exit 1
+        ;;
+esac
 
 setsid bash -c "cd \"\$1\"; exec -a ProjectSServerKt sleep 60" bash "$old_worktree" &
 managed_pid=$!
@@ -62,6 +82,7 @@ fi
 
 issue_command=$(<"$REPO_ROOT/.opencode/commands/issue.md")
 parallel_command=$(<"$REPO_ROOT/.opencode/commands/parallel.md")
+smoke_command=$(<"$REPO_ROOT/.opencode/commands/smoke.md")
 case "$issue_command" in
     *'PROJECTS_V2_SUPPRESS_MANUAL_SMOKE=1'*) ;;
     *) printf 'issue command does not suppress child Manual Smoke launch\n' >&2; exit 1 ;;
@@ -69,6 +90,14 @@ esac
 case "$parallel_command" in
     *'PROJECTS_V2_SUPPRESS_MANUAL_SMOKE=1'*'1回だけ'*'起動試行は0回'*) ;;
     *) printf 'parallel command does not state the single/multi launch policy\n' >&2; exit 1 ;;
+esac
+case "$parallel_command" in
+    *'このオーケストレーター側worktreeの'*'--worktree'*'target worktree内のlauncher scriptは参照・要求しない'*) ;;
+    *) printf 'parallel command does not use its own launcher with the target worktree\n' >&2; exit 1 ;;
+esac
+case "$smoke_command" in
+    *'このオーケストレーター側worktreeの'*'--worktree'*'target worktree内にlauncher scriptが存在することは要求しない'*) ;;
+    *) printf 'smoke command does not use its own launcher with the target worktree\n' >&2; exit 1 ;;
 esac
 
 printf 'manual smoke launcher safety and autolaunch policy tests passed\n'

--- a/scripts/manual-smoke-launch.sh
+++ b/scripts/manual-smoke-launch.sh
@@ -1,0 +1,253 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT_DIR=$(git rev-parse --show-toplevel)
+STATE_DIR="${TMPDIR:-/tmp}/projects-v2-manual-smoke"
+SERVER_LOG="$STATE_DIR/server.log"
+CLIENT_LOG="$STATE_DIR/client.log"
+INSTALL_LOG="$STATE_DIR/server-install.log"
+SERVER_PID_FILE="$STATE_DIR/server.pid"
+CLIENT_PID_FILE="$STATE_DIR/client.pid"
+SERVER_PORT=25565
+
+print_usage() {
+    cat <<'EOF'
+Usage: scripts/manual-smoke-launch.sh [--dry-run]
+
+Start the ProjectS server and Fabric client from this worktree for Manual Smoke.
+Logs and managed PID files are stored under /tmp/projects-v2-manual-smoke.
+EOF
+}
+
+log_excerpt() {
+    local file=$1
+    local line_count
+    line_count=$(wc -l < "$file")
+    local first_line=1
+    if (( line_count > 40 )); then
+        first_line=$((line_count - 39))
+    fi
+    sed -n "${first_line},${line_count}p" "$file"
+}
+
+process_command() {
+    local pid=$1
+    if [[ -r "/proc/$pid/cmdline" ]]; then
+        tr '\0' ' ' < "/proc/$pid/cmdline"
+    else
+        printf '<exited>'
+    fi
+}
+
+managed_process_matches() {
+    local kind=$1
+    local pid=$2
+    local expected_worktree=$3
+    [[ "$pid" =~ ^[0-9]+$ ]] || return 1
+    [[ -d "/proc/$pid" ]] || return 1
+
+    local process_worktree
+    process_worktree=$(readlink -f "/proc/$pid/cwd" 2>/dev/null || true)
+    [[ "$process_worktree" == "$expected_worktree" ]] || return 1
+
+    local command
+    command=$(process_command "$pid")
+    case "$kind" in
+        server) [[ "$command" == *"ProjectSServerKt"* ]] ;;
+        client) [[ "$command" == *"client-fabric:runClient"* ]] ;;
+        *) return 1 ;;
+    esac
+}
+
+read_pid() {
+    local file=$1
+    [[ -r "$file" ]] || return 1
+    local pid
+    pid=$(sed -n 's/^pid=//p' "$file")
+    [[ "$pid" =~ ^[0-9]+$ ]] || return 1
+    printf '%s\n' "$pid"
+}
+
+stop_managed_process() {
+    local kind=$1
+    local pid_file=$2
+    [[ -e "$pid_file" ]] || return 0
+
+    local pid
+    pid=$(read_pid "$pid_file" || true)
+    if [[ -z "$pid" ]]; then
+        printf 'Ignoring invalid %s PID file: %s\n' "$kind" "$pid_file" >&2
+        rm -f "$pid_file"
+        return 0
+    fi
+    if ! managed_process_matches "$kind" "$pid" "$ROOT_DIR"; then
+        printf 'Ignoring stale or mismatched %s PID file for PID %s; no process was killed.\n' "$kind" "$pid" >&2
+        rm -f "$pid_file"
+        return 0
+    fi
+
+    printf 'Stopping previous managed %s (PID %s).\n' "$kind" "$pid"
+    kill -TERM -- "-$pid" 2>/dev/null || kill -TERM "$pid" 2>/dev/null || true
+    for _ in {1..20}; do
+        if ! kill -0 "$pid" 2>/dev/null; then
+            rm -f "$pid_file"
+            return 0
+        fi
+        sleep 0.25
+    done
+    kill -KILL -- "-$pid" 2>/dev/null || kill -KILL "$pid" 2>/dev/null || true
+    sleep 0.25
+    if kill -0 "$pid" 2>/dev/null; then
+        printf 'Manual Smoke launch: BLOCKED\nUnable to stop managed %s PID %s.\n' "$kind" "$pid" >&2
+        return 1
+    fi
+    rm -f "$pid_file"
+}
+
+port_occupants() {
+    local pid
+    if command -v lsof >/dev/null 2>&1; then
+        lsof -nP -t -iTCP:"$SERVER_PORT" -sTCP:LISTEN 2>/dev/null || true
+        return
+    fi
+    if command -v fuser >/dev/null 2>&1; then
+        local tokens
+        read -r -a tokens <<< "$(fuser -n tcp "$SERVER_PORT" 2>/dev/null || true)"
+        for pid in "${tokens[@]}"; do
+            [[ "$pid" =~ ^[0-9]+$ ]] && printf '%s\n' "$pid"
+        done
+        return
+    fi
+    printf 'Cannot inspect TCP port %s: neither lsof nor fuser is installed.\n' "$SERVER_PORT" >&2
+    return 1
+}
+
+report_port_block() {
+    local pids=$1
+    printf 'Manual Smoke launch: BLOCKED\n'
+    printf 'TCP port %s is occupied by an unmanaged process; it was not killed.\n' "$SERVER_PORT"
+    while read -r pid; do
+        [[ -n "$pid" ]] || continue
+        printf '  PID %s: %s\n' "$pid" "$(process_command "$pid")"
+    done <<< "$pids"
+}
+
+write_pid_file() {
+    local file=$1
+    local kind=$2
+    local pid=$3
+    {
+        printf 'pid=%s\n' "$pid"
+        printf 'kind=%s\n' "$kind"
+        printf 'worktree=%s\n' "$ROOT_DIR"
+        printf 'branch=%s\n' "$BRANCH"
+        printf 'commit=%s\n' "$COMMIT"
+    } > "$file"
+}
+
+start_detached() {
+    local kind=$1
+    local pid_file=$2
+    local log_file=$3
+    shift 3
+    setsid "$@" > "$log_file" 2>&1 < /dev/null &
+    local pid=$!
+    write_pid_file "$pid_file" "$kind" "$pid"
+    printf '%s started with PID %s; log: %s\n' "$kind" "$pid" "$log_file"
+}
+
+if [[ ${1:-} == --help || ${1:-} == -h ]]; then
+    print_usage
+    exit 0
+fi
+DRY_RUN=false
+if [[ ${1:-} == --dry-run ]]; then
+    DRY_RUN=true
+    shift
+fi
+if (( $# != 0 )); then
+    print_usage >&2
+    exit 2
+fi
+
+BRANCH=$(git -C "$ROOT_DIR" branch --show-current)
+BRANCH=${BRANCH:-detached}
+COMMIT=$(git -C "$ROOT_DIR" rev-parse HEAD)
+GRADLE="$ROOT_DIR/gradlew"
+SERVER_LAUNCHER="$ROOT_DIR/server-minestom/build/install/server-minestom/bin/server-minestom"
+
+printf 'Manual Smoke worktree: %s\n' "$ROOT_DIR"
+printf 'Manual Smoke branch: %s\n' "$BRANCH"
+printf 'Manual Smoke commit: %s\n' "$COMMIT"
+printf 'Manual Smoke state: %s\n' "$STATE_DIR"
+
+if "$DRY_RUN"; then
+    printf 'Dry run server build: %s --no-daemon -Dorg.gradle.jvmargs="-Xmx768m -XX:MaxMetaspaceSize=256m" :server-minestom:installDist\n' "$GRADLE"
+    printf 'Dry run server command: JAVA_OPTS="-Xms128m -Xmx512m -XX:MaxMetaspaceSize=256m" %s\n' "$SERVER_LAUNCHER"
+    printf 'Dry run client command: %s --no-daemon :client-fabric:runClient\n' "$GRADLE"
+    exit 0
+fi
+
+mkdir -p "$STATE_DIR"
+stop_managed_process client "$CLIENT_PID_FILE"
+stop_managed_process server "$SERVER_PID_FILE"
+
+existing_pids=$(port_occupants || true)
+if [[ -n "$existing_pids" ]]; then
+    report_port_block "$existing_pids"
+    exit 1
+fi
+
+if [[ ! -x "$GRADLE" ]]; then
+    printf 'Manual Smoke launch: BLOCKED\nGradle wrapper is not executable: %s\n' "$GRADLE" >&2
+    exit 1
+fi
+
+printf 'Building the server distribution with a bounded Gradle heap.\n'
+if ! "$GRADLE" --no-daemon -Dorg.gradle.jvmargs='-Xmx768m -XX:MaxMetaspaceSize=256m' :server-minestom:installDist > "$INSTALL_LOG" 2>&1; then
+    printf 'Manual Smoke launch: BLOCKED\nServer distribution build failed. Log: %s\n' "$INSTALL_LOG" >&2
+    log_excerpt "$INSTALL_LOG" >&2
+    exit 1
+fi
+if [[ ! -x "$SERVER_LAUNCHER" ]]; then
+    printf 'Manual Smoke launch: BLOCKED\nGenerated server launcher is missing: %s\n' "$SERVER_LAUNCHER" >&2
+    exit 1
+fi
+
+start_detached server "$SERVER_PID_FILE" "$SERVER_LOG" \
+    env JAVA_OPTS='-Xms128m -Xmx512m -XX:MaxMetaspaceSize=256m' "$SERVER_LAUNCHER"
+
+server_pid=$(read_pid "$SERVER_PID_FILE")
+server_ready=false
+for _ in {1..120}; do
+    if ! kill -0 "$server_pid" 2>/dev/null; then
+        break
+    fi
+    if [[ -n "$(port_occupants || true)" ]]; then
+        server_ready=true
+        break
+    fi
+    sleep 0.5
+done
+if ! "$server_ready"; then
+    printf 'Manual Smoke launch: BLOCKED\nServer did not become ready. Log: %s\n' "$SERVER_LOG" >&2
+    log_excerpt "$SERVER_LOG" >&2
+    stop_managed_process server "$SERVER_PID_FILE" || true
+    exit 1
+fi
+
+start_detached client "$CLIENT_PID_FILE" "$CLIENT_LOG" \
+    "$GRADLE" --no-daemon :client-fabric:runClient
+client_pid=$(read_pid "$CLIENT_PID_FILE")
+sleep 2
+if ! kill -0 "$client_pid" 2>/dev/null; then
+    printf 'Manual Smoke launch: BLOCKED\nClient exited during startup. Log: %s\n' "$CLIENT_LOG" >&2
+    log_excerpt "$CLIENT_LOG" >&2
+    stop_managed_process server "$SERVER_PID_FILE" || true
+    rm -f "$CLIENT_PID_FILE"
+    exit 1
+fi
+
+printf 'Manual Smoke launch: READY\n'
+printf 'Server log: %s\nClient log: %s\n' "$SERVER_LOG" "$CLIENT_LOG"
+printf 'Minecraft GUI is ready for User Manual Smoke; no in-game operation was performed.\n'

--- a/scripts/manual-smoke-launch.sh
+++ b/scripts/manual-smoke-launch.sh
@@ -2,7 +2,7 @@
 set -Eeuo pipefail
 
 ROOT_DIR=$(git rev-parse --show-toplevel)
-STATE_DIR="${TMPDIR:-/tmp}/projects-v2-manual-smoke"
+STATE_DIR="${MANUAL_SMOKE_STATE_DIR:-${TMPDIR:-/tmp}/projects-v2-manual-smoke}"
 SERVER_LOG="$STATE_DIR/server.log"
 CLIENT_LOG="$STATE_DIR/client.log"
 INSTALL_LOG="$STATE_DIR/server-install.log"
@@ -42,13 +42,13 @@ process_command() {
 managed_process_matches() {
     local kind=$1
     local pid=$2
-    local expected_worktree=$3
+    local recorded_worktree=$3
     [[ "$pid" =~ ^[0-9]+$ ]] || return 1
     [[ -d "/proc/$pid" ]] || return 1
 
     local process_worktree
     process_worktree=$(readlink -f "/proc/$pid/cwd" 2>/dev/null || true)
-    [[ "$process_worktree" == "$expected_worktree" ]] || return 1
+    [[ -n "$recorded_worktree" && "$process_worktree" == "$recorded_worktree" ]] || return 1
 
     local command
     command=$(process_command "$pid")
@@ -68,6 +68,13 @@ read_pid() {
     printf '%s\n' "$pid"
 }
 
+read_pid_field() {
+    local file=$1
+    local field=$2
+    [[ -r "$file" ]] || return 1
+    sed -n "s/^${field}=//p" "$file"
+}
+
 stop_managed_process() {
     local kind=$1
     local pid_file=$2
@@ -80,7 +87,11 @@ stop_managed_process() {
         rm -f "$pid_file"
         return 0
     fi
-    if ! managed_process_matches "$kind" "$pid" "$ROOT_DIR"; then
+    local recorded_kind
+    local recorded_worktree
+    recorded_kind=$(read_pid_field "$pid_file" kind || true)
+    recorded_worktree=$(read_pid_field "$pid_file" worktree || true)
+    if [[ "$recorded_kind" != "$kind" ]] || ! managed_process_matches "$kind" "$pid" "$recorded_worktree"; then
         printf 'Ignoring stale or mismatched %s PID file for PID %s; no process was killed.\n' "$kind" "$pid" >&2
         rm -f "$pid_file"
         return 0
@@ -105,7 +116,6 @@ stop_managed_process() {
 }
 
 port_occupants() {
-    local pid
     if command -v lsof >/dev/null 2>&1; then
         lsof -nP -t -iTCP:"$SERVER_PORT" -sTCP:LISTEN 2>/dev/null || true
         return
@@ -119,6 +129,68 @@ port_occupants() {
         return
     fi
     printf 'Cannot inspect TCP port %s: neither lsof nor fuser is installed.\n' "$SERVER_PORT" >&2
+    return 1
+}
+
+server_port_ready() {
+    local expected_pid=$1
+    local occupants
+    local found_expected=false
+    occupants=$(port_occupants || true)
+    [[ -n "$occupants" ]] || return 1
+    while read -r pid; do
+        [[ -n "$pid" ]] || continue
+        if [[ "$pid" == "$expected_pid" ]]; then
+            found_expected=true
+        else
+            return 1
+        fi
+    done <<< "$occupants"
+    "$found_expected"
+}
+
+process_descendants() {
+    local parent_pid=$1
+    local child_pid
+    local children=()
+    [[ -r "/proc/$parent_pid/task/$parent_pid/children" ]] || return 0
+    read -r -a children < "/proc/$parent_pid/task/$parent_pid/children" || true
+    for child_pid in "${children[@]}"; do
+        printf '%s\n' "$child_pid"
+        process_descendants "$child_pid"
+    done
+}
+
+client_process_pid() {
+    local launcher_pid=$1
+    local candidate
+    local command
+    while read -r candidate; do
+        [[ -n "$candidate" ]] || continue
+        command=$(process_command "$candidate")
+        case "$command" in
+            *KnotClient*|*net.fabricmc.loader*)
+                printf '%s\n' "$candidate"
+                return 0
+                ;;
+        esac
+    done < <(
+        printf '%s\n' "$launcher_pid"
+        process_descendants "$launcher_pid"
+    )
+    return 1
+}
+
+client_log_has_startup() {
+    local line
+    [[ -r "$CLIENT_LOG" ]] || return 1
+    while IFS= read -r line; do
+        case "$line" in
+            *"Starting Minecraft "*|*"Fabric Loader"*|*"Loading Minecraft"*)
+                return 0
+                ;;
+        esac
+    done < "$CLIENT_LOG"
     return 1
 }
 
@@ -156,98 +228,128 @@ start_detached() {
     printf '%s started with PID %s; log: %s\n' "$kind" "$pid" "$log_file"
 }
 
-if [[ ${1:-} == --help || ${1:-} == -h ]]; then
-    print_usage
-    exit 0
-fi
-DRY_RUN=false
-if [[ ${1:-} == --dry-run ]]; then
-    DRY_RUN=true
-    shift
-fi
-if (( $# != 0 )); then
-    print_usage >&2
-    exit 2
-fi
-
-BRANCH=$(git -C "$ROOT_DIR" branch --show-current)
-BRANCH=${BRANCH:-detached}
-COMMIT=$(git -C "$ROOT_DIR" rev-parse HEAD)
-GRADLE="$ROOT_DIR/gradlew"
-SERVER_LAUNCHER="$ROOT_DIR/server-minestom/build/install/server-minestom/bin/server-minestom"
-
-printf 'Manual Smoke worktree: %s\n' "$ROOT_DIR"
-printf 'Manual Smoke branch: %s\n' "$BRANCH"
-printf 'Manual Smoke commit: %s\n' "$COMMIT"
-printf 'Manual Smoke state: %s\n' "$STATE_DIR"
-
-if "$DRY_RUN"; then
-    printf 'Dry run server build: %s --no-daemon -Dorg.gradle.jvmargs="-Xmx768m -XX:MaxMetaspaceSize=256m" :server-minestom:installDist\n' "$GRADLE"
-    printf 'Dry run server command: JAVA_OPTS="-Xms128m -Xmx512m -XX:MaxMetaspaceSize=256m" %s\n' "$SERVER_LAUNCHER"
-    printf 'Dry run client command: %s --no-daemon :client-fabric:runClient\n' "$GRADLE"
-    exit 0
-fi
-
-mkdir -p "$STATE_DIR"
-stop_managed_process client "$CLIENT_PID_FILE"
-stop_managed_process server "$SERVER_PID_FILE"
-
-existing_pids=$(port_occupants || true)
-if [[ -n "$existing_pids" ]]; then
-    report_port_block "$existing_pids"
-    exit 1
-fi
-
-if [[ ! -x "$GRADLE" ]]; then
-    printf 'Manual Smoke launch: BLOCKED\nGradle wrapper is not executable: %s\n' "$GRADLE" >&2
-    exit 1
-fi
-
-printf 'Building the server distribution with a bounded Gradle heap.\n'
-if ! "$GRADLE" --no-daemon -Dorg.gradle.jvmargs='-Xmx768m -XX:MaxMetaspaceSize=256m' :server-minestom:installDist > "$INSTALL_LOG" 2>&1; then
-    printf 'Manual Smoke launch: BLOCKED\nServer distribution build failed. Log: %s\n' "$INSTALL_LOG" >&2
-    log_excerpt "$INSTALL_LOG" >&2
-    exit 1
-fi
-if [[ ! -x "$SERVER_LAUNCHER" ]]; then
-    printf 'Manual Smoke launch: BLOCKED\nGenerated server launcher is missing: %s\n' "$SERVER_LAUNCHER" >&2
-    exit 1
-fi
-
-start_detached server "$SERVER_PID_FILE" "$SERVER_LOG" \
-    env JAVA_OPTS='-Xms128m -Xmx512m -XX:MaxMetaspaceSize=256m' "$SERVER_LAUNCHER"
-
-server_pid=$(read_pid "$SERVER_PID_FILE")
-server_ready=false
-for _ in {1..120}; do
-    if ! kill -0 "$server_pid" 2>/dev/null; then
-        break
+main() {
+    if [[ ${1:-} == --help || ${1:-} == -h ]]; then
+        print_usage
+        exit 0
     fi
-    if [[ -n "$(port_occupants || true)" ]]; then
-        server_ready=true
-        break
+    DRY_RUN=false
+    if [[ ${1:-} == --dry-run ]]; then
+        DRY_RUN=true
+        shift
     fi
-    sleep 0.5
-done
-if ! "$server_ready"; then
-    printf 'Manual Smoke launch: BLOCKED\nServer did not become ready. Log: %s\n' "$SERVER_LOG" >&2
-    log_excerpt "$SERVER_LOG" >&2
-    stop_managed_process server "$SERVER_PID_FILE" || true
-    exit 1
-fi
+    if (( $# != 0 )); then
+        print_usage >&2
+        exit 2
+    fi
 
-start_detached client "$CLIENT_PID_FILE" "$CLIENT_LOG" \
-    "$GRADLE" --no-daemon :client-fabric:runClient
-client_pid=$(read_pid "$CLIENT_PID_FILE")
-sleep 2
-if ! kill -0 "$client_pid" 2>/dev/null; then
-    printf 'Manual Smoke launch: BLOCKED\nClient exited during startup. Log: %s\n' "$CLIENT_LOG" >&2
-    log_excerpt "$CLIENT_LOG" >&2
-    stop_managed_process server "$SERVER_PID_FILE" || true
-    rm -f "$CLIENT_PID_FILE"
-    exit 1
-fi
+    BRANCH=$(git -C "$ROOT_DIR" branch --show-current)
+    BRANCH=${BRANCH:-detached}
+    COMMIT=$(git -C "$ROOT_DIR" rev-parse HEAD)
+    GRADLE="$ROOT_DIR/gradlew"
+    SERVER_LAUNCHER="$ROOT_DIR/server-minestom/build/install/server-minestom/bin/server-minestom"
 
-printf 'Manual Smoke launch: READY\n'
-printf 'Server log: %s\nClient log: %s\n' "$SERVER_LOG" "$CLIENT_LOG"
-printf 'Minecraft GUI is ready for User Manual Smoke; no in-game operation was performed.\n'
+    printf 'Manual Smoke worktree: %s\n' "$ROOT_DIR"
+    printf 'Manual Smoke branch: %s\n' "$BRANCH"
+    printf 'Manual Smoke commit: %s\n' "$COMMIT"
+    printf 'Manual Smoke state: %s\n' "$STATE_DIR"
+
+    if "$DRY_RUN"; then
+        printf 'Dry run server build: %s --no-daemon -Dorg.gradle.jvmargs="-Xmx768m -XX:MaxMetaspaceSize=256m" :server-minestom:installDist\n' "$GRADLE"
+        printf 'Dry run server command: JAVA_OPTS="-Xms128m -Xmx512m -XX:MaxMetaspaceSize=256m" %s\n' "$SERVER_LAUNCHER"
+        printf 'Dry run client command: %s --no-daemon :client-fabric:runClient\n' "$GRADLE"
+        exit 0
+    fi
+
+    mkdir -p "$STATE_DIR"
+    stop_managed_process client "$CLIENT_PID_FILE"
+    stop_managed_process server "$SERVER_PID_FILE"
+
+    existing_pids=$(port_occupants || true)
+    if [[ -n "$existing_pids" ]]; then
+        report_port_block "$existing_pids"
+        exit 1
+    fi
+
+    if [[ ! -x "$GRADLE" ]]; then
+        printf 'Manual Smoke launch: BLOCKED\nGradle wrapper is not executable: %s\n' "$GRADLE" >&2
+        exit 1
+    fi
+
+    printf 'Building the server distribution with a bounded Gradle heap.\n'
+    if ! "$GRADLE" --no-daemon -Dorg.gradle.jvmargs='-Xmx768m -XX:MaxMetaspaceSize=256m' :server-minestom:installDist > "$INSTALL_LOG" 2>&1; then
+        printf 'Manual Smoke launch: BLOCKED\nServer distribution build failed. Log: %s\n' "$INSTALL_LOG" >&2
+        log_excerpt "$INSTALL_LOG" >&2
+        exit 1
+    fi
+    if [[ ! -x "$SERVER_LAUNCHER" ]]; then
+        printf 'Manual Smoke launch: BLOCKED\nGenerated server launcher is missing: %s\n' "$SERVER_LAUNCHER" >&2
+        exit 1
+    fi
+
+    start_detached server "$SERVER_PID_FILE" "$SERVER_LOG" \
+        env JAVA_OPTS='-Xms128m -Xmx512m -XX:MaxMetaspaceSize=256m' "$SERVER_LAUNCHER"
+
+    server_pid=$(read_pid "$SERVER_PID_FILE")
+    server_ready=false
+    for _ in {1..120}; do
+        if ! kill -0 "$server_pid" 2>/dev/null; then
+            break
+        fi
+        if server_port_ready "$server_pid"; then
+            server_ready=true
+            break
+        fi
+        sleep 0.5
+    done
+    if ! "$server_ready"; then
+        printf 'Manual Smoke launch: BLOCKED\nManaged server PID %s did not become the listener on %s. Log: %s\n' "$server_pid" "$SERVER_PORT" "$SERVER_LOG" >&2
+        log_excerpt "$SERVER_LOG" >&2
+        stop_managed_process server "$SERVER_PID_FILE" || true
+        exit 1
+    fi
+
+    start_detached client "$CLIENT_PID_FILE" "$CLIENT_LOG" \
+        "$GRADLE" --no-daemon :client-fabric:runClient
+    client_pid=$(read_pid "$CLIENT_PID_FILE")
+    client_ready=false
+    last_client_process=
+    client_observations=0
+    for _ in {1..240}; do
+        if ! kill -0 "$client_pid" 2>/dev/null; then
+            break
+        fi
+        actual_client_pid=$(client_process_pid "$client_pid" || true)
+        if [[ -n "$actual_client_pid" ]] && client_log_has_startup; then
+            if [[ "$actual_client_pid" == "$last_client_process" ]]; then
+                client_observations=$((client_observations + 1))
+            else
+                last_client_process=$actual_client_pid
+                client_observations=1
+            fi
+            if (( client_observations >= 2 )) && kill -0 "$actual_client_pid" 2>/dev/null; then
+                client_ready=true
+                break
+            fi
+        else
+            last_client_process=
+            client_observations=0
+        fi
+        sleep 0.5
+    done
+    if ! "$client_ready"; then
+        printf 'Manual Smoke launch: BLOCKED\nMinecraft client startup/log was not confirmed before timeout. Client log: %s\n' "$CLIENT_LOG" >&2
+        log_excerpt "$CLIENT_LOG" >&2
+        stop_managed_process client "$CLIENT_PID_FILE" || true
+        stop_managed_process server "$SERVER_PID_FILE" || true
+        exit 1
+    fi
+
+    printf 'Manual Smoke launch: READY\n'
+    printf 'Server log: %s\nClient log: %s\n' "$SERVER_LOG" "$CLIENT_LOG"
+    printf 'Minecraft client startup was confirmed; GUI and in-game operation remain for User Manual Smoke.\n'
+}
+
+if [[ ${MANUAL_SMOKE_LAUNCH_SOURCE_ONLY:-0} != 1 ]]; then
+    main "$@"
+fi

--- a/scripts/manual-smoke-launch.sh
+++ b/scripts/manual-smoke-launch.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-ROOT_DIR=$(git rev-parse --show-toplevel)
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)
+DEFAULT_WORKTREE=$(git rev-parse --show-toplevel)
 STATE_DIR="${MANUAL_SMOKE_STATE_DIR:-${TMPDIR:-/tmp}/projects-v2-manual-smoke}"
 SERVER_LOG="$STATE_DIR/server.log"
 CLIENT_LOG="$STATE_DIR/client.log"
@@ -12,9 +13,11 @@ SERVER_PORT=25565
 
 print_usage() {
     cat <<'EOF'
-Usage: scripts/manual-smoke-launch.sh [--dry-run]
+Usage: scripts/manual-smoke-launch.sh [--dry-run] [--worktree <path>]
 
-Start the ProjectS server and Fabric client from this worktree for Manual Smoke.
+Start the ProjectS server and Fabric client from the target worktree for Manual Smoke.
+The launcher can be run from another worktree; --worktree selects the build/run target.
+When omitted, the current worktree is used.
 Logs and managed PID files are stored under /tmp/projects-v2-manual-smoke.
 EOF
 }
@@ -222,7 +225,7 @@ start_detached() {
     local pid_file=$2
     local log_file=$3
     shift 3
-    setsid "$@" > "$log_file" 2>&1 < /dev/null &
+    setsid bash -c "cd \"\$1\" && shift && exec \"\$@\"" bash "$ROOT_DIR" "$@" > "$log_file" 2>&1 < /dev/null &
     local pid=$!
     write_pid_file "$pid_file" "$kind" "$pid"
     printf '%s started with PID %s; log: %s\n' "$kind" "$pid" "$log_file"
@@ -234,15 +237,38 @@ main() {
         exit 0
     fi
     DRY_RUN=false
-    if [[ ${1:-} == --dry-run ]]; then
-        DRY_RUN=true
-        shift
-    fi
-    if (( $# != 0 )); then
-        print_usage >&2
-        exit 2
-    fi
+    requested_worktree=$DEFAULT_WORKTREE
+    while (( $# > 0 )); do
+        case "$1" in
+            --dry-run)
+                DRY_RUN=true
+                shift
+                ;;
+            --worktree)
+                if (( $# < 2 )); then
+                    printf '%s\n' '--worktree requires a path.' >&2
+                    print_usage >&2
+                    exit 2
+                fi
+                requested_worktree=$2
+                shift 2
+                ;;
+            --help|-h)
+                print_usage
+                exit 0
+                ;;
+            *)
+                print_usage >&2
+                exit 2
+                ;;
+        esac
+    done
 
+    if ! ROOT_DIR=$(git -C "$requested_worktree" rev-parse --show-toplevel 2>/dev/null); then
+        printf 'Manual Smoke launch: BLOCKED\nTarget is not a git worktree: %s\n' "$requested_worktree" >&2
+        exit 1
+    fi
+    ROOT_DIR=$(cd -- "$ROOT_DIR" && pwd -P)
     BRANCH=$(git -C "$ROOT_DIR" branch --show-current)
     BRANCH=${BRANCH:-detached}
     COMMIT=$(git -C "$ROOT_DIR" rev-parse HEAD)
@@ -255,6 +281,7 @@ main() {
     printf 'Manual Smoke state: %s\n' "$STATE_DIR"
 
     if "$DRY_RUN"; then
+        printf 'Manual Smoke launcher: %s\n' "$SCRIPT_DIR/manual-smoke-launch.sh"
         printf 'Dry run server build: %s --no-daemon -Dorg.gradle.jvmargs="-Xmx768m -XX:MaxMetaspaceSize=256m" :server-minestom:installDist\n' "$GRADLE"
         printf 'Dry run server command: JAVA_OPTS="-Xms128m -Xmx512m -XX:MaxMetaspaceSize=256m" %s\n' "$SERVER_LAUNCHER"
         printf 'Dry run client command: %s --no-daemon :client-fabric:runClient\n' "$GRADLE"
@@ -277,7 +304,7 @@ main() {
     fi
 
     printf 'Building the server distribution with a bounded Gradle heap.\n'
-    if ! "$GRADLE" --no-daemon -Dorg.gradle.jvmargs='-Xmx768m -XX:MaxMetaspaceSize=256m' :server-minestom:installDist > "$INSTALL_LOG" 2>&1; then
+    if ! (cd "$ROOT_DIR" && "$GRADLE" --no-daemon -Dorg.gradle.jvmargs='-Xmx768m -XX:MaxMetaspaceSize=256m' :server-minestom:installDist) > "$INSTALL_LOG" 2>&1; then
         printf 'Manual Smoke launch: BLOCKED\nServer distribution build failed. Log: %s\n' "$INSTALL_LOG" >&2
         log_excerpt "$INSTALL_LOG" >&2
         exit 1


### PR DESCRIPTION
Closes #40

## Summary
- Manual Smoke用Server + Fabric Client launcherを追加
- 同じlauncherが起動した旧worktreeのServer/Clientを安全に置換
- unknownな25565占有プロセスはkillせずBLOCKED
- bounded heapでServer distributionを起動しexit 137を避ける
- `/issue` / 単独`/parallel`から自動起動、fallback `/smoke N`
- `--worktree`で#40導入前の既存worktreeもtargetにできる
- Minecraft内操作はUserのみ

## Verification
- Sol Review PASS
- bash -n PASS
- ShellCheck PASS
- cross-worktree PID / port / dry-run / autolaunch policy tests PASS
- git diff --check PASS
- :server-minestom:installDist PASS

PID 93489の既存#39 Serverは#40導入前の管理外プロセスなので、安全仕様どおり自動停止していない。