### PR TITLE
Speed up OpenCode fix iterations

### DIFF
--- a/.opencode/commands/issue.md
+++ b/.opencode/commands/issue.md
@@ -9,21 +9,31 @@ ProjectS v2 の GitHub Issue #$1 を実装してください。
 
 進め方:
 1. `git status` と現在Branchを確認する。
-2. `gh issue view $1 --repo retardedgyai/Projects-V2` でIssue本文を取得する。`gh` が使えない/未認証なら、実装を始めずUserへIssue本文を貼るよう依頼する。
+2. `gh issue view $1 --repo retardedgyai/Projects-V2 --comments` でIssue本文と最新コメントを取得する。`gh` が使えない/未認証なら、実装を始めずUserへIssue本文を貼るよう依頼する。最新Sol Reviewコメントに `FIX-FIRST` / `PASS` 等のfollow-up指示がある場合は、それを本文より新しい指示として扱う。
 3. Issueに書かれたBranchと現在Branchが一致するか確認する。不一致なら勝手にcheckoutせず報告する。
 4. Issueが明示的に参照するDocsと、その作業に本当に必要なRulesだけ読む。全Docsを先読みしない。
 5. 受け入れ条件と非対象を守って、そのまま自分で実装する。
 6. 別の実装Agentへ丸投げしない。必要ならExplore/Scoutを短い読み取り専用調査にだけ使う。
-7. Issue指定の自動Test / Buildを実行する。
+7. Test / Buildは初回実装とFIX-FIRST follow-upで分ける。
+   - **初回実装:** Issue本文で要求された自動Test / Buildを実行する。
+   - **FIX-FIRST follow-up:** 最新Sol Reviewで修正箇所と内容が狭く特定されている場合、Issue本文のFull Test Matrixを毎回やり直さない。最新コメントで指定されたtargeted testを実行する。指定が無ければ、変更したmoduleを直接compile/testする最小コマンド + `git diff --check` を実行する。
+   - server-onlyの小修正なら原則 `:server-minestom:test` + `git diff --check`、client-onlyの小修正なら原則 `:client-fabric:build` + `git diff --check` 程度を目安にする。
+   - Protocol、build/dependency、共有interface変更、複数moduleにまたがる高リスク変更ではfast pathを使わず、Issue本文のFull Test Matrixを実行する。
+   - `clean` は初回Issueが明示要求する場合か、clean buildが必要な理由がある場合だけ使う。狭いfollow-upで惰性的に毎回 `clean` しない。
 8. Issueがcommitを要求している場合はcommitする。
 9. Test / Build成功後、そのTask専用の現在branchへ通常pushする。`main`への直接pushやforce pushはしない。
-10. Issue本文にManual Smoke対象がある場合、実装、Test、Build、push成功後に同じworktreeで `scripts/manual-smoke-launch.sh` を実行し、Server + Fabric Clientを起動する。ただし `PROJECTS_V2_SUPPRESS_MANUAL_SMOKE=1` が設定されている場合は子Taskとして自動起動せず、親オーケストレーターへ委譲したことを報告する。起動失敗は実装commitの失敗にはせず、`Manual Smoke launch: BLOCKED` と理由・log pathを報告する。
+10. Manual SmokeはSol Review前のFIX-FIRST follow-upでは起動しない。
+   - 初回実装でIssue本文にManual Smoke対象がある場合、実装、Test、Build、push成功後に同じworktreeで `scripts/manual-smoke-launch.sh` を実行してServer + Fabric Clientを起動してよい。
+   - 最新Sol Reviewが `FIX-FIRST` のfollow-upでは、実装後の自動Manual Smokeをスキップし、Sol Review PASS後の `/smoke <Issue番号>` に委譲する。
+   - `PROJECTS_V2_SUPPRESS_MANUAL_SMOKE=1` が設定されている場合は常に子Taskとして自動起動せず、親オーケストレーターへ委譲したことを報告する。
+   - 起動失敗は実装commitの失敗にはせず、`Manual Smoke launch: BLOCKED` と理由・log pathを報告する。
 
 重要:
 - Issue外の機能を追加しない。
 - Generic Frameworkを先に作らない。
 - 固定済みProtocol等の共有境界を変更する必要が出たら、独断で変更せず理由を報告して止める。
 - Minecraft Client等のGUIやゲーム内Manual Smokeを自動操作しない。Server/Clientの起動・停止はManual Smoke準備として許可される。
+- 狭いfollow-up fixでは「念のため」の全Docs再読・全Build・全Client起動を増やさず、Sol Reviewで指定された不具合を最短で直す。
 
 最後の報告は日本語で:
 1. 何を変更したか

--- a/.opencode/commands/parallel.md
+++ b/.opencode/commands/parallel.md
@@ -3,7 +3,7 @@ description: Run multiple ProjectS issues in parallel across isolated worktrees
 agent: build
 ---
 
-ProjectS v2 の GitHub Issues `$ARGUMENTS` を、Userが追加操作しなくても独立worktreeで並列実装してください。
+ProjectS v2 の GitHub Issues `$ARGUMENTS` を、Userが追加操作しなくても独立worktreeで実装してください。
 
 このコマンド自身はオーケストレーター専用です。製品コードは編集しません。
 
@@ -11,7 +11,7 @@ ProjectS v2 の GitHub Issues `$ARGUMENTS` を、Userが追加操作しなくて
 
 1. `git status` を確認し、現在のオーケストレーション用worktreeがcleanであることを確認する。dirtyなら停止して報告する。
 2. `git fetch origin` を実行する。
-3. 引数で渡されたIssue番号をすべて取得する。例: `/parallel 2 3 4`。
+3. 引数で渡されたIssue番号をすべて取得する。例: `/parallel 2 3 4`。各Issueは本文だけでなく最新コメントも確認し、Sol Reviewの `FIX-FIRST` / `PASS` 等のfollow-up指示があれば本文より新しい指示として扱う。
 4. 各Issueについて、Issue本文または明示参照された `docs/development/codex-day-1-task-split.md` から指定Branchを解決する。
 5. `git worktree list --porcelain` で、そのBranchに対応する既存worktreeを探す。
    - 既存worktreeがあればそれを使う。
@@ -23,23 +23,32 @@ ProjectS v2 の GitHub Issues `$ARGUMENTS` を、Userが追加操作しなくて
    - Issueが要求する共有境界/ProtocolのBaseを含む
 7. Issue本文の推奨Model / 推論強度を確認する。
    - `opencode models` で利用可能Modelを1回だけ確認してよい。
+   - 初回実装はIssue指定Model / variantを優先する。
+   - 最新Sol Reviewが `FIX-FIRST` で、変更箇所と修正内容が狭く機械的に特定されているfollow-upでは、Lunaを使う場合は原則 `medium` variantを使う。最新コメントで別variantが明示されている場合はそちらを優先する。
    - 推奨Modelを一意に解決できる場合のみ `--model` を付ける。
    - 推論強度/variantを安全に一意解決できる場合のみ `--variant` を付ける。
    - 解決が曖昧な場合は、Model選択のために全体を止めず、その子TaskはOpenCodeの現在/default Modelで実行し、最終報告に明記する。
-8. 各Issueを別々の `opencode run` プロセスとして、同時に開始する。子Taskには必ず `PROJECTS_V2_SUPPRESS_MANUAL_SMOKE=1` を明示的に設定し、子 `/issue` が自動起動せず親だけが起動を担当する。
-   - `--dir <worktree>` を必ず使う。
-   - `PROJECTS_V2_SUPPRESS_MANUAL_SMOKE=1 opencode run --dir <worktree> --command issue <Issue番号>` の形で起動し、Issue番号を引数として渡す。
+8. 実行方法をIssue数で分ける。
+   - **Issueが1つだけの場合:** background化、`nohup`、固定時間pollを使わない。`PROJECTS_V2_SUPPRESS_MANUAL_SMOKE=1 opencode run --dir <worktree> --command issue <Issue番号>` をforegroundで1回実行し、その終了を直接待つ。stdout/stderrは `/tmp/projects-v2-opencode/issue-<番号>.log` に残してよい。
+   - **Issueが複数の場合:** 各Issueを別々の `opencode run` プロセスとして同時にbackground開始する。子Taskには必ず `PROJECTS_V2_SUPPRESS_MANUAL_SMOKE=1` を設定する。`--dir <worktree>` を必ず使い、各stdout/stderrを `/tmp/projects-v2-opencode/issue-<番号>.log` へ分離する。1つのIssueが失敗しても他Issueは止めない。
    - 非対話実行なので `--auto` を使ってよい。ただし設定でdenyされている操作は迂回しない。
-   - 各プロセスのstdout/stderrは `/tmp/projects-v2-opencode/issue-<番号>.log` へ分離する。
-   - 1つのIssueが失敗しても他Issueは止めない。
-9. 子プロセスをbackgroundで開始した後、短い間隔で状態を確認する。1つの長時間blocking shellに依存しない。
+9. 複数Issueのbackground監視は短いpollだけにする。
+   - poll間隔は原則 **5秒**。
+   - 1回の `sleep` は最大 **10秒**。`sleep 30` / `60` / `90` のような長時間固定待機は禁止。
+   - 各pollでprocess生存と必要ならlog末尾を確認し、完了したTaskをすぐ回収する。
+   - 1つの長時間blocking shellに依存しない。
 10. 全Issue終了後、各worktreeについて確認する。
    - `git status`
    - 最新commit SHA
    - remoteへ通常push済みか
    - Test / Build結果が子Task報告に含まれているか
 11. merge / cherry-pick / main更新はしない。統合はSol Review後。
-12. 全子Taskの終了後、引数が1つだけで、Issue本文にManual Smoke対象があり、子Taskの実装、Test、Build、commit、pushが成功した場合に限り、成功した子Taskのworktree pathを解決し、**このオーケストレーター側worktreeの** `scripts/manual-smoke-launch.sh --worktree <成功した子Taskのworktree>` を1回だけ実行する。target worktree内のlauncher scriptは参照・要求しない。Server/Clientのbuild/runはlauncherに渡したtarget worktreeから行う。起動失敗は実装commitの失敗にはせず、`Manual Smoke launch: BLOCKED` と理由・log pathを報告する。複数IssueではMinecraft Clientを自動起動せず、起動試行は0回とする。
+12. Manual Smoke自動起動は初回実装時だけ候補にする。
+   - 最新Sol Reviewが `FIX-FIRST` のfollow-up実装では、単一IssueでもManual Smokeを自動起動しない。Sol Review PASS後にUserが `/smoke <Issue番号>` を実行する。
+   - 初回実装で、引数が1つだけ、Issue本文にManual Smoke対象があり、実装、Test、Build、commit、pushが成功した場合に限り、成功した子Taskのworktree pathを解決し、このオーケストレーター側worktreeの `scripts/manual-smoke-launch.sh --worktree <成功した子Taskのworktree>` を1回だけ実行してよい。
+   - target worktree内のlauncher scriptは参照・要求しない。Server/Clientのbuild/runはlauncherに渡したtarget worktreeから行う。
+   - 起動失敗は実装commitの失敗にはせず、`Manual Smoke launch: BLOCKED` と理由・log pathを報告する。
+   - 複数IssueではMinecraft Clientを自動起動せず、起動試行は0回とする。
 
 並列実行の原則:
 - 1 Branch = 1 worktree = 1 editing OpenCode process。


### PR DESCRIPTION
## Summary
- Single-Issue `/parallel N` no longer uses background + long polling; it waits in foreground
- Multi-Issue polling is limited to 5s intervals and max 10s sleeps; 30/60/90s fixed waits are forbidden
- Narrow Sol `FIX-FIRST` follow-ups use targeted module tests instead of rerunning the full original test matrix
- Narrow Luna follow-up fixes default to Medium unless the latest review asks otherwise
- `FIX-FIRST` follow-ups skip automatic Manual Smoke; `/smoke N` is used after Sol Review PASS

## Scope
Only `.opencode/commands/parallel.md` and `.opencode/commands/issue.md` are changed. No product code, launcher code, or framework was added.