### PR TITLE
Class presentation pass: cooldown HUD and skill VFX

### DIFF
--- a/client-fabric/build.gradle.kts
+++ b/client-fabric/build.gradle.kts
@@ -14,10 +14,15 @@ dependencies {
     implementation("net.fabricmc:fabric-language-kotlin:${property("fabric_kotlin_version")}")
     implementation(project(":protocol"))
     include(project(":protocol"))
+    testImplementation(kotlin("test"))
 }
 
 kotlin {
     jvmToolchain(25)
+}
+
+tasks.test {
+    useJUnitPlatform()
 }
 
 tasks.processResources {

--- a/client-fabric/src/main/kotlin/dev/projects/client/CooldownHud.kt
+++ b/client-fabric/src/main/kotlin/dev/projects/client/CooldownHud.kt
@@ -1,0 +1,11 @@
+package dev.projects.client
+
+import java.util.Locale
+
+internal fun cooldownFillRatio(remainingTicks: Int, maxTicks: Int): Float {
+    if (maxTicks <= 0) return 0f
+    return (remainingTicks.toFloat() / maxTicks.toFloat()).coerceIn(0f, 1f)
+}
+
+internal fun cooldownSecondsText(remainingTicks: Int): String =
+    String.format(Locale.ROOT, "%.1f", remainingTicks.coerceAtLeast(0) / 20.0)

--- a/client-fabric/src/main/kotlin/dev/projects/client/ProjectSClient.kt
+++ b/client-fabric/src/main/kotlin/dev/projects/client/ProjectSClient.kt
@@ -46,6 +46,10 @@ object ProjectSClient : ClientModInitializer {
     private var twinRodSide = false
     private var mana = 0
     private var maxMana = 100
+    private var skill1CooldownTicks = 0
+    private var skill1CooldownMaxTicks = 80
+    private var skill2CooldownTicks = 0
+    private var skill2CooldownMaxTicks = 100
     private var skill3CooldownTicks = 0
     private var skill3CooldownMaxTicks = 60
     private val skillCategory = KeyMapping.Category.register(
@@ -94,6 +98,10 @@ object ProjectSClient : ClientModInitializer {
                     is ClassResourceSnapshot -> context.client().execute {
                         mana = message.mana
                         maxMana = message.maxMana
+                        skill1CooldownTicks = message.skill1CooldownTicks
+                        skill1CooldownMaxTicks = message.skill1CooldownMaxTicks
+                        skill2CooldownTicks = message.skill2CooldownTicks
+                        skill2CooldownMaxTicks = message.skill2CooldownMaxTicks
                         skill3CooldownTicks = message.skill3CooldownTicks
                         skill3CooldownMaxTicks = message.skill3CooldownMaxTicks
                     }
@@ -122,6 +130,8 @@ object ProjectSClient : ClientModInitializer {
             suppressNextAttackStarted = false
             twinRodSide = false
             mana = 0
+            skill1CooldownTicks = 0
+            skill2CooldownTicks = 0
             skill3CooldownTicks = 0
             return
         }
@@ -195,12 +205,63 @@ object ProjectSClient : ClientModInitializer {
         val x = (context.guiWidth() - barWidth) / 2
         val y = context.guiHeight() - 52
         drawResourceBar(context, "MANA $mana / $maxMana", mana, maxMana, x, y, barWidth, barHeight, 0xFF4C9BFF.toInt())
-        val cooldownText = if (skill3CooldownTicks == 0) {
-            "S3 READY"
-        } else {
-            "S3 %.1fs".format(skill3CooldownTicks / 20.0)
+        renderSkillHud(context)
+    }
+
+    private fun renderSkillHud(context: GuiGraphicsExtractor) {
+        val slotWidth = 38
+        val slotHeight = 28
+        val gap = 4
+        val totalWidth = slotWidth * 4 + gap * 3
+        val startX = (context.guiWidth() - totalWidth) / 2
+        val y = context.guiHeight() - 84
+        val slots = listOf(
+            SkillHudSlot("S1", skill1Key, skill1CooldownTicks, skill1CooldownMaxTicks, true),
+            SkillHudSlot("S2", skill2Key, skill2CooldownTicks, skill2CooldownMaxTicks, true),
+            SkillHudSlot("S3", skill3Key, skill3CooldownTicks, skill3CooldownMaxTicks, true),
+            SkillHudSlot("ULT", ultimateKey, 0, 1, false),
+        )
+        for ((index, slot) in slots.withIndex()) {
+            val slotX = startX + index * (slotWidth + gap)
+            drawSkillSlot(context, slot, slotX, y, slotWidth, slotHeight)
         }
-        context.text(Minecraft.getInstance().font, cooldownText, x, y + 19, 0xFFFFFFFF.toInt(), true)
+    }
+
+    private fun drawSkillSlot(
+        context: GuiGraphicsExtractor,
+        slot: SkillHudSlot,
+        x: Int,
+        y: Int,
+        width: Int,
+        height: Int,
+    ) {
+        val ready = slot.implemented && slot.remainingTicks == 0
+        val background = if (ready) 0xDD1E6B78.toInt() else 0xDD18202A.toInt()
+        context.fill(x, y, x + width, y + height, background)
+        if (!ready) {
+            val fillHeight = (height * cooldownFillRatio(slot.remainingTicks, slot.maxTicks)).toInt()
+            if (fillHeight > 0) {
+                context.fill(x, y, x + width, y + fillHeight, 0xAA080B10.toInt())
+            }
+        }
+        val keyLabel = slot.key.getTranslatedKeyMessage().getString()
+        val keyColor = if (slot.implemented) 0xFFFFFFFF.toInt() else 0xFF707780.toInt()
+        context.text(Minecraft.getInstance().font, slot.name, x + 3, y + 3, keyColor, true)
+        context.text(Minecraft.getInstance().font, keyLabel, x + 3, y + height - 10, keyColor, true)
+        val centerText = when {
+            !slot.implemented -> "--"
+            ready -> "READY"
+            else -> cooldownSecondsText(slot.remainingTicks)
+        }
+        val textWidth = Minecraft.getInstance().font.width(centerText)
+        context.text(
+            Minecraft.getInstance().font,
+            centerText,
+            x + (width - textWidth) / 2,
+            y + 9,
+            keyColor,
+            true,
+        )
     }
 
     private fun drawResourceBar(
@@ -225,6 +286,14 @@ object ProjectSClient : ClientModInitializer {
         InputConstants.Type.KEYSYM,
         defaultKey,
         skillCategory,
+    )
+
+    private data class SkillHudSlot(
+        val name: String,
+        val key: KeyMapping,
+        val remainingTicks: Int,
+        val maxTicks: Int,
+        val implemented: Boolean,
     )
 
     private fun showSwingEffect(client: Minecraft, player: net.minecraft.client.player.LocalPlayer) {

--- a/client-fabric/src/test/kotlin/dev/projects/client/CooldownHudTest.kt
+++ b/client-fabric/src/test/kotlin/dev/projects/client/CooldownHudTest.kt
@@ -1,0 +1,20 @@
+package dev.projects.client
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class CooldownHudTest {
+    @Test
+    fun `cooldown fill is clamped to remaining range`() {
+        assertEquals(0f, cooldownFillRatio(0, 80))
+        assertEquals(0.5f, cooldownFillRatio(40, 80))
+        assertEquals(1f, cooldownFillRatio(100, 80))
+        assertEquals(0f, cooldownFillRatio(20, 0))
+    }
+
+    @Test
+    fun `cooldown seconds use one decimal place`() {
+        assertEquals("2.4", cooldownSecondsText(48))
+        assertEquals("0.0", cooldownSecondsText(0))
+    }
+}

--- a/protocol/src/main/kotlin/dev/projects/protocol/Protocol.kt
+++ b/protocol/src/main/kotlin/dev/projects/protocol/Protocol.kt
@@ -12,7 +12,7 @@ import kotlin.math.sqrt
 const val PROJECTS_CHANNEL = "projects:protocol"
 
 object ProtocolVersion {
-    const val CURRENT = 5
+    const val CURRENT = 6
 
     fun requireCompatible(version: Int) {
         if (version != CURRENT) {

--- a/protocol/src/main/kotlin/dev/projects/protocol/Protocol.kt
+++ b/protocol/src/main/kotlin/dev/projects/protocol/Protocol.kt
@@ -11,7 +11,7 @@ import kotlin.math.abs
 const val PROJECTS_CHANNEL = "projects:protocol"
 
 object ProtocolVersion {
-    const val CURRENT = 4
+    const val CURRENT = 5
 
     fun requireCompatible(version: Int) {
         if (version != CURRENT) {
@@ -75,12 +75,21 @@ data class ClassSkillInput(
 data class ClassResourceSnapshot(
     val mana: Int,
     val maxMana: Int,
+    val skill1CooldownTicks: Int,
+    val skill1CooldownMaxTicks: Int,
+    val skill2CooldownTicks: Int,
+    val skill2CooldownMaxTicks: Int,
     val skill3CooldownTicks: Int,
     val skill3CooldownMaxTicks: Int,
 ) : ProtocolMessage {
     init {
-        require(maxMana > 0 && skill3CooldownMaxTicks > 0) { "Resource maximums must be positive" }
+        require(
+            maxMana > 0 && skill1CooldownMaxTicks > 0 && skill2CooldownMaxTicks > 0 &&
+                skill3CooldownMaxTicks > 0,
+        ) { "Resource maximums must be positive" }
         require(mana in 0..maxMana) { "Mana is out of range" }
+        require(skill1CooldownTicks in 0..skill1CooldownMaxTicks) { "Skill1 cooldown is out of range" }
+        require(skill2CooldownTicks in 0..skill2CooldownMaxTicks) { "Skill2 cooldown is out of range" }
         require(skill3CooldownTicks in 0..skill3CooldownMaxTicks) { "Skill3 cooldown is out of range" }
     }
 }
@@ -144,6 +153,10 @@ object ProtocolCodec {
                     data.writeByte(CLASS_RESOURCE_SNAPSHOT)
                     data.writeInt(message.mana)
                     data.writeInt(message.maxMana)
+                    data.writeInt(message.skill1CooldownTicks)
+                    data.writeInt(message.skill1CooldownMaxTicks)
+                    data.writeInt(message.skill2CooldownTicks)
+                    data.writeInt(message.skill2CooldownMaxTicks)
                     data.writeInt(message.skill3CooldownTicks)
                     data.writeInt(message.skill3CooldownMaxTicks)
                 }
@@ -188,6 +201,10 @@ object ProtocolCodec {
                 ClassSkillInput(slot, input.readDouble(), input.readDouble())
             }
             CLASS_RESOURCE_SNAPSHOT -> ClassResourceSnapshot(
+                input.readInt(),
+                input.readInt(),
+                input.readInt(),
+                input.readInt(),
                 input.readInt(),
                 input.readInt(),
                 input.readInt(),

--- a/protocol/src/test/kotlin/dev/projects/protocol/ProtocolCodecTest.kt
+++ b/protocol/src/test/kotlin/dev/projects/protocol/ProtocolCodecTest.kt
@@ -123,14 +123,14 @@ class ProtocolCodecTest {
     }
 
     @Test
-    fun `resource snapshot round trips mana and skill3 cooldown`() {
-        assertRoundTrip(ClassResourceSnapshot(75, 100, 40, 60))
+    fun `resource snapshot round trips mana and all skill cooldowns`() {
+        assertRoundTrip(ClassResourceSnapshot(75, 100, 20, 80, 50, 100, 40, 60))
     }
 
     @Test
     fun `malformed resource snapshot fails closed`() {
-        val malformed = ProtocolCodec.encode(ClassResourceSnapshot(75, 100, 40, 60)).copyOf().also { bytes ->
-            java.nio.ByteBuffer.wrap(bytes, 9, Int.SIZE_BYTES).putInt(61)
+        val malformed = ProtocolCodec.encode(ClassResourceSnapshot(75, 100, 20, 80, 50, 100, 40, 60)).copyOf().also { bytes ->
+            java.nio.ByteBuffer.wrap(bytes, 25, Int.SIZE_BYTES).putInt(61)
         }
         assertFailsWith<IllegalArgumentException> { ProtocolCodec.decode(malformed) }
     }

--- a/server-minestom/src/main/kotlin/dev/projects/server/ClassResourceState.kt
+++ b/server-minestom/src/main/kotlin/dev/projects/server/ClassResourceState.kt
@@ -27,9 +27,17 @@ class ClassResourceState(
         return true
     }
 
-    fun snapshot(skill3CooldownTicks: Int): ClassResourceSnapshot = ClassResourceSnapshot(
+    fun snapshot(
+        skill1CooldownTicks: Int,
+        skill2CooldownTicks: Int,
+        skill3CooldownTicks: Int,
+    ): ClassResourceSnapshot = ClassResourceSnapshot(
         mana = mana,
         maxMana = maxMana,
+        skill1CooldownTicks = skill1CooldownTicks,
+        skill1CooldownMaxTicks = Skill1State.COOLDOWN_TICKS,
+        skill2CooldownTicks = skill2CooldownTicks,
+        skill2CooldownMaxTicks = Skill2State.COOLDOWN_TICKS,
         skill3CooldownTicks = skill3CooldownTicks,
         skill3CooldownMaxTicks = Skill3State.COOLDOWN_TICKS,
     )

--- a/server-minestom/src/main/kotlin/dev/projects/server/ProjectSServer.kt
+++ b/server-minestom/src/main/kotlin/dev/projects/server/ProjectSServer.kt
@@ -43,7 +43,9 @@ import net.kyori.adventure.sound.Sound
 import net.kyori.adventure.key.Key
 import java.nio.charset.StandardCharsets
 import java.util.UUID
+import kotlin.math.abs
 import kotlin.math.floor
+import kotlin.math.sqrt
 import net.minestom.server.collision.BoundingBox
 import net.minestom.server.coordinate.Point
 import net.minestom.server.command.CommandSender
@@ -436,7 +438,7 @@ fun main() {
             }
         }
         if (previousSkill3Phase == Skill3Phase.DASH && skill3.phase == Skill3Phase.HOVER) {
-            showSkill3Snap(event.player)
+            showSkill3Snap(event.player, requireNotNull(skill3Tick.dashDirection))
             showSkill3Hover(event.player)
             sendResourceSnapshot(event.player)
         }
@@ -549,6 +551,7 @@ fun main() {
                                 skill1.cancelActiveMovement()
                                 skill3.cancelActiveMovement()
                                 event.player.setVelocity(Vec(0.0, -Skill2State.DOWNWARD_SPEED, 0.0))
+                                showSkill2Cast(event.player)
                             }
                         }
                         ClassSkillSlot.SKILL_3 -> {
@@ -559,7 +562,10 @@ fun main() {
                                 event.player.position.direction(),
                                 ClassSkillDirection(message.directionX, message.directionZ),
                             )
-                            if (castId != null) sendResourceSnapshot(event.player)
+                            if (castId != null) {
+                                showSkill3Cast(event.player)
+                                sendResourceSnapshot(event.player)
+                            }
                         }
                         ClassSkillSlot.ULTIMATE -> return@addListener
                     }
@@ -772,46 +778,115 @@ private fun showWeakpointHit(
 
 private fun showSkill1Cast(player: net.minestom.server.entity.Player) {
     val origin = player.position.add(0.0, 0.12, 0.0)
+    val direction = FixedAttackTester.normalizeHorizontal(player.position.direction())
     sendSkillParticle(player, Particle.END_ROD, origin)
+    sendSkillParticle(player, Particle.ENCHANT, origin.add(direction.x() * 0.35, 0.2, direction.z() * 0.35))
     sendSkillParticle(player, Particle.END_ROD, origin.add(0.25, 0.0, 0.0))
     sendSkillParticle(player, Particle.END_ROD, origin.add(-0.25, 0.0, 0.0))
+    sendSkillArc(player, Particle.END_ROD, origin.add(0.0, 0.12, 0.0), direction, 0.62, -1.1, 1.1, 7)
+    sendSkillArc(player, Particle.ENCHANT, origin.add(0.0, 0.18, 0.0), direction, 0.45, -0.85, 0.85, 5)
+    playSkillSound(player, "entity.player.attack.sweep", origin, 0.75f, 1.35f)
 }
 
 private fun showSkill1Trail(player: net.minestom.server.entity.Player, position: Pos, direction: Vec) {
-    sendSkillParticle(player, Particle.END_ROD, position.add(direction.x() * 0.35, 0.45, direction.z() * 0.35))
+    val origin = position.add(0.0, 0.45, 0.0)
+    for (step in 0..3) {
+        val distance = 0.12 + step * 0.22
+        sendSkillParticle(
+            player,
+            Particle.END_ROD,
+            origin.add(direction.x() * distance, 0.0, direction.z() * distance),
+        )
+        if (step < 3) {
+            sendSkillParticle(
+                player,
+                Particle.ENCHANT,
+                origin.add(-direction.x() * step * 0.16, 0.1, -direction.z() * step * 0.16),
+            )
+        }
+    }
+    sendSkillParticle(player, Particle.ELECTRIC_SPARK, origin.add(-direction.x() * 0.25, -0.12, -direction.z() * 0.25))
 }
 
 private fun showSkill1Impact(player: net.minestom.server.entity.Player, position: Point) {
-    sendSkillParticle(player, Particle.CRIT, position.add(0.0, 1.0, 0.0))
-    sendSkillParticle(player, Particle.CRIT, position.add(0.25, 1.15, 0.0))
-    sendSkillParticle(player, Particle.CRIT, position.add(-0.25, 0.9, 0.0))
-    sendSkillParticle(player, Particle.EXPLOSION, position.add(0.0, 1.0, 0.0))
+    val center = position.add(0.0, 1.0, 0.0)
+    sendSkillParticle(player, Particle.EXPLOSION, center)
+    sendSkillParticle(player, Particle.END_ROD, center)
+    sendSkillParticle(player, Particle.CRIT, center.add(0.45, 0.0, 0.0))
+    sendSkillParticle(player, Particle.CRIT, center.add(-0.45, 0.0, 0.0))
+    sendSkillParticle(player, Particle.CRIT, center.add(0.0, 0.45, 0.0))
+    sendSkillParticle(player, Particle.CRIT, center.add(0.0, -0.45, 0.0))
+    sendSkillArc(player, Particle.END_ROD, center, Vec(0.0, 0.0, 1.0), 0.58, -Math.PI, Math.PI, 10)
+    playSkillSound(player, "entity.player.attack.crit", center, 0.9f, 0.9f)
 }
 
 private fun showSkill1Launch(player: net.minestom.server.entity.Player) {
     val origin = player.position.add(0.0, 0.15, 0.0)
-    for (step in 0..3) {
-        sendSkillParticle(player, Particle.END_ROD, origin.add(0.0, step * 0.35, 0.0))
+    for (step in 0..7) {
+        val progress = step / 7.0
+        val angle = progress * Math.PI * 2.2
+        val radius = 0.12 + progress * 0.2
+        val point = origin.add(
+            kotlin.math.cos(angle) * radius,
+            step * 0.34,
+            kotlin.math.sin(angle) * radius,
+        )
+        sendSkillParticle(player, Particle.END_ROD, point)
+        if (step % 2 == 0) sendSkillParticle(player, Particle.ENCHANT, point.add(0.0, 0.12, 0.0))
     }
+    playSkillSound(player, "entity.player.levelup", origin.add(0.0, 0.8, 0.0), 0.5f, 1.65f)
+}
+
+private fun showSkill2Cast(player: net.minestom.server.entity.Player) {
+    val origin = player.position.add(0.0, 0.3, 0.0)
+    sendSkillParticle(player, Particle.END_ROD, origin)
+    sendSkillParticle(player, Particle.ENCHANT, origin.add(0.0, 0.4, 0.0))
+    sendSkillParticle(player, Particle.ELECTRIC_SPARK, origin.add(0.18, 0.2, 0.0))
+    sendSkillParticle(player, Particle.ELECTRIC_SPARK, origin.add(-0.18, 0.2, 0.0))
+    playSkillSound(player, "entity.phantom.flap", origin, 0.45f, 1.2f)
 }
 
 private fun showSkill2DiveTrail(player: net.minestom.server.entity.Player) {
     val position = player.position
-    sendSkillParticle(player, Particle.END_ROD, position.add(0.0, 0.8, 0.0))
-    sendSkillParticle(player, Particle.END_ROD, position.add(0.0, 0.25, 0.0))
+    for (step in 0..4) {
+        val progress = step / 4.0
+        val y = 0.18 + progress * 1.15
+        val radius = 0.2 - progress * 0.12
+        sendSkillParticle(player, Particle.END_ROD, position.add(0.0, y, 0.0))
+        sendSkillParticle(player, Particle.ELECTRIC_SPARK, position.add(radius, y - 0.08, 0.0))
+        sendSkillParticle(player, Particle.ELECTRIC_SPARK, position.add(-radius, y - 0.08, 0.0))
+    }
+    sendSkillParticle(player, Particle.CLOUD, position.add(0.0, 1.25, 0.0))
 }
 
 private fun showSkill2Landing(player: net.minestom.server.entity.Player) {
     val center = player.position.add(0.0, 0.12, 0.0)
-    for (step in 0..11) {
-        val angle = step * Math.PI / 6.0
-        sendSkillParticle(
-            player,
-            Particle.END_ROD,
-            center.add(kotlin.math.cos(angle) * 3.5, 0.0, kotlin.math.sin(angle) * 3.5),
-        )
+    sendSkillRing(player, Particle.END_ROD, center, 4.0, 18)
+    sendSkillRing(player, Particle.ENCHANT, center, 3.15, 14)
+    for (spoke in 0..7) {
+        val angle = spoke * Math.PI / 4.0
+        for (step in 1..4) {
+            val radius = step.toDouble()
+            sendSkillParticle(
+                player,
+                if (step % 2 == 0) Particle.END_ROD else Particle.ELECTRIC_SPARK,
+                center.add(kotlin.math.cos(angle) * radius, 0.0, kotlin.math.sin(angle) * radius),
+            )
+        }
     }
     sendSkillParticle(player, Particle.EXPLOSION, center)
+    sendSkillParticle(player, Particle.END_ROD, center.add(0.0, 0.35, 0.0))
+    playSkillSound(player, "entity.generic.explode", center, 0.85f, 0.85f)
+    playSkillSound(player, "entity.player.attack.crit", center, 0.5f, 1.3f)
+}
+
+private fun showSkill3Cast(player: net.minestom.server.entity.Player) {
+    val origin = player.position.add(0.0, 0.8, 0.0)
+    val (forward, _, _) = directionBasis(player.position.direction())
+    for (step in 0..2) {
+        sendSkillParticle(player, Particle.END_ROD, origin.add(forward.x() * step * 0.3, forward.y() * step * 0.3, forward.z() * step * 0.3))
+    }
+    playSkillSound(player, "entity.enderman.teleport", origin, 0.65f, 1.25f)
 }
 
 private fun showSkill3DashTrail(
@@ -819,24 +894,139 @@ private fun showSkill3DashTrail(
     position: Pos,
     direction: Vec,
 ) {
-    sendSkillParticle(
-        player,
-        Particle.END_ROD,
-        position.add(direction.x() * 0.4, direction.y() * 0.4 + 0.8, direction.z() * 0.4),
-    )
+    val origin = position.add(0.0, 0.8, 0.0)
+    val (forward, right, up) = directionBasis(direction)
+    for (step in 0..3) {
+        val progress = step / 3.0
+        val distance = 0.12 + progress * 0.9
+        val core = origin.add(
+            forward.x() * distance,
+            forward.y() * distance,
+            forward.z() * distance,
+        )
+        sendSkillParticle(player, Particle.END_ROD, core)
+        for (ribbon in 0..1) {
+            val phase = progress * Math.PI * 1.4 + ribbon * Math.PI
+            val radial = Vec(
+                right.x() * kotlin.math.cos(phase) * 0.22 + up.x() * kotlin.math.sin(phase) * 0.22,
+                right.y() * kotlin.math.cos(phase) * 0.22 + up.y() * kotlin.math.sin(phase) * 0.22,
+                right.z() * kotlin.math.cos(phase) * 0.22 + up.z() * kotlin.math.sin(phase) * 0.22,
+            )
+            sendSkillParticle(
+                player,
+                if (ribbon == 0) Particle.ENCHANT else Particle.ELECTRIC_SPARK,
+                core.add(radial.x(), radial.y(), radial.z()),
+            )
+        }
+    }
 }
 
-private fun showSkill3Snap(player: net.minestom.server.entity.Player) {
+private fun showSkill3Snap(player: net.minestom.server.entity.Player, direction: Vec) {
     val position = player.position.add(0.0, 0.8, 0.0)
+    val (_, right, up) = directionBasis(direction)
     sendSkillParticle(player, Particle.EXPLOSION, position)
-    sendSkillParticle(player, Particle.CRIT, position.add(0.25, 0.0, 0.0))
-    sendSkillParticle(player, Particle.CRIT, position.add(-0.25, 0.0, 0.0))
+    sendSkillParticle(player, Particle.END_ROD, position)
+    sendSkillParticle(player, Particle.CRIT, position.add(right.x() * 0.45, right.y() * 0.45, right.z() * 0.45))
+    sendSkillParticle(player, Particle.CRIT, position.add(-right.x() * 0.45, -right.y() * 0.45, -right.z() * 0.45))
+    sendSkillParticle(player, Particle.CRIT, position.add(up.x() * 0.45, up.y() * 0.45, up.z() * 0.45))
+    sendSkillParticle(player, Particle.CRIT, position.add(-up.x() * 0.45, -up.y() * 0.45, -up.z() * 0.45))
+    for (step in 0..11) {
+        val angle = step * Math.PI / 6.0
+        val radial = Vec(
+            right.x() * kotlin.math.cos(angle) + up.x() * kotlin.math.sin(angle),
+            right.y() * kotlin.math.cos(angle) + up.y() * kotlin.math.sin(angle),
+            right.z() * kotlin.math.cos(angle) + up.z() * kotlin.math.sin(angle),
+        )
+        sendSkillParticle(player, Particle.END_ROD, position.add(radial.x() * 0.62, radial.y() * 0.62, radial.z() * 0.62))
+    }
+    playSkillSound(player, "block.amethyst_block.hit", position, 0.75f, 1.55f)
 }
 
 private fun showSkill3Hover(player: net.minestom.server.entity.Player) {
     val position = player.position.add(0.0, 1.0, 0.0)
-    sendSkillParticle(player, Particle.END_ROD, position.add(0.0, 0.35, 0.0))
-    sendSkillParticle(player, Particle.END_ROD, position.add(0.0, -0.35, 0.0))
+    for (step in 0..7) {
+        val angle = step * Math.PI / 4.0
+        val radial = 0.32
+        sendSkillParticle(
+            player,
+            if (step % 2 == 0) Particle.GLOW else Particle.END_ROD,
+            position.add(
+                kotlin.math.cos(angle) * radial,
+                kotlin.math.sin(angle * 1.5) * 0.18,
+                kotlin.math.sin(angle) * radial,
+            ),
+        )
+    }
+}
+
+private fun sendSkillArc(
+    player: net.minestom.server.entity.Player,
+    particle: Particle,
+    center: Point,
+    direction: Vec,
+    radius: Double,
+    startAngle: Double,
+    endAngle: Double,
+    segments: Int,
+) {
+    val forward = FixedAttackTester.normalizeHorizontal(direction)
+    val right = Vec(-forward.z(), 0.0, forward.x())
+    for (step in 0..segments) {
+        val angle = startAngle + (endAngle - startAngle) * step / segments
+        val radial = Vec(
+            forward.x() * kotlin.math.cos(angle) + right.x() * kotlin.math.sin(angle),
+            0.0,
+            forward.z() * kotlin.math.cos(angle) + right.z() * kotlin.math.sin(angle),
+        )
+        sendSkillParticle(player, particle, center.add(radial.x() * radius, 0.0, radial.z() * radius))
+    }
+}
+
+private fun sendSkillRing(
+    player: net.minestom.server.entity.Player,
+    particle: Particle,
+    center: Point,
+    radius: Double,
+    segments: Int,
+) {
+    for (step in 0 until segments) {
+        val angle = 2.0 * Math.PI * step / segments
+        sendSkillParticle(
+            player,
+            particle,
+            center.add(kotlin.math.cos(angle) * radius, 0.0, kotlin.math.sin(angle) * radius),
+        )
+    }
+}
+
+private fun directionBasis(direction: Vec): Triple<Vec, Vec, Vec> {
+    val length = sqrt(direction.x() * direction.x() + direction.y() * direction.y() + direction.z() * direction.z())
+    val forward = Vec(direction.x() / length, direction.y() / length, direction.z() / length)
+    val reference = if (abs(forward.y()) < 0.9) Vec(0.0, 1.0, 0.0) else Vec(1.0, 0.0, 0.0)
+    val rawRight = Vec(
+        forward.y() * reference.z() - forward.z() * reference.y(),
+        forward.z() * reference.x() - forward.x() * reference.z(),
+        forward.x() * reference.y() - forward.y() * reference.x(),
+    )
+    val rightLength = sqrt(rawRight.x() * rawRight.x() + rawRight.y() * rawRight.y() + rawRight.z() * rawRight.z())
+    val right = Vec(rawRight.x() / rightLength, rawRight.y() / rightLength, rawRight.z() / rightLength)
+    val up = Vec(
+        forward.y() * right.z() - forward.z() * right.y(),
+        forward.z() * right.x() - forward.x() * right.z(),
+        forward.x() * right.y() - forward.y() * right.x(),
+    )
+    return Triple(forward, right, up)
+}
+
+private fun playSkillSound(
+    player: net.minestom.server.entity.Player,
+    key: String,
+    point: Point,
+    volume: Float,
+    pitch: Float,
+) {
+    val soundEvent = SoundEvent.fromKey(Key.key("minecraft", key)) ?: return
+    player.playSound(Sound.sound(soundEvent, Sound.Source.PLAYER, volume, pitch), point)
 }
 
 private fun sendSkillParticle(

--- a/server-minestom/src/main/kotlin/dev/projects/server/ProjectSServer.kt
+++ b/server-minestom/src/main/kotlin/dev/projects/server/ProjectSServer.kt
@@ -56,6 +56,12 @@ private val SUPPORTED_ATTACK_SPEEDS = setOf(1.0, 1.5, 2.0)
 private const val DODGE_PLAYER_WIDTH = 0.6
 private const val DODGE_PLAYER_HEIGHT = 1.8
 
+internal data class SkillCooldowns(
+    val skill1: Int,
+    val skill2: Int,
+    val skill3: Int,
+)
+
 fun main() {
     val server = MinecraftServer.init(Auth.Offline())
     val instance = MinecraftServer.getInstanceManager().createInstanceContainer()
@@ -74,7 +80,7 @@ fun main() {
     val skill2States = mutableMapOf<UUID, Skill2State>()
     val skill3States = mutableMapOf<UUID, Skill3State>()
     val resourceSyncTicks = mutableMapOf<UUID, Int>()
-    val lastSentSkill3Cooldown = mutableMapOf<UUID, Int>()
+    val lastSentCooldowns = mutableMapOf<UUID, SkillCooldowns>()
     val dodgeVelocityActive = mutableMapOf<UUID, Boolean>()
     val attackSpeeds = mutableMapOf<UUID, Double>()
     val prototypeBoss = PrototypeBossState()
@@ -90,12 +96,19 @@ fun main() {
 
     fun sendResourceSnapshot(player: net.minestom.server.entity.Player) {
         val resources = classResources[player.uuid] ?: return
+        val skill1 = skill1States[player.uuid] ?: return
+        val skill2 = skill2States[player.uuid] ?: return
         val skill3 = skill3States[player.uuid] ?: return
+        val cooldowns = SkillCooldowns(
+            skill1 = skill1.cooldownTicksRemaining,
+            skill2 = skill2.cooldownTicksRemaining,
+            skill3 = skill3.cooldownTicksRemaining,
+        )
         player.sendPluginMessage(
             PROJECTS_CHANNEL,
-            ProtocolCodec.encode(resources.snapshot(skill3.cooldownTicksRemaining)),
+            ProtocolCodec.encode(resources.snapshot(cooldowns.skill1, cooldowns.skill2, cooldowns.skill3)),
         )
-        lastSentSkill3Cooldown[player.uuid] = skill3.cooldownTicksRemaining
+        lastSentCooldowns[player.uuid] = cooldowns
     }
 
     fun updateBossBar() {
@@ -249,7 +262,7 @@ fun main() {
         skill2States.remove(playerId)
         skill3States.remove(playerId)
         resourceSyncTicks.remove(playerId)
-        lastSentSkill3Cooldown.remove(playerId)
+        lastSentCooldowns.remove(playerId)
         attackSpeeds.remove(playerId)
     }
     events.addListener(PlayerTickEvent::class.java) { event ->
@@ -324,6 +337,7 @@ fun main() {
                     direction.z() * Skill1State.DASH_SPEED,
                 ),
             )
+            showSkill1Trail(event.player, start, direction)
             val skillTargets = tester?.let { listOf(combatTarget(it)) } ?: emptyList()
             val hitTargets = skill1.hitTargetsOnSegment(start, end, skillTargets)
             if (hitTargets.isNotEmpty()) {
@@ -331,6 +345,8 @@ fun main() {
                     val damage = prototypeBoss.applySkill1Attack(skill1.castId, targetId)
                     if (damage > 0) updateBossBar()
                 }
+                showSkill1Impact(event.player, tester?.position ?: end)
+                showSkill1Launch(event.player)
                 event.player.setVelocity(
                     Vec(
                         direction.x() * Skill1State.LAUNCH_HORIZONTAL_SPEED,
@@ -349,19 +365,22 @@ fun main() {
         val skill2Tick = skill2.tick(event.player.isOnGround)
         if (skill2Tick.diveActive) {
             event.player.setVelocity(Vec(0.0, -Skill2State.DOWNWARD_SPEED, 0.0))
+            showSkill2DiveTrail(event.player)
         } else if (skill2Tick.landed) {
             val skillTargets = tester?.let { listOf(combatTarget(it)) } ?: emptyList()
             skill2.hitTargetsAtLanding(event.player.position, skillTargets).forEach { targetId ->
                 val damage = prototypeBoss.applySkill2Attack(skill2.castId, targetId)
                 if (damage > 0) updateBossBar()
             }
+            showSkill2Landing(event.player)
+            sendResourceSnapshot(event.player)
             event.player.setVelocity(Vec.ZERO)
         }
         if (!prototypeBoss.isActive) {
             finishEncounter()
             return@addListener
         }
-        val previousSkill3Cooldown = skill3.cooldownTicksRemaining
+        val previousSkill3Phase = skill3.phase
         val skill3Tick = skill3.tick(event.player.isOnGround, event.player.velocity.y())
         if (skill3Tick.dashActive) {
             val direction = requireNotNull(skill3Tick.dashDirection)
@@ -383,6 +402,7 @@ fun main() {
                     direction.z() * Skill3State.DASH_SPEED,
                 ),
             )
+            showSkill3DashTrail(event.player, start, direction)
         } else if (skill3Tick.phase == Skill3Phase.HOVER) {
             if (skill3Tick.stopHorizontalVelocity) {
                 event.player.setVelocity(Vec.ZERO)
@@ -390,7 +410,9 @@ fun main() {
                 event.player.setVelocity(skill3HoverVelocity(event.player.velocity, skill3Tick.velocityY))
             }
         }
-        if (previousSkill3Cooldown == 0 && skill3.cooldownTicksRemaining > 0) {
+        if (previousSkill3Phase == Skill3Phase.DASH && skill3.phase == Skill3Phase.HOVER) {
+            showSkill3Snap(event.player)
+            showSkill3Hover(event.player)
             sendResourceSnapshot(event.player)
         }
         if (!prototypeBoss.isActive) {
@@ -421,10 +443,14 @@ fun main() {
         val syncTick = (resourceSyncTicks[event.player.uuid] ?: 0) + 1
         if (syncTick >= 4) {
             resourceSyncTicks[event.player.uuid] = 0
-            if (shouldSyncSkill3Cooldown(
+            if (shouldSyncSkillCooldowns(
                     syncTick,
-                    skill3.cooldownTicksRemaining,
-                    lastSentSkill3Cooldown[event.player.uuid],
+                    SkillCooldowns(
+                        skill1 = skill1.cooldownTicksRemaining,
+                        skill2 = skill2.cooldownTicksRemaining,
+                        skill3 = skill3.cooldownTicksRemaining,
+                    ),
+                    lastSentCooldowns[event.player.uuid],
                 )
             ) {
                 sendResourceSnapshot(event.player)
@@ -487,7 +513,10 @@ fun main() {
                     when (message.slot) {
                         ClassSkillSlot.SKILL_1 -> {
                             if (skill2.phase == Skill2Phase.DIVE || skill3.phase != Skill3Phase.IDLE) return@addListener
-                            skill1.tryCast(event.player.position.direction())
+                            if (skill1.tryCast(event.player.position.direction()) != null) {
+                                showSkill1Cast(event.player)
+                                sendResourceSnapshot(event.player)
+                            }
                         }
                         ClassSkillSlot.SKILL_2 -> {
                             val castId = skill2.tryCast(event.player.isOnGround)
@@ -568,6 +597,12 @@ internal fun skill3HoverVelocity(currentVelocity: Vec, velocityY: Double): Vec =
 
 internal fun shouldSyncSkill3Cooldown(syncTick: Int, currentCooldown: Int, lastSentCooldown: Int?): Boolean =
     syncTick >= 4 && currentCooldown != lastSentCooldown
+
+internal fun shouldSyncSkillCooldowns(
+    syncTick: Int,
+    currentCooldowns: SkillCooldowns,
+    lastSentCooldowns: SkillCooldowns?,
+): Boolean = syncTick >= 4 && currentCooldowns != lastSentCooldowns
 
 private fun tickFixedTester(
     instance: Instance,
@@ -693,6 +728,83 @@ private fun showWeakpointHit(
         ),
         center,
     )
+}
+
+private fun showSkill1Cast(player: net.minestom.server.entity.Player) {
+    val origin = player.position.add(0.0, 0.12, 0.0)
+    sendSkillParticle(player, Particle.END_ROD, origin)
+    sendSkillParticle(player, Particle.END_ROD, origin.add(0.25, 0.0, 0.0))
+    sendSkillParticle(player, Particle.END_ROD, origin.add(-0.25, 0.0, 0.0))
+}
+
+private fun showSkill1Trail(player: net.minestom.server.entity.Player, position: Pos, direction: Vec) {
+    sendSkillParticle(player, Particle.END_ROD, position.add(direction.x() * 0.35, 0.45, direction.z() * 0.35))
+}
+
+private fun showSkill1Impact(player: net.minestom.server.entity.Player, position: Point) {
+    sendSkillParticle(player, Particle.CRIT, position.add(0.0, 1.0, 0.0))
+    sendSkillParticle(player, Particle.CRIT, position.add(0.25, 1.15, 0.0))
+    sendSkillParticle(player, Particle.CRIT, position.add(-0.25, 0.9, 0.0))
+    sendSkillParticle(player, Particle.EXPLOSION, position.add(0.0, 1.0, 0.0))
+}
+
+private fun showSkill1Launch(player: net.minestom.server.entity.Player) {
+    val origin = player.position.add(0.0, 0.15, 0.0)
+    for (step in 0..3) {
+        sendSkillParticle(player, Particle.END_ROD, origin.add(0.0, step * 0.35, 0.0))
+    }
+}
+
+private fun showSkill2DiveTrail(player: net.minestom.server.entity.Player) {
+    val position = player.position
+    sendSkillParticle(player, Particle.END_ROD, position.add(0.0, 0.8, 0.0))
+    sendSkillParticle(player, Particle.END_ROD, position.add(0.0, 0.25, 0.0))
+}
+
+private fun showSkill2Landing(player: net.minestom.server.entity.Player) {
+    val center = player.position.add(0.0, 0.12, 0.0)
+    for (step in 0..11) {
+        val angle = step * Math.PI / 6.0
+        sendSkillParticle(
+            player,
+            Particle.END_ROD,
+            center.add(kotlin.math.cos(angle) * 3.5, 0.0, kotlin.math.sin(angle) * 3.5),
+        )
+    }
+    sendSkillParticle(player, Particle.EXPLOSION, center)
+}
+
+private fun showSkill3DashTrail(
+    player: net.minestom.server.entity.Player,
+    position: Pos,
+    direction: Vec,
+) {
+    sendSkillParticle(
+        player,
+        Particle.END_ROD,
+        position.add(direction.x() * 0.4, direction.y() * 0.4 + 0.8, direction.z() * 0.4),
+    )
+}
+
+private fun showSkill3Snap(player: net.minestom.server.entity.Player) {
+    val position = player.position.add(0.0, 0.8, 0.0)
+    sendSkillParticle(player, Particle.EXPLOSION, position)
+    sendSkillParticle(player, Particle.CRIT, position.add(0.25, 0.0, 0.0))
+    sendSkillParticle(player, Particle.CRIT, position.add(-0.25, 0.0, 0.0))
+}
+
+private fun showSkill3Hover(player: net.minestom.server.entity.Player) {
+    val position = player.position.add(0.0, 1.0, 0.0)
+    sendSkillParticle(player, Particle.END_ROD, position.add(0.0, 0.35, 0.0))
+    sendSkillParticle(player, Particle.END_ROD, position.add(0.0, -0.35, 0.0))
+}
+
+private fun sendSkillParticle(
+    player: net.minestom.server.entity.Player,
+    particle: Particle,
+    point: Point,
+) {
+    player.sendPacket(ParticlePacket(particle, point.x(), point.y(), point.z(), 0f, 0f, 0f, 0f, 1))
 }
 
 internal fun directionFrom(origin: Pos, target: Pos): Vec =

--- a/server-minestom/src/test/kotlin/dev/projects/server/ClassResourceStateTest.kt
+++ b/server-minestom/src/test/kotlin/dev/projects/server/ClassResourceStateTest.kt
@@ -4,6 +4,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import net.minestom.server.coordinate.Vec
 
 class ClassResourceStateTest {
     @Test
@@ -23,7 +24,47 @@ class ClassResourceStateTest {
 
         assertFalse(resources.trySpend(101))
         assertEquals(100, resources.mana)
-        assertEquals(100, resources.snapshot(0).mana)
-        assertEquals(60, resources.snapshot(0).skill3CooldownMaxTicks)
+        val snapshot = resources.snapshot(0, 0, 0)
+        assertEquals(100, snapshot.mana)
+        assertEquals(80, snapshot.skill1CooldownMaxTicks)
+        assertEquals(100, snapshot.skill2CooldownMaxTicks)
+        assertEquals(60, snapshot.skill3CooldownMaxTicks)
+    }
+
+    @Test
+    fun `snapshot exposes server cooldowns and reset returns all skills to ready`() {
+        val resources = ClassResourceState()
+        val skill1 = Skill1State()
+        val skill2 = Skill2State()
+        val skill3 = Skill3State()
+
+        skill1.tryCast(Vec(0.0, 0.0, 1.0))
+        skill2.tryCast(false)
+        skill2.tick(true)
+        skill3.tryCast(Vec(0.0, 0.0, 1.0), ClassSkillDirection(0.0, 0.0))
+        repeat(4) { skill3.tick(false, 0.0) }
+        skill3.reduceCooldownForNormalAttack(1L)
+
+        val active = resources.snapshot(
+            skill1.cooldownTicksRemaining,
+            skill2.cooldownTicksRemaining,
+            skill3.cooldownTicksRemaining,
+        )
+        assertEquals(80, active.skill1CooldownTicks)
+        assertEquals(100, active.skill2CooldownTicks)
+        assertEquals(40, active.skill3CooldownTicks)
+
+        resources.reset()
+        skill1.reset()
+        skill2.reset()
+        skill3.reset()
+        val reset = resources.snapshot(
+            skill1.cooldownTicksRemaining,
+            skill2.cooldownTicksRemaining,
+            skill3.cooldownTicksRemaining,
+        )
+        assertEquals(0, reset.skill1CooldownTicks)
+        assertEquals(0, reset.skill2CooldownTicks)
+        assertEquals(0, reset.skill3CooldownTicks)
     }
 }

--- a/server-minestom/src/test/kotlin/dev/projects/server/Skill2StateTest.kt
+++ b/server-minestom/src/test/kotlin/dev/projects/server/Skill2StateTest.kt
@@ -16,6 +16,7 @@ class Skill2StateTest {
 
         assertEquals(null, skill2.tryCast(true))
         assertTrue(skill2.isReady)
+        assertEquals(0, ClassResourceState().snapshot(0, skill2.cooldownTicksRemaining, 0).skill2CooldownTicks)
         assertNotNull(skill2.tryCast(false))
         repeat(3) {
             val tick = skill2.tick(false)

--- a/server-minestom/src/test/kotlin/dev/projects/server/Skill3StateTest.kt
+++ b/server-minestom/src/test/kotlin/dev/projects/server/Skill3StateTest.kt
@@ -211,6 +211,8 @@ class Skill3StateTest {
         assertFalse(shouldSyncSkill3Cooldown(3, 57, 60))
         assertTrue(shouldSyncSkill3Cooldown(4, 56, 60))
         assertFalse(shouldSyncSkill3Cooldown(4, 60, 60))
+        assertFalse(shouldSyncSkillCooldowns(3, SkillCooldowns(79, 99, 59), SkillCooldowns(80, 100, 60)))
+        assertTrue(shouldSyncSkillCooldowns(4, SkillCooldowns(76, 96, 56), SkillCooldowns(80, 100, 60)))
     }
 
     private fun sequence(): () -> Long {


### PR DESCRIPTION
## Summary
- Server-authoritative S1/S2/S3 cooldown HUD
- Protocol v6 resource snapshot
- Skill1/2/3 presentation VFX and vanilla sound pass
- Latest main combat behavior preserved

## Manual Smoke
User accepted the current presentation as sufficient for now. The VFX is still notably below the reference-video quality target; deeper presentation polish is intentionally deferred so development can continue on the playable vertical slice.

Closes #45