### PR TITLE
Shared creator workflow

### DIFF
--- a/.opencode/commands/review.md
+++ b/.opencode/commands/review.md
@@ -5,7 +5,7 @@ agent: plan
 
 現在のBranchの変更を読み取り専用でレビューしてください。ファイルは変更しないでください。
 
-最初に `AGENTS.md` を読む。
+最初に `AGENTS.md` と `docs/development/sol-review.md` を読む。
 その後 `git status`、`git diff --stat`、`git diff`、必要なら `git log` / `git show` を使って確認する。
 
 重点:
@@ -17,6 +17,8 @@ agent: plan
 - lifecycle / cleanup漏れがないか
 - Test不足や明確なedge caseがないか
 - ProjectSの現在の設計判断と矛盾していないか
+
+判定は `PASS` / `FIX-FIRST` / `BLOCKED` のいずれかに統一する。Playgroundでは `DROP` も可。細かいstyle好みだけで `FIX-FIRST` にせず、Manual Visual / Feelは人間Creatorの判断とする。
 
 細かい好みより、実際に壊れる問題・手戻りになる問題を優先する。
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,51 +1,61 @@
-# ProjectS v2 — OpenCode Rules
+# ProjectS v2 — Shared Creator / Agent Rules
 
-OpenCodeはこのRepositoryでは「実装端末」として使う。全体設計や優先順位をOpenCode内で再構築しない。
+このrepoは、人間CreatorとCodex / OpenCode等のAgentが同じ自由度で制作する共有環境です。Agentはrepoのルールと対象Taskの契約に従い、全体設計や優先順位を独断で再構築しません。
 
-## 最優先
+## 全Creator共通のルール
 
-- GitHub Issueをその作業のsource of truthにする。
-- Issue外へScopeを広げない。
+- PlaygroundではGitHub Issueは必須ではなく、Creatorが目的と範囲を決める。ProductionではGitHub Issueをtask contractにする。
+- 合意したScope外へ広げない。
 - 実際の機能より先にGeneric Frameworkを作らない。
 - 1 worktree / 1 branchにつき、編集するAgentは1つだけ。
-- Subagentは調査・探索・読み取り専用Reviewに限定し、別実装を並列で書かせない。
-- Subagentの入れ子を作らない。
 - Kotlin-first。
 - ServerがDamage / Hit / Reward / Progressionの最終判定を持つ。
 - Clientから「Hitした対象」を信用しない。
-- Minecraft内Manual Smokeの操作と最終判定はUserだけが行う。Manual Smoke準備のServer/Clientプロセス起動・停止はAgentが行ってよい。Issueの実装、Test、Build、pushが成功した場合、可能なら対象worktreeを起動済みにしてUserへ渡す。
-- Task完了後は、そのTask専用の作業branchへの通常`git push`まで行ってよい。
-- `main`への直接pushは禁止。
-- force push（`--force` / `--force-with-lease`）は禁止。
-- 他Agentが作業中のbranchへpushしない。
+- Protocol/Core共有境界を無断で壊さない。
+- main直接push禁止。
+- force push（`--force` / `--force-with-lease`）禁止。
+- 他人/他Agentが作業中のbranchへpushしない。
 - 破壊的なGit操作や大量削除を独断でしない。
+- Manual Smokeのゲーム操作と最終feel判定は、そのTaskを作っている人間Creatorが行う。準備のServer/Client起動・停止はAgentが行ってよい。
+
+repo ownerだけを唯一の設計者/承認者として扱いません。各Creatorは自分のPlaygroundで自由に設計し、自分のSol ReviewとManual Smokeを完結できます。
+
+## Shared Core
+
+次の変更はPlaygroundで試すこと自体はできますが、本編へ入れる前にProduction Issue化し、Sol Reviewを通します。
+
+- `protocol/`
+- networking / handshake
+- persistence format
+- Particle Framework core
+- Class runtime共通基盤
+- build / CI
+- shared world/save format
+
+## Development modes
+
+- `play/<creator>/<slug>`はPlayground / Labs用。Issueなしでprototypeを作り、面白くなければbranchごとDROPしてよい。
+- Production branchは本編へ入れるTask用。Issue、acceptance、Test、Sol Review、Creator Manual Smoke、PRを通す。
+- PlaygroundのVerdictは`PASS` / `FIX-FIRST` / `DROP`。Productionの正式Verdictは`PASS` / `FIX-FIRST` / `BLOCKED`。
 
 ## 作業開始時
 
-1. `git status` と現在Branchを確認する。
-2. Issue本文を読む。
-3. Issueに明示されたDocsだけを読む。
-4. 必要なら以下を追加で読む。ただし全部を毎回読み込まない。
-   - `docs/development/rewrite-rules.md`
-   - `docs/development/learning-while-building.md`
-   - `docs/development/codex-day-1-task-split.md`
-   - `docs/decisions/2026-08-19-current-decisions.md`
-5. 変更範囲と受け入れ条件を短く確認して、そのまま実装へ進む。
+1. `git status`と現在Branchを確認する。
+2. ProductionならIssue本文と明示されたDocsを読む。PlaygroundならCreatorの目的と必要なDocsを読む。
+3. 変更範囲と受け入れ条件を短く確認して、そのまま実装へ進む。
 
 ## 実装中
 
-- 小さなタスクでPlan Agent → Architect → Implementerのような多段オーケストレーションを作らない。
-- Build Agent自身が実装する。
-- Explore / Scoutは「場所を探す」「公式APIを確認する」など明確な調査だけに使う。
-- Protocol等、Issueで固定された共有境界を変更したくなった場合は独断で変更せず、理由を報告して止める。
+- Protocol等、固定された共有境界を変更したくなった場合は独断で変更せず、理由を報告して止める。
 - 不要な抽象化、将来用API、汎用Registryを追加しない。
 - 迷った場合は最小の実装を選ぶ。
 
 ## 完了時
 
-Issueで指定されたTest / Buildを実行する。
+IssueまたはTaskで指定されたTest / Buildを実行します。
 
 報告は日本語で:
+
 1. 何を変更したか
 2. 変更File
 3. Test / Build結果
@@ -55,5 +65,3 @@ Issueで指定されたTest / Buildを実行する。
 7. 一番重要なFile / Class
 8. 壊れた時に最初に見る場所
 9. commit SHA / push先branch
-
-Issueがcommitを要求している場合はcommitまで行う。Task専用作業branchへの通常pushも行ってよい。`main`への直接pushやforce pushは行わない。

--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ ProjectS v2 は、旧ProjectSを引き継ぎつつコードはゼロから作り
 
 ## まず読む文書
 
+- [`docs/development/onboarding.md`](docs/development/onboarding.md) — 新しいCreatorのcloneから開始まで。
+- [`docs/development/creator-workflow.md`](docs/development/creator-workflow.md) — PlaygroundとProductionの使い分け。
+- [`docs/development/sol-review.md`](docs/development/sol-review.md) — 共通Sol Review手順。
 - [`docs/decisions/2026-08-19-current-decisions.md`](docs/decisions/2026-08-19-current-decisions.md) — **現在決まっていること全部の基準書**。
 - [`docs/game/combat-principles.md`](docs/game/combat-principles.md) — 一人称、通常攻撃、攻撃判定、Mob攻撃、回避等。
 - [`docs/game/mana-and-class-resources.md`](docs/game/mana-and-class-resources.md) — マナ/Cooldown/固有ゲージ。

--- a/docs/development/creator-workflow.md
+++ b/docs/development/creator-workflow.md
@@ -1,0 +1,42 @@
+# Shared Creator Workflow
+
+ProjectS v2は、repo ownerだけでなく各Creatorが自分のアイデアを実装、Review、Manual Smokeまで完結できる共同開発環境です。
+
+## Playground / Labs
+
+思いついたものを許可待ちせず作って遊ぶモードです。新クラス、武器、Mob、Boss、VFX、UI、魔法、採取、製造などのprototypeが対象です。
+
+- GitHub Issueは必須ではありません。
+- Creator本人が仕様と範囲を決めます。
+- 推奨branchは`play/<creator>/<slug>`です。
+- Codex / OpenCode等へ「こういうものを作りたい」と伝えて開始できます。
+- prototype品質でよく、最初からproduction cleanupは要求しません。
+- 面白くなければbranchごと捨てて構いません。
+
+Playgroundでも`protocol/`、networking / handshake、persistence format、Particle Framework core、Class runtime共通基盤、build / CI、shared world/save formatは自由変更の対象外です。本編へ取り込む場合はProduction Issue化し、Sol Reviewを通します。
+
+### Playground Review
+
+Creator本人がSolへ次を渡してReviewします。
+
+- current branch
+- base
+- intent
+- diff
+- test結果
+
+判定は`PASS`、`FIX-FIRST`、または`DROP`です。`PASS`後にCreatorがManual Smokeを行い、面白さと継続/破棄を決めます。Playgroundでは本編採用の可否を判定しません。
+
+## Production
+
+Playgroundで面白かったもの、または最初から本編用のTaskはProductionへ昇格します。
+
+1. GitHub Issueをtask contractにする。
+2. branch / worktreeを分離する。
+3. acceptanceとTestを明記する。
+4. 実装と自動Testを行う。
+5. Creator自身のSol Reviewを行う。
+6. Gameplay変更ならCreatorがManual Smokeを行う。
+7. CI/test greenを確認してPRにする。
+
+Productionの正式Verdictは`PASS`、`FIX-FIRST`、`BLOCKED`です。mainは直接pushせず、通常のfeatureはCreatorのSol Review PASS、必要なManual Smoke accepted、自動Test greenを満たしてmerge candidateにします。

--- a/docs/development/onboarding.md
+++ b/docs/development/onboarding.md
@@ -1,0 +1,55 @@
+# Creator Onboarding
+
+## Prerequisites
+
+- Git
+- JDK 25
+- GitHub access
+- Codex（またはOpenCode等の自分が選んだAI開発環境）
+
+## Clone and verify
+
+```bash
+git clone <repository-url>
+cd Projects-V2
+./gradlew build
+```
+
+WindowsではGradle wrapperを`gradlew.bat`として実行します。PowerShellでは`./gradlew.bat build`、Linuxでは`./gradlew build`を使います。
+
+repo rootでCodexを起動し、最初に`AGENTS.md`を読ませます。特定のownerの許可を待つ必要はありません。自分のbranch / worktreeで作業し、mainへ直接pushしないでください。
+
+## Run the game
+
+Server:
+
+```bash
+./gradlew :server-minestom:run
+```
+
+Client（別ターミナル）:
+
+```bash
+./gradlew :client-fabric:runClient
+```
+
+## First Playground
+
+```bash
+git switch -c play/<name>/first-class
+codex
+```
+
+Codexへ次のように伝えます。
+
+```text
+AGENTS.mdを読んでください。
+ProjectSのPlaygroundとして、既存Frameworkを使いながら自分の新クラスを自由に試作したいです。
+まずrepoを調べて最小の試作を作ってください。
+```
+
+実装後は`docs/development/sol-review.md`のpromptで自分のSol Reviewを行い、`PASS`ならManual Smoke、`FIX-FIRST`なら修正、`DROP`ならbranchを破棄します。Gameplayの操作とfeel判定はCreator本人が行います。
+
+## Mainline feature
+
+本編へ入れる場合は、Playgroundの成果または新しいGitHub IssueをProduction workflowへ昇格し、Issueのacceptance、Test、Sol Review、必要なManual Smoke、PRを通します。

--- a/docs/development/sol-review.md
+++ b/docs/development/sol-review.md
@@ -1,0 +1,45 @@
+# Sol Review Protocol
+
+この手順はChatGPT/Sol、Codex経由、その他の利用環境で共通に使います。Reviewは読み取り専用で行い、コードを変更しません。
+
+## Review input
+
+最低限、次をCreatorから受け取ります。
+
+- Repository
+- branch
+- base commit/ref
+- head commit
+- 元の目的 / Issue（あれば）
+- tests/build結果
+- Manual Smoke前か後か
+
+## Review procedure
+
+1. `AGENTS.md`とこの文書を読む。
+2. `git status`で作業ツリーを確認する。
+3. base/headを確認する。
+4. `git diff --stat <base>...HEAD`を確認する。
+5. `git diff <base>...HEAD`を確認する。
+6. 必要なら該当file全文を読む。
+7. testsが変更範囲を実際にカバーしているか確認する。
+
+重点は、実際に壊れるbug、lifecycle / cleanup、server/client authority、protocol compatibility、concurrency/state、scope逸脱、regression、tests不足、不要なframeworkです。細かいstyle好みだけで`FIX-FIRST`にしません。Manual Visual / Feelの最終authorityは人間Creatorです。
+
+## Verdict
+
+Productionは正式に次の3つへ統一します。
+
+- `PASS`
+- `FIX-FIRST`
+- `BLOCKED`
+
+Playgroundでは追加で`DROP`を使えます。
+
+## Ready-to-copy prompt
+
+```text
+ProjectSのSol Reviewをしてください。
+最初にAGENTS.mdとdocs/development/sol-review.mdを読み、現在branchをbaseからreviewしてください。
+コード編集は禁止。重大な問題を優先し、PASS / FIX-FIRST / BLOCKEDで判定してください。
+```

--- a/scripts/review-context.sh
+++ b/scripts/review-context.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+BASE=${1:-main}
+ROOT_DIR=$(git rev-parse --show-toplevel)
+BRANCH=$(git branch --show-current)
+HEAD_COMMIT=$(git rev-parse HEAD)
+
+printf 'Repository root: %s\n' "$ROOT_DIR"
+printf 'Current branch: %s\n' "${BRANCH:-detached}"
+printf 'HEAD: %s\n' "$HEAD_COMMIT"
+printf '\nStatus:\n'
+git status --short
+printf '\nBase: %s\n' "$BASE"
+printf '\nCommits (%s..HEAD):\n' "$BASE"
+git log --oneline "$BASE..HEAD"
+printf '\nDiff stat (%s...HEAD):\n' "$BASE"
+git diff --stat "$BASE...HEAD"


### PR DESCRIPTION
Closes #70

## Summary
- Shared Creator / Agent Rules in `AGENTS.md`
- Playground / Production development modes
- Equal Creator-owned Sol Review + Manual Smoke flow
- Creator onboarding for Codex/OpenCode
- Shared Sol Review protocol
- Lightweight review-context helper

## Verification
- Sol Review PASS
- `bash -n scripts/review-context.sh` PASS
- `shellcheck` PASS
- `git diff --check` PASS
- Docs/tooling only; no gameplay changes and no Manual Smoke required