### PR TITLE
VFX Editor MVP: Slash Tuner

### DIFF
--- a/client-fabric/src/main/kotlin/dev/projects/client/ProjectSClient.kt
+++ b/client-fabric/src/main/kotlin/dev/projects/client/ProjectSClient.kt
@@ -18,6 +18,11 @@ import dev.projects.protocol.ProtocolCodec
 import dev.projects.protocol.ProtocolHello
 import dev.projects.protocol.ProtocolHelloAck
 import dev.projects.protocol.ProtocolVersion
+import dev.projects.protocol.SlashEditorParameters
+import dev.projects.protocol.VfxEditorNotice
+import dev.projects.protocol.VfxEditorOpen
+import dev.projects.protocol.VfxSlashDraft
+import dev.projects.protocol.VfxSlashDraftList
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents
 import net.fabricmc.fabric.api.client.keymapping.v1.KeyMappingHelper
 import net.fabricmc.fabric.api.client.rendering.v1.hud.HudElementRegistry
@@ -70,6 +75,7 @@ object ProjectSClient : ClientModInitializer {
     private var attackDebugShape: AttackDebugShape? = null
     private var attackDebugTicksRemaining = 0
     private var attackDebugEnabled = true
+    private var slashDraftNames: List<String> = emptyList()
     private val skillCategory = KeyMapping.Category.register(
         Identifier.fromNamespaceAndPath("projects", "skills"),
     )
@@ -141,6 +147,29 @@ object ProjectSClient : ClientModInitializer {
                     is GroundTelegraphRemove -> context.client().execute {
                         GroundTelegraphRenderer.remove(message.telegraphId)
                     }
+                    is VfxEditorOpen -> context.client().execute {
+                        val client = context.client()
+                        if (client.gui.screen() is SlashEditorScreen) return@execute
+                        client.gui.setScreen(
+                            SlashEditorScreen(message.parameters) { outgoing ->
+                                if (outgoing is dev.projects.protocol.ProtocolMessage &&
+                                    ClientPlayNetworking.canSend(ProjectSPayload.TYPE)
+                                ) {
+                                    ClientPlayNetworking.send(ProjectSPayload(ProtocolCodec.encode(outgoing)))
+                                }
+                            }.also { it.setDraftNames(slashDraftNames) },
+                        )
+                    }
+                    is VfxSlashDraftList -> context.client().execute {
+                        slashDraftNames = message.names
+                        (context.client().gui.screen() as? SlashEditorScreen)?.setDraftNames(message.names)
+                    }
+                    is VfxSlashDraft -> context.client().execute {
+                        (context.client().gui.screen() as? SlashEditorScreen)?.applyDraft(message.parameters)
+                    }
+                    is VfxEditorNotice -> context.client().execute {
+                        context.client().player?.sendSystemMessage(Component.literal(message.text))
+                    }
                     else -> require(false) { "Unexpected ProjectS clientbound message" }
                 }
             } catch (error: IllegalArgumentException) {
@@ -172,6 +201,8 @@ object ProjectSClient : ClientModInitializer {
             skill3CooldownTicks = 0
             attackDebugShape = null
             attackDebugTicksRemaining = 0
+            slashDraftNames = emptyList()
+            if (client.gui.screen() is SlashEditorScreen) client.gui.setScreen(null)
             return
         }
         renderAttackDebugShape(client)

--- a/client-fabric/src/main/kotlin/dev/projects/client/SlashEditorScreen.kt
+++ b/client-fabric/src/main/kotlin/dev/projects/client/SlashEditorScreen.kt
@@ -1,0 +1,176 @@
+package dev.projects.client
+
+import dev.projects.protocol.SlashEditorParameters
+import dev.projects.protocol.VfxSlashDraftLoadRequest
+import dev.projects.protocol.VfxSlashPreviewCancel
+import dev.projects.protocol.VfxSlashPreviewRequest
+import dev.projects.protocol.VfxSlashSaveRequest
+import net.minecraft.client.Minecraft
+import net.minecraft.client.gui.GuiGraphicsExtractor
+import net.minecraft.client.gui.components.Button
+import net.minecraft.client.gui.components.EditBox
+import net.minecraft.client.gui.screens.Screen
+import net.minecraft.network.chat.Component
+
+class SlashEditorScreen(
+    initialParameters: SlashEditorParameters,
+    private val sendMessage: (Any) -> Unit,
+) : Screen(Component.literal("Slash Editor")) {
+    private var parameters = initialParameters
+    private var autoPreview = true
+    private var previewDebounce = 0
+    private var requestId = 0L
+    private var draftNames: List<String> = emptyList()
+    private val fields = linkedMapOf<String, EditBox>()
+    private lateinit var draftName: EditBox
+
+    override fun isPauseScreen(): Boolean = false
+
+    override fun init() {
+        val panelX = width - 326
+        val fieldX = panelX + 145
+        val fieldWidth = 155
+        val names = listOf(
+            "originY" to "Origin Y",
+            "forwardOffset" to "Forward Offset",
+            "length" to "Length / Reach",
+            "arcSpan" to "Arc Span",
+            "curvature" to "Curvature / Radius",
+            "tilt" to "Tilt",
+            "yaw" to "Yaw",
+            "width" to "Width / lane offset",
+            "particleSize" to "Particle Size",
+            "spacing" to "Spacing / density",
+            "durationTicks" to "Duration ticks",
+            "color" to "Color (#RRGGBB)",
+            "targetDistance" to "Target Distance",
+        )
+        names.forEachIndexed { index, (key, _) ->
+            val field = EditBox(font, fieldX, 31 + index * 20, fieldWidth, 18, Component.literal(key))
+            field.setValue(formatValue(key, parameters))
+            field.setMaxLength(16)
+            field.setResponder { updateFromFields() }
+            fields[key] = addRenderableWidget(field)
+        }
+
+        val buttonY = 31 + names.size * 20 + 5
+        addRenderableWidget(Button.builder(Component.literal("Replay")) { replay() }.bounds(panelX + 8, buttonY, 76, 20).build())
+        addRenderableWidget(Button.builder(Component.literal("Reset")) { reset() }.bounds(panelX + 88, buttonY, 76, 20).build())
+        addRenderableWidget(Button.builder(Component.literal("Auto: ON")) { autoPreview = !autoPreview }.bounds(panelX + 168, buttonY, 100, 20).build())
+
+        val draftY = buttonY + 27
+        draftName = addRenderableWidget(EditBox(font, panelX + 8, draftY, 180, 18, Component.literal("Draft name")))
+        draftName.setMaxLength(32)
+        addRenderableWidget(Button.builder(Component.literal("Save Draft")) { saveDraft() }.bounds(panelX + 192, draftY, 76, 20).build())
+        addRenderableWidget(Button.builder(Component.literal("Load Draft")) { loadDraft() }.bounds(panelX + 192, draftY + 23, 76, 20).build())
+    }
+
+    override fun extractRenderState(graphics: GuiGraphicsExtractor, mouseX: Int, mouseY: Int, delta: Float) {
+        super.extractRenderState(graphics, mouseX, mouseY, delta)
+        val panelX = width - 326
+        graphics.fill(panelX, 0, width, height, 0xD9101824.toInt())
+        graphics.fill(panelX, 0, panelX + 2, height, 0xFF2871C7.toInt())
+        graphics.text(font, "SLASH TUNER MVP", panelX + 8, 8, 0xFFE8F3FF.toInt(), true)
+        graphics.text(font, "Edit values while watching the world", panelX + 8, 19, 0xFF9BB4CE.toInt(), false)
+        val labels = listOf(
+            "Origin Y", "Forward Offset", "Length / Reach", "Arc Span", "Curvature / Radius", "Tilt", "Yaw",
+            "Width / lane offset", "Particle Size", "Spacing / density", "Duration ticks", "Color (#RRGGBB)", "Target Distance",
+        )
+        labels.forEachIndexed { index, label ->
+            graphics.text(font, label, panelX + 8, 36 + index * 20, 0xFFD5E2F0.toInt(), false)
+        }
+        graphics.text(font, "Drafts: ${draftNames.joinToString().ifBlank { "none" }}", panelX + 8, height - 14, 0xFF8EA9C5.toInt(), false)
+    }
+
+    override fun tick() {
+        super.tick()
+        if (previewDebounce > 0) {
+            previewDebounce--
+            if (previewDebounce == 0 && autoPreview) sendPreview()
+        }
+    }
+
+    fun setDraftNames(names: List<String>) {
+        draftNames = names
+    }
+
+    fun applyDraft(loaded: SlashEditorParameters) {
+        parameters = loaded
+        fields.forEach { (key, field) -> field.setValue(formatValue(key, parameters)) }
+        replay()
+    }
+
+    override fun onClose() {
+        sendMessage(VfxSlashPreviewCancel)
+        super.onClose()
+    }
+
+    private fun updateFromFields() {
+        val next = parseParameters() ?: return
+        parameters = next
+        previewDebounce = 5
+    }
+
+    private fun parseParameters(): SlashEditorParameters? = runCatching {
+        fun number(key: String): Double = fields.getValue(key).value.toDouble()
+        val color = fields.getValue("color").value.removePrefix("#").toInt(16)
+        SlashEditorParameters.clamped(
+            originY = number("originY"),
+            forwardOffset = number("forwardOffset"),
+            length = number("length"),
+            arcSpan = number("arcSpan"),
+            curvature = number("curvature"),
+            tilt = number("tilt"),
+            yaw = number("yaw"),
+            width = number("width"),
+            particleSize = number("particleSize"),
+            spacing = number("spacing"),
+            durationTicks = number("durationTicks").toInt(),
+            color = color,
+            targetDistance = number("targetDistance"),
+        )
+    }.getOrNull()
+
+    private fun replay() {
+        parseParameters()?.let {
+            parameters = it
+            sendPreview()
+        }
+    }
+
+    private fun sendPreview() {
+        sendMessage(VfxSlashPreviewRequest(++requestId, parameters))
+    }
+
+    private fun reset() {
+        parameters = SlashEditorParameters()
+        fields.forEach { (key, field) -> field.setValue(formatValue(key, parameters)) }
+        replay()
+    }
+
+    private fun saveDraft() {
+        parseParameters()?.let { sendMessage(VfxSlashSaveRequest(draftName.value.trim(), it)) }
+    }
+
+    private fun loadDraft() {
+        val name = draftName.value.trim()
+        if (name.isNotEmpty()) sendMessage(VfxSlashDraftLoadRequest(name))
+    }
+
+    private fun formatValue(key: String, values: SlashEditorParameters): String = when (key) {
+        "originY" -> values.originY.toString()
+        "forwardOffset" -> values.forwardOffset.toString()
+        "length" -> values.length.toString()
+        "arcSpan" -> values.arcSpan.toString()
+        "curvature" -> values.curvature.toString()
+        "tilt" -> values.tilt.toString()
+        "yaw" -> values.yaw.toString()
+        "width" -> values.width.toString()
+        "particleSize" -> values.particleSize.toString()
+        "spacing" -> values.spacing.toString()
+        "durationTicks" -> values.durationTicks.toString()
+        "color" -> "#%06x".format(values.color)
+        "targetDistance" -> values.targetDistance.toString()
+        else -> ""
+    }
+}

--- a/protocol/src/main/kotlin/dev/projects/protocol/Protocol.kt
+++ b/protocol/src/main/kotlin/dev/projects/protocol/Protocol.kt
@@ -12,7 +12,7 @@ import kotlin.math.sqrt
 const val PROJECTS_CHANNEL = "projects:protocol"
 
 object ProtocolVersion {
-    const val CURRENT = 7
+    const val CURRENT = 8
 
     fun requireCompatible(version: Int) {
         if (version != CURRENT) {
@@ -205,6 +205,148 @@ data class GroundTelegraphRemove(val telegraphId: Long) : ProtocolMessage {
     }
 }
 
+private object SlashEditorLimits {
+    const val MAX_NAME_LENGTH = 32
+    const val MAX_DRAFTS = 16
+    const val MIN_ORIGIN_Y = -4.0
+    const val MAX_ORIGIN_Y = 8.0
+    const val MIN_FORWARD_OFFSET = 0.0
+    const val MAX_FORWARD_OFFSET = 8.0
+    const val MIN_LENGTH = 0.5
+    const val MAX_LENGTH = 12.0
+    const val MIN_ARC_SPAN = 10.0
+    const val MAX_ARC_SPAN = 350.0
+    const val MIN_CURVATURE = 0.0
+    const val MAX_CURVATURE = 4.0
+    const val MIN_TILT = -90.0
+    const val MAX_TILT = 90.0
+    const val MIN_YAW = -180.0
+    const val MAX_YAW = 180.0
+    const val MIN_WIDTH = 0.0
+    const val MAX_WIDTH = 1.5
+    const val MIN_PARTICLE_SIZE = 0.05
+    const val MAX_PARTICLE_SIZE = 2.0
+    const val MIN_SPACING = 0.05
+    const val MAX_SPACING = 2.0
+    const val MIN_DURATION_TICKS = 1
+    const val MAX_DURATION_TICKS = 80
+    const val MAX_TARGET_DISTANCE = 32.0
+}
+
+data class SlashEditorParameters(
+    val originY: Double = 1.2,
+    val forwardOffset: Double = 0.2,
+    val length: Double = 5.0,
+    val arcSpan: Double = 160.0,
+    val curvature: Double = 0.35,
+    val tilt: Double = 12.0,
+    val yaw: Double = 0.0,
+    val width: Double = 0.28,
+    val particleSize: Double = 0.28,
+    val spacing: Double = 0.18,
+    val durationTicks: Int = 8,
+    val color: Int = 0x123bdb,
+    val targetDistance: Double = 5.0,
+) {
+    init {
+        require(listOf(originY, forwardOffset, length, arcSpan, curvature, tilt, yaw, width, particleSize, spacing, targetDistance).all { it.isFinite() }) {
+            "Slash editor values must be finite"
+        }
+        require(durationTicks in SlashEditorLimits.MIN_DURATION_TICKS..SlashEditorLimits.MAX_DURATION_TICKS) {
+            "Slash editor duration is out of range"
+        }
+        require(color in 0..0xffffff) { "Slash editor color is out of range" }
+    }
+
+    companion object {
+        fun clamped(
+            originY: Double,
+            forwardOffset: Double,
+            length: Double,
+            arcSpan: Double,
+            curvature: Double,
+            tilt: Double,
+            yaw: Double,
+            width: Double,
+            particleSize: Double,
+            spacing: Double,
+            durationTicks: Int,
+            color: Int,
+            targetDistance: Double,
+        ): SlashEditorParameters {
+            require(listOf(originY, forwardOffset, length, arcSpan, curvature, tilt, yaw, width, particleSize, spacing, targetDistance).all { it.isFinite() }) {
+                "Slash editor values must be finite"
+            }
+            return SlashEditorParameters(
+                originY.coerceIn(SlashEditorLimits.MIN_ORIGIN_Y, SlashEditorLimits.MAX_ORIGIN_Y),
+                forwardOffset.coerceIn(SlashEditorLimits.MIN_FORWARD_OFFSET, SlashEditorLimits.MAX_FORWARD_OFFSET),
+                length.coerceIn(SlashEditorLimits.MIN_LENGTH, SlashEditorLimits.MAX_LENGTH),
+                arcSpan.coerceIn(SlashEditorLimits.MIN_ARC_SPAN, SlashEditorLimits.MAX_ARC_SPAN),
+                curvature.coerceIn(SlashEditorLimits.MIN_CURVATURE, SlashEditorLimits.MAX_CURVATURE),
+                tilt.coerceIn(SlashEditorLimits.MIN_TILT, SlashEditorLimits.MAX_TILT),
+                yaw.coerceIn(SlashEditorLimits.MIN_YAW, SlashEditorLimits.MAX_YAW),
+                width.coerceIn(SlashEditorLimits.MIN_WIDTH, SlashEditorLimits.MAX_WIDTH),
+                particleSize.coerceIn(SlashEditorLimits.MIN_PARTICLE_SIZE, SlashEditorLimits.MAX_PARTICLE_SIZE),
+                spacing.coerceIn(SlashEditorLimits.MIN_SPACING, SlashEditorLimits.MAX_SPACING),
+                durationTicks.coerceIn(SlashEditorLimits.MIN_DURATION_TICKS, SlashEditorLimits.MAX_DURATION_TICKS),
+                color.coerceIn(0, 0xffffff),
+                targetDistance.coerceIn(SlashEditorLimits.MIN_FORWARD_OFFSET, SlashEditorLimits.MAX_TARGET_DISTANCE),
+            )
+        }
+    }
+}
+
+data class VfxEditorOpen(val parameters: SlashEditorParameters = SlashEditorParameters()) : ProtocolMessage
+
+data class VfxSlashPreviewRequest(
+    val requestId: Long,
+    val parameters: SlashEditorParameters,
+) : ProtocolMessage
+
+object VfxSlashPreviewCancel : ProtocolMessage
+
+data class VfxSlashSaveRequest(
+    val name: String,
+    val parameters: SlashEditorParameters,
+) : ProtocolMessage {
+    init {
+        require(name.isNotBlank() && name.length <= SlashEditorLimits.MAX_NAME_LENGTH) {
+            "Slash draft name is invalid"
+        }
+    }
+}
+
+data class VfxSlashDraftList(val names: List<String>) : ProtocolMessage {
+    init {
+        require(names.size <= SlashEditorLimits.MAX_DRAFTS) { "Too many slash drafts" }
+        require(names.all { it.isNotBlank() && it.length <= SlashEditorLimits.MAX_NAME_LENGTH }) {
+            "Slash draft name is invalid"
+        }
+    }
+}
+
+data class VfxSlashDraftLoadRequest(val name: String) : ProtocolMessage {
+    init {
+        require(name.isNotBlank() && name.length <= SlashEditorLimits.MAX_NAME_LENGTH) {
+            "Slash draft name is invalid"
+        }
+    }
+}
+
+data class VfxSlashDraft(val name: String, val parameters: SlashEditorParameters) : ProtocolMessage {
+    init {
+        require(name.isNotBlank() && name.length <= SlashEditorLimits.MAX_NAME_LENGTH) {
+            "Slash draft name is invalid"
+        }
+    }
+}
+
+data class VfxEditorNotice(val text: String) : ProtocolMessage {
+    init {
+        require(text.length <= 160) { "Editor notice is too long" }
+    }
+}
+
 object ProtocolCodec {
     private const val MAX_PACKET_SIZE = 1024
     private const val HELLO = 1
@@ -219,6 +361,14 @@ object ProtocolCodec {
     private const val ATTACK_DEBUG_SHAPE = 18
     private const val GROUND_TELEGRAPH_START = 19
     private const val GROUND_TELEGRAPH_REMOVE = 20
+    private const val VFX_EDITOR_OPEN = 21
+    private const val VFX_SLASH_PREVIEW_REQUEST = 22
+    private const val VFX_SLASH_SAVE_REQUEST = 23
+    private const val VFX_SLASH_DRAFT_LIST = 24
+    private const val VFX_SLASH_DRAFT_LOAD_REQUEST = 25
+    private const val VFX_SLASH_DRAFT = 26
+    private const val VFX_EDITOR_NOTICE = 27
+    private const val VFX_SLASH_PREVIEW_CANCEL = 28
 
     fun encode(message: ProtocolMessage): ByteArray {
         val output = ByteArrayOutputStream()
@@ -303,9 +453,44 @@ object ProtocolCodec {
                     data.writeByte(GROUND_TELEGRAPH_REMOVE)
                     data.writeLong(message.telegraphId)
                 }
+                is VfxEditorOpen -> {
+                    data.writeByte(VFX_EDITOR_OPEN)
+                    writeSlashParameters(data, message.parameters)
+                }
+                is VfxSlashPreviewRequest -> {
+                    data.writeByte(VFX_SLASH_PREVIEW_REQUEST)
+                    data.writeLong(message.requestId)
+                    writeSlashParameters(data, message.parameters)
+                }
+                VfxSlashPreviewCancel -> data.writeByte(VFX_SLASH_PREVIEW_CANCEL)
+                is VfxSlashSaveRequest -> {
+                    data.writeByte(VFX_SLASH_SAVE_REQUEST)
+                    writeString(data, message.name)
+                    writeSlashParameters(data, message.parameters)
+                }
+                is VfxSlashDraftList -> {
+                    data.writeByte(VFX_SLASH_DRAFT_LIST)
+                    data.writeByte(message.names.size)
+                    message.names.forEach { writeString(data, it) }
+                }
+                is VfxSlashDraftLoadRequest -> {
+                    data.writeByte(VFX_SLASH_DRAFT_LOAD_REQUEST)
+                    writeString(data, message.name)
+                }
+                is VfxSlashDraft -> {
+                    data.writeByte(VFX_SLASH_DRAFT)
+                    writeString(data, message.name)
+                    writeSlashParameters(data, message.parameters)
+                }
+                is VfxEditorNotice -> {
+                    data.writeByte(VFX_EDITOR_NOTICE)
+                    writeString(data, message.text)
+                }
             }
         }
-        return output.toByteArray()
+        return output.toByteArray().also {
+            require(it.size <= MAX_PACKET_SIZE) { "ProjectS protocol packet exceeds $MAX_PACKET_SIZE bytes" }
+        }
     }
 
     fun decode(bytes: ByteArray): ProtocolMessage {
@@ -382,9 +567,66 @@ object ProtocolCodec {
                 durationTicks = input.readInt(),
             )
             GROUND_TELEGRAPH_REMOVE -> GroundTelegraphRemove(input.readLong())
+            VFX_EDITOR_OPEN -> VfxEditorOpen(readSlashParameters(input))
+            VFX_SLASH_PREVIEW_REQUEST -> VfxSlashPreviewRequest(input.readLong(), readSlashParameters(input))
+            VFX_SLASH_PREVIEW_CANCEL -> VfxSlashPreviewCancel
+            VFX_SLASH_SAVE_REQUEST -> VfxSlashSaveRequest(readString(input), readSlashParameters(input))
+            VFX_SLASH_DRAFT_LIST -> {
+                val count = input.readUnsignedByte()
+                require(count <= SlashEditorLimits.MAX_DRAFTS) { "Too many slash drafts" }
+                VfxSlashDraftList(List(count) { readString(input) })
+            }
+            VFX_SLASH_DRAFT_LOAD_REQUEST -> VfxSlashDraftLoadRequest(readString(input))
+            VFX_SLASH_DRAFT -> VfxSlashDraft(readString(input), readSlashParameters(input))
+            VFX_EDITOR_NOTICE -> VfxEditorNotice(readString(input))
             else -> throw IllegalArgumentException("Unknown ProjectS message type: $type")
         }
         require(input.available() == 0) { "Unexpected trailing ProjectS protocol data" }
         return message
+    }
+
+    private fun writeSlashParameters(data: DataOutputStream, parameters: SlashEditorParameters) {
+        data.writeDouble(parameters.originY)
+        data.writeDouble(parameters.forwardOffset)
+        data.writeDouble(parameters.length)
+        data.writeDouble(parameters.arcSpan)
+        data.writeDouble(parameters.curvature)
+        data.writeDouble(parameters.tilt)
+        data.writeDouble(parameters.yaw)
+        data.writeDouble(parameters.width)
+        data.writeDouble(parameters.particleSize)
+        data.writeDouble(parameters.spacing)
+        data.writeInt(parameters.durationTicks)
+        data.writeInt(parameters.color)
+        data.writeDouble(parameters.targetDistance)
+    }
+
+    private fun readSlashParameters(input: DataInputStream): SlashEditorParameters = SlashEditorParameters.clamped(
+        originY = input.readDouble(),
+        forwardOffset = input.readDouble(),
+        length = input.readDouble(),
+        arcSpan = input.readDouble(),
+        curvature = input.readDouble(),
+        tilt = input.readDouble(),
+        yaw = input.readDouble(),
+        width = input.readDouble(),
+        particleSize = input.readDouble(),
+        spacing = input.readDouble(),
+        durationTicks = input.readInt(),
+        color = input.readInt(),
+        targetDistance = input.readDouble(),
+    )
+
+    private fun writeString(data: DataOutputStream, value: String) {
+        val bytes = value.toByteArray(Charsets.UTF_8)
+        require(bytes.size <= SlashEditorLimits.MAX_NAME_LENGTH * 4) { "ProjectS string is too long" }
+        data.writeShort(bytes.size)
+        data.write(bytes)
+    }
+
+    private fun readString(input: DataInputStream): String {
+        val size = input.readUnsignedShort()
+        require(size <= SlashEditorLimits.MAX_NAME_LENGTH * 4) { "ProjectS string is too long" }
+        return ByteArray(size).also(input::readFully).toString(Charsets.UTF_8)
     }
 }

--- a/protocol/src/test/kotlin/dev/projects/protocol/ProtocolCodecTest.kt
+++ b/protocol/src/test/kotlin/dev/projects/protocol/ProtocolCodecTest.kt
@@ -200,6 +200,50 @@ class ProtocolCodecTest {
         assertEquals(64.0, decoded.radius)
     }
 
+    @Test
+    fun `slash editor parameters reject non finite values and clamp bounds`() {
+        assertFailsWith<IllegalArgumentException> {
+            SlashEditorParameters.clamped(
+                Double.NaN, 0.0, 1.0, 90.0, 0.0, 0.0, 0.0, 0.1, 0.1, 0.1, 8, 0xffffff, 1.0,
+            )
+        }
+        val parameters = SlashEditorParameters.clamped(
+            -100.0, 100.0, 100.0, -100.0, 100.0, -100.0, 100.0, 100.0, 100.0, -100.0, 1000, -1, 100.0,
+        )
+        assertEquals(-4.0, parameters.originY)
+        assertEquals(8.0, parameters.forwardOffset)
+        assertEquals(12.0, parameters.length)
+        assertEquals(10.0, parameters.arcSpan)
+        assertEquals(4.0, parameters.curvature)
+        assertEquals(0.05, parameters.spacing)
+        assertEquals(80, parameters.durationTicks)
+        assertEquals(0, parameters.color)
+        assertEquals(32.0, parameters.targetDistance)
+    }
+
+    @Test
+    fun `vfx editor messages round trip`() {
+        val parameters = SlashEditorParameters()
+        listOf<ProtocolMessage>(
+            VfxEditorOpen(parameters),
+            VfxSlashPreviewRequest(42L, parameters),
+            VfxSlashPreviewCancel,
+            VfxSlashSaveRequest("blue slash", parameters),
+            VfxSlashDraftList(listOf("blue slash")),
+            VfxSlashDraftLoadRequest("blue slash"),
+            VfxSlashDraft("blue slash", parameters),
+            VfxEditorNotice("saved"),
+        ).forEach(::assertRoundTrip)
+    }
+
+    @Test
+    fun `vfx editor parameter decode rejects non finite values`() {
+        val malformed = ProtocolCodec.encode(VfxSlashPreviewRequest(1L, SlashEditorParameters())).copyOf().also { bytes ->
+            java.nio.ByteBuffer.wrap(bytes, 1 + Long.SIZE_BYTES, Double.SIZE_BYTES).putDouble(Double.NaN)
+        }
+        assertFailsWith<IllegalArgumentException> { ProtocolCodec.decode(malformed) }
+    }
+
     private fun assertRoundTrip(message: ProtocolMessage) {
         assertEquals(message, ProtocolCodec.decode(ProtocolCodec.encode(message)))
     }

--- a/server-minestom/src/main/kotlin/dev/projects/server/ProjectSServer.kt
+++ b/server-minestom/src/main/kotlin/dev/projects/server/ProjectSServer.kt
@@ -16,6 +16,15 @@ import dev.projects.protocol.ProtocolCodec
 import dev.projects.protocol.ProtocolHello
 import dev.projects.protocol.ProtocolHelloAck
 import dev.projects.protocol.ProtocolVersion
+import dev.projects.protocol.SlashEditorParameters
+import dev.projects.protocol.VfxEditorNotice
+import dev.projects.protocol.VfxEditorOpen
+import dev.projects.protocol.VfxSlashDraft
+import dev.projects.protocol.VfxSlashDraftList
+import dev.projects.protocol.VfxSlashDraftLoadRequest
+import dev.projects.protocol.VfxSlashPreviewRequest
+import dev.projects.protocol.VfxSlashPreviewCancel
+import dev.projects.protocol.VfxSlashSaveRequest
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.bossbar.BossBar
 import net.minestom.server.Auth
@@ -46,6 +55,7 @@ import net.minestom.server.sound.SoundEvent
 import net.kyori.adventure.sound.Sound
 import net.kyori.adventure.key.Key
 import java.nio.charset.StandardCharsets
+import java.nio.file.Path
 import java.util.UUID
 import kotlin.math.abs
 import kotlin.math.floor
@@ -65,6 +75,9 @@ import dev.projects.server.particle.startParticlePreset
 import net.minestom.server.command.builder.suggestion.SuggestionEntry
 import dev.projects.server.particle.startParticleDemo
 import dev.projects.server.particle.startParticleV2Diagnostic
+import dev.projects.server.particle.ParticleEffectHandle
+import dev.projects.server.particle.ParticleViewer
+import dev.projects.server.particle.PlayerParticleSink
 
 private const val SERVER_ADDRESS = "127.0.0.1"
 private const val SERVER_PORT = 25565
@@ -121,6 +134,41 @@ fun main() {
     val lastGroundTelegraphIds = mutableMapOf<UUID, Long>()
     val bossGroundTelegraphIds = mutableSetOf<Long>()
     val bossRiftTelegraphIds = mutableMapOf<Long, Long>()
+    val slashDraftStore = SlashDraftStore(Path.of("config", "projects", "vfx-editor", "slash-drafts.json"))
+    val slashPreviewHandles = mutableMapOf<UUID, ParticleEffectHandle>()
+
+    fun sendSlashDraftList(player: net.minestom.server.entity.Player) {
+        player.sendPluginMessage(
+            PROJECTS_CHANNEL,
+            ProtocolCodec.encode(VfxSlashDraftList(slashDraftStore.list())),
+        )
+    }
+
+    fun openSlashEditor(player: net.minestom.server.entity.Player) {
+        player.sendPluginMessage(PROJECTS_CHANNEL, ProtocolCodec.encode(VfxEditorOpen()))
+        sendSlashDraftList(player)
+    }
+
+    fun previewSlash(player: net.minestom.server.entity.Player, parameters: SlashEditorParameters) {
+        particleAnimations.cancel(slashPreviewHandles.remove(player.uuid))
+        val direction = player.position.direction()
+        val forward = FixedAttackTester.normalizeHorizontal(direction)
+        val origin = player.position.add(
+            forward.x() * parameters.forwardOffset,
+            parameters.originY,
+            forward.z() * parameters.forwardOffset,
+        )
+        val sink = particleManager.sink(
+            ParticleViewer(player.position, player),
+            PlayerParticleSink(player),
+            "editor:slash",
+        )
+        slashPreviewHandles[player.uuid] = particleAnimations.start(
+            SlashEditorPreview.create(origin, direction, parameters),
+            sink,
+            id = "editor:slash:${player.uuid}",
+        )
+    }
 
     fun clearBossTelegraphs() {
         bossGroundTelegraphIds.toList().forEach { telegraphId ->
@@ -384,6 +432,14 @@ fun main() {
         },
     )
     MinecraftServer.getCommandManager().register(
+        Command("vfxedit").apply {
+            addSyntax(
+                { sender, _ -> (sender as? net.minestom.server.entity.Player)?.let(::openSlashEditor) },
+                ArgumentType.Literal("slash"),
+            )
+        },
+    )
+    MinecraftServer.getCommandManager().register(
         Command("vfxdemo").apply {
             addSyntax(::handleVfxDemo, vfxTypeArgument)
             addSyntax({ sender, _ -> (sender as? net.minestom.server.entity.Player)?.let { particleAnimations.pauseFor(it) } }, ArgumentType.Literal("evolved"), ArgumentType.Literal("pause"))
@@ -531,6 +587,7 @@ fun main() {
     }
     events.addListener(PlayerDisconnectEvent::class.java) { event ->
         val playerId = event.player.uuid
+        particleAnimations.cancel(slashPreviewHandles.remove(playerId))
         particleAnimations.cancelFor(event.player)
         combatStates.remove(playerId)
         dodgeStates.remove(playerId)
@@ -979,6 +1036,29 @@ fun main() {
                         }
                         ClassSkillSlot.ULTIMATE -> return@addListener
                     }
+                }
+                is VfxSlashPreviewRequest -> previewSlash(event.player, message.parameters)
+                VfxSlashPreviewCancel -> particleAnimations.cancel(slashPreviewHandles.remove(event.player.uuid))
+                is VfxSlashSaveRequest -> {
+                    val saved = slashDraftStore.save(message.name, message.parameters)
+                    event.player.sendPluginMessage(
+                        PROJECTS_CHANNEL,
+                        ProtocolCodec.encode(
+                            if (saved) VfxEditorNotice("Saved draft '${message.name}'")
+                            else VfxEditorNotice("Draft name is invalid or storage is full"),
+                        ),
+                    )
+                    if (saved) sendSlashDraftList(event.player)
+                }
+                is VfxSlashDraftLoadRequest -> {
+                    val parameters = slashDraftStore.load(message.name)
+                    event.player.sendPluginMessage(
+                        PROJECTS_CHANNEL,
+                        ProtocolCodec.encode(
+                            if (parameters == null) VfxEditorNotice("Draft not found")
+                            else VfxSlashDraft(message.name, parameters),
+                        ),
+                    )
                 }
                 else -> throw IllegalArgumentException("Unexpected ProjectS message")
             }

--- a/server-minestom/src/main/kotlin/dev/projects/server/SlashEditor.kt
+++ b/server-minestom/src/main/kotlin/dev/projects/server/SlashEditor.kt
@@ -1,0 +1,161 @@
+package dev.projects.server
+
+import dev.projects.protocol.SlashEditorParameters
+import dev.projects.server.particle.ParticleCircle
+import dev.projects.server.particle.ParticleEffect
+import dev.projects.server.particle.ParticleGeometry
+import dev.projects.server.particle.ParticleParallel
+import dev.projects.server.particle.ParticleStyle
+import dev.projects.server.particle.basis
+import dev.projects.server.particle.dust
+import net.minestom.server.coordinate.Point
+import net.minestom.server.coordinate.Vec
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.math.roundToInt
+
+private const val DRAFT_SCHEMA_VERSION = 1
+private const val MAX_DRAFTS = 16
+
+/** Fixed-path, deliberately small persistence for the in-game slash authoring tool. */
+class SlashDraftStore(private val file: Path) {
+    private val drafts = linkedMapOf<String, SlashEditorParameters>()
+
+    init {
+        readFromDisk()
+    }
+
+    fun list(): List<String> = drafts.keys.sorted()
+
+    fun load(name: String): SlashEditorParameters? = drafts[name]
+
+    fun save(name: String, parameters: SlashEditorParameters): Boolean {
+        if (!isSafeName(name)) return false
+        if (name !in drafts && drafts.size >= MAX_DRAFTS) return false
+        drafts[name] = parameters
+        return writeToDisk()
+    }
+
+    private fun readFromDisk() {
+        if (!Files.isRegularFile(file)) return
+        runCatching {
+            val content = Files.readString(file)
+            Regex("""\{"name":"([^"\\]*)","parameters":\{([^}]*)\}\}""")
+                .findAll(content)
+                .take(MAX_DRAFTS)
+                .forEach { match ->
+                    val name = match.groupValues[1]
+                    if (!isSafeName(name)) return@forEach
+                    parseParameters(match.groupValues[2])?.let { drafts[name] = it }
+                }
+        }
+    }
+
+    private fun parseParameters(raw: String): SlashEditorParameters? = runCatching {
+        fun number(key: String): Double = Regex("\\\"$key\\\":([^,}]+)").find(raw)!!.groupValues[1].toDouble()
+        fun integer(key: String): Int = Regex("\\\"$key\\\":([^,}]+)").find(raw)!!.groupValues[1].toInt()
+        SlashEditorParameters.clamped(
+            originY = number("originY"),
+            forwardOffset = number("forwardOffset"),
+            length = number("length"),
+            arcSpan = number("arcSpan"),
+            curvature = number("curvature"),
+            tilt = number("tilt"),
+            yaw = number("yaw"),
+            width = number("width"),
+            particleSize = number("particleSize"),
+            spacing = number("spacing"),
+            durationTicks = integer("durationTicks"),
+            color = integer("color"),
+            targetDistance = number("targetDistance"),
+        )
+    }.getOrNull()
+
+    private fun writeToDisk(): Boolean = runCatching {
+        file.parent?.let(Files::createDirectories)
+        val json = buildString {
+            append("{\"schemaVersion\":").append(DRAFT_SCHEMA_VERSION).append(",\"drafts\":[")
+            drafts.entries.sortedBy { it.key }.forEachIndexed { index, (name, parameters) ->
+                if (index > 0) append(',')
+                append("{\"name\":\"").append(name).append("\",\"parameters\":{")
+                append("\"originY\":").append(parameters.originY)
+                append(",\"forwardOffset\":").append(parameters.forwardOffset)
+                append(",\"length\":").append(parameters.length)
+                append(",\"arcSpan\":").append(parameters.arcSpan)
+                append(",\"curvature\":").append(parameters.curvature)
+                append(",\"tilt\":").append(parameters.tilt)
+                append(",\"yaw\":").append(parameters.yaw)
+                append(",\"width\":").append(parameters.width)
+                append(",\"particleSize\":").append(parameters.particleSize)
+                append(",\"spacing\":").append(parameters.spacing)
+                append(",\"durationTicks\":").append(parameters.durationTicks)
+                append(",\"color\":").append(parameters.color)
+                append(",\"targetDistance\":").append(parameters.targetDistance)
+                append("}}")
+            }
+            append("]}")
+        }
+        Files.writeString(file, json)
+        true
+    }.getOrDefault(false)
+
+    companion object {
+        private val SAFE_NAME = Regex("[A-Za-z0-9][A-Za-z0-9 _-]{0,31}")
+
+        fun isSafeName(name: String): Boolean = SAFE_NAME.matches(name)
+    }
+}
+
+object SlashEditorPreview {
+    fun create(origin: Point, direction: Vec, parameters: SlashEditorParameters): ParticleEffect {
+        val (forward, right, up) = basis(direction)
+        val radius = (parameters.length * (0.72 + parameters.curvature * 0.07)).coerceIn(0.5, 12.0)
+        val lanes = when {
+            parameters.width < 0.16 -> 1
+            parameters.width < 0.7 -> 2
+            else -> 3
+        }
+        val degreeStep = (parameters.spacing * 42.0).coerceIn(2.0, 32.0)
+        val arc = ParticleGeometry.drawCleaveArc(
+            origin = origin,
+            facing = direction,
+            radius = radius,
+            tiltAngle = parameters.tilt,
+            startDegrees = -parameters.arcSpan / 2.0,
+            endDegrees = parameters.arcSpan / 2.0,
+            rings = lanes,
+            extraYaw = parameters.yaw,
+            ringSpacing = parameters.width.coerceAtLeast(0.04),
+            degreesPerTick = parameters.arcSpan / parameters.durationTicks,
+            degreeStep = degreeStep,
+        ) { _, ring, progress ->
+            val color = if (ring == 0) parameters.color else blendTowardWhite(parameters.color, progress)
+            ParticleStyle(
+                dust(color, parameters.particleSize.toFloat() * if (ring == 0) 1.0f else 0.72f),
+                count = if (ring == 0) 2 else 1,
+            )
+        }
+        val target = origin.add(
+            forward.x() * parameters.targetDistance,
+            forward.y() * parameters.targetDistance,
+            forward.z() * parameters.targetDistance,
+        )
+        val targetMarker = ParticleCircle(
+            center = target,
+            radius = 0.16,
+            axis1 = right,
+            axis2 = up,
+            countPerMeter = 18.0,
+            style = ParticleStyle(dust(parameters.color, (parameters.particleSize * 0.7).toFloat())),
+        )
+        return ParticleParallel.of(arc, targetMarker)
+    }
+
+    private fun blendTowardWhite(color: Int, progress: Double): Int {
+        fun channel(shift: Int): Int {
+            val value = color shr shift and 0xff
+            return (value + (255 - value) * (progress * 0.35).coerceIn(0.0, 1.0)).roundToInt()
+        }
+        return channel(16) shl 16 or (channel(8) shl 8) or channel(0)
+    }
+}

--- a/server-minestom/src/main/kotlin/dev/projects/server/SlashEditor.kt
+++ b/server-minestom/src/main/kotlin/dev/projects/server/SlashEditor.kt
@@ -12,7 +12,6 @@ import net.minestom.server.coordinate.Point
 import net.minestom.server.coordinate.Vec
 import java.nio.file.Files
 import java.nio.file.Path
-import kotlin.math.roundToInt
 
 private const val DRAFT_SCHEMA_VERSION = 1
 private const val MAX_DRAFTS = 16
@@ -128,10 +127,9 @@ object SlashEditorPreview {
             ringSpacing = parameters.width.coerceAtLeast(0.04),
             degreesPerTick = parameters.arcSpan / parameters.durationTicks,
             degreeStep = degreeStep,
-        ) { _, ring, progress ->
-            val color = if (ring == 0) parameters.color else blendTowardWhite(parameters.color, progress)
+        ) { _, ring, _ ->
             ParticleStyle(
-                dust(color, parameters.particleSize.toFloat() * if (ring == 0) 1.0f else 0.72f),
+                dust(parameters.color, parameters.particleSize.toFloat() * if (ring == 0) 1.0f else 0.72f),
                 count = if (ring == 0) 2 else 1,
             )
         }
@@ -149,13 +147,5 @@ object SlashEditorPreview {
             style = ParticleStyle(dust(parameters.color, (parameters.particleSize * 0.7).toFloat())),
         )
         return ParticleParallel.of(arc, targetMarker)
-    }
-
-    private fun blendTowardWhite(color: Int, progress: Double): Int {
-        fun channel(shift: Int): Int {
-            val value = color shr shift and 0xff
-            return (value + (255 - value) * (progress * 0.35).coerceIn(0.0, 1.0)).roundToInt()
-        }
-        return channel(16) shl 16 or (channel(8) shl 8) or channel(0)
     }
 }

--- a/server-minestom/src/main/kotlin/dev/projects/server/particle/ParticleAnimationScheduler.kt
+++ b/server-minestom/src/main/kotlin/dev/projects/server/particle/ParticleAnimationScheduler.kt
@@ -37,6 +37,12 @@ class ParticleAnimationScheduler {
         }
     }
 
+    fun cancel(handle: ParticleEffectHandle?) {
+        if (handle == null) return
+        handle.cancel()
+        active.removeIf { it.handle === handle }
+    }
+
     fun pauseFor(player: Player) {
         active.filter { (it.sink as? PlayerOwnedParticleSink)?.owner === player }
             .forEach { it.handle.pause() }

--- a/server-minestom/src/test/kotlin/dev/projects/server/SlashEditorTest.kt
+++ b/server-minestom/src/test/kotlin/dev/projects/server/SlashEditorTest.kt
@@ -1,0 +1,55 @@
+package dev.projects.server
+
+import dev.projects.protocol.SlashEditorParameters
+import dev.projects.server.particle.RecordingParticleSink
+import net.minestom.server.coordinate.Pos
+import net.minestom.server.coordinate.Vec
+import net.minestom.server.particle.Particle
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class SlashEditorTest {
+    @Test
+    fun `drafts survive a new store and reject unsafe names`() {
+        val directory = Files.createTempDirectory("slash-editor-test")
+        val file = directory.resolve("drafts.json")
+        val parameters = SlashEditorParameters(color = 0x123456)
+
+        assertTrue(SlashDraftStore(file).save("deep blue", parameters))
+        val reloaded = SlashDraftStore(file)
+        assertEquals(parameters, reloaded.load("deep blue"))
+        assertFalse(reloaded.save("../escape", parameters))
+        assertFalse(reloaded.save("", parameters))
+    }
+
+    @Test
+    fun `draft store enforces the maximum number of drafts`() {
+        val file = Files.createTempFile("slash-editor-test", ".json")
+        val store = SlashDraftStore(file)
+        repeat(16) { index -> assertTrue(store.save("draft-$index", SlashEditorParameters())) }
+        assertFalse(store.save("draft-16", SlashEditorParameters()))
+        assertTrue(store.save("draft-0", SlashEditorParameters(color = 0xabcdef)))
+    }
+
+    @Test
+    fun `preview emits finite positions with the requested color`() {
+        val color = 0x123456
+        val effect = SlashEditorPreview.create(Pos.ZERO, Vec(0.0, 0.0, 1.0), SlashEditorParameters(color = color))
+        val sink = RecordingParticleSink()
+        repeat(effect.durationTicks) { effect.emit(it, sink) }
+
+        assertTrue(sink.spawns.isNotEmpty())
+        assertTrue(sink.spawns.all { spawn ->
+            spawn.position.x().isFinite() && spawn.position.y().isFinite() && spawn.position.z().isFinite()
+        })
+        val dustColors = sink.spawns.mapNotNull { spawn ->
+            (spawn.particle as? Particle.Dust)?.color()?.let { textColor ->
+                textColor.red() shl 16 or (textColor.green() shl 8) or textColor.blue()
+            }
+        }.toSet()
+        assertEquals(setOf(color), dustColors)
+    }
+}


### PR DESCRIPTION
Closes #69

## Summary
- In-game Slash VFX Editor MVP
- Live world preview using the existing ProjectS particle framework
- Slash parameter editing for origin/length/arc/curvature/tilt/yaw/width/size/spacing/duration/color/target distance
- Replay / Auto Preview / Reset
- Draft save/load persistence
- Protocol v8 editor messages with validation and packet-size limits
- Minecraft 26.2 Screen API support

## Review / Verification
- Sol Review PASS
- User Manual Smoke accepted
- targeted editor/protocol tests PASS
- `:protocol:test` PASS
- `:server-minestom:test` PASS
- `:client-fabric:test` PASS
- `:server-minestom:build` PASS
- `:client-fabric:build` PASS
- `git diff --check` PASS

## Visual constraint
- Slash preview uses the requested color as a true single-color Dust effect; no automatic white blend.