### PR TITLE
OpenCode: allow read-only Gradle cache inspection

### DIFF
--- a/opencode.jsonc
+++ b/opencode.jsonc
@@ -10,6 +10,14 @@
   // Task branches may be pushed automatically after tests/build pass.
   // Protect main and history rewriting.
   "permission": {
+    // Allow API/dependency inspection from Gradle's shared cache while
+    // keeping that external directory read-only for Agent file edits.
+    "external_directory": {
+      "~/.gradle/caches/**": "allow"
+    },
+    "edit": {
+      "~/.gradle/caches/**": "deny"
+    },
     "bash": {
       "git push*": "allow",
       "git push origin main*": "deny",


### PR DESCRIPTION
Closes #78

## Summary
- Allow `~/.gradle/caches/**` through OpenCode `external_directory`
- Explicitly deny Agent file edits inside that cache
- Keep existing main/force-push safety rules unchanged

## Why
Issue #77 was blocked before implementation because the non-interactive OpenCode child task could not inspect Minecraft/Fabric 26.2 API artifacts in Gradle's shared cache.

## Verification
- Matches current OpenCode `external_directory` permission syntax
- Scope is one config file / 8 added lines
- Manual Smoke not required