### PR TITLE
VFX Editor slash lane controls

### DIFF
--- a/client-fabric/src/main/kotlin/dev/projects/client/SlashEditorScreen.kt
+++ b/client-fabric/src/main/kotlin/dev/projects/client/SlashEditorScreen.kt
@@ -21,6 +21,8 @@ class SlashEditorScreen(
         const val MAX_PARTICLE_SIZE = 2.0
         const val MIN_SPACING = 0.05
         const val MAX_SPACING = 2.0
+        const val MIN_LANE_SPACING = 0.05
+        const val MAX_LANE_SPACING = 2.0
         const val BASIC_ROW_SPACING = 19
         const val BASIC_START_Y = 30
     }
@@ -53,7 +55,9 @@ class SlashEditorScreen(
         BasicControl("tilt", "傾き", "斬撃面の角度", -90.0, 90.0, 0),
         BasicControl("yaw", "向き", "斬撃全体を左右へ回転", -180.0, 180.0, 0),
         BasicControl("originY", "開始高さ", "プレイヤー基準の発生高さ", -4.0, 8.0),
-        BasicControl("width", "太さ", "並行するSlashライン間隔", 0.0, 1.5),
+        BasicControl("width", "太さ", "斬撃1本の視覚的な太さ", 0.0, 1.5),
+        BasicControl("laneCount", "線の本数", "平行に描く斬撃ラインの本数", 1.0, 3.0, 0),
+        BasicControl("laneSpacing", "線の間隔", "斬撃ライン同士の距離", MIN_LANE_SPACING, MAX_LANE_SPACING, 2),
         BasicControl("particleSize", "粒の大きさ", "1粒の見た目の大きさ", MIN_PARTICLE_SIZE, MAX_PARTICLE_SIZE, 2),
         BasicControl("density", "密度", "斬撃ライン上の粒の詰まり具合", MIN_SPACING, MAX_SPACING, 2),
         BasicControl("forwardOffset", "前後位置", "斬撃全体をプレイヤーから前後に移動", 0.0, 8.0, 2),
@@ -190,7 +194,8 @@ class SlashEditorScreen(
         SlashEditorParameters.clamped(
             originY = valueFor("originY"), forwardOffset = number("forwardOffset"), length = valueFor("length"),
             arcSpan = valueFor("arcSpan"), curvature = valueFor("curvature"), tilt = valueFor("tilt"), yaw = number("yaw"),
-            width = valueFor("width"), particleSize = number("particleSize"), spacing = number("spacing"),
+            width = valueFor("width"), laneCount = valueFor("laneCount").toInt(), laneSpacing = valueFor("laneSpacing"),
+            particleSize = number("particleSize"), spacing = number("spacing"),
             durationTicks = number("durationTicks").toInt(), color = color, targetDistance = number("targetDistance"),
         )
     }.getOrNull()
@@ -211,7 +216,8 @@ class SlashEditorScreen(
     private fun valueFor(key: String): Double = when (key) {
         "originY" -> parameters.originY; "forwardOffset" -> parameters.forwardOffset; "length" -> parameters.length
         "arcSpan" -> parameters.arcSpan; "curvature" -> parameters.curvature; "tilt" -> parameters.tilt
-        "yaw" -> parameters.yaw; "width" -> parameters.width; "particleSize" -> parameters.particleSize
+        "yaw" -> parameters.yaw; "width" -> parameters.width; "laneCount" -> parameters.laneCount.toDouble(); "laneSpacing" -> parameters.laneSpacing
+        "particleSize" -> parameters.particleSize
         "spacing" -> parameters.spacing; "density" -> densityForSpacing(parameters.spacing)
         "durationTicks" -> parameters.durationTicks.toDouble(); "targetDistance" -> parameters.targetDistance
         else -> 0.0
@@ -232,6 +238,8 @@ class SlashEditorScreen(
         length = if (key == "length") value else length, arcSpan = if (key == "arcSpan") value else arcSpan,
         curvature = if (key == "curvature") value else curvature, tilt = if (key == "tilt") value else tilt,
         yaw = if (key == "yaw") value else yaw, width = if (key == "width") value else width,
+        laneCount = if (key == "laneCount") value.toInt() else laneCount,
+        laneSpacing = if (key == "laneSpacing") value else laneSpacing,
         particleSize = if (key == "particleSize") value else particleSize,
         spacing = if (key == "density") spacingForDensity(value) else spacing,
         durationTicks = durationTicks, color = color, targetDistance = targetDistance,

--- a/client-fabric/src/main/kotlin/dev/projects/client/SlashEditorScreen.kt
+++ b/client-fabric/src/main/kotlin/dev/projects/client/SlashEditorScreen.kt
@@ -256,7 +256,7 @@ class SlashEditorScreen(
         x: Int, y: Int, width: Int, private val control: BasicControl, value: Double,
         private val changed: (Double) -> Unit,
     ) : AbstractSliderButton(
-        x, y, width, 20, Component.literal(control.label),
+        x, y, width, BASIC_ROW_SPACING, Component.literal(control.label),
         ((value - control.min) / (control.max - control.min)).coerceIn(0.0, 1.0),
     ) {
         private var current = value

--- a/client-fabric/src/main/kotlin/dev/projects/client/SlashEditorScreen.kt
+++ b/client-fabric/src/main/kotlin/dev/projects/client/SlashEditorScreen.kt
@@ -11,6 +11,7 @@ import net.minecraft.client.gui.components.Button
 import net.minecraft.client.gui.components.EditBox
 import net.minecraft.client.gui.screens.Screen
 import net.minecraft.network.chat.Component
+import kotlin.math.roundToInt
 
 class SlashEditorScreen(
     initialParameters: SlashEditorParameters,
@@ -23,7 +24,7 @@ class SlashEditorScreen(
         const val MAX_SPACING = 2.0
         const val MIN_LANE_SPACING = 0.05
         const val MAX_LANE_SPACING = 2.0
-        const val BASIC_ROW_SPACING = 19
+        const val BASIC_ROW_SPACING = 16
         const val BASIC_START_Y = 30
     }
 
@@ -194,7 +195,7 @@ class SlashEditorScreen(
         SlashEditorParameters.clamped(
             originY = valueFor("originY"), forwardOffset = number("forwardOffset"), length = valueFor("length"),
             arcSpan = valueFor("arcSpan"), curvature = valueFor("curvature"), tilt = valueFor("tilt"), yaw = number("yaw"),
-            width = valueFor("width"), laneCount = valueFor("laneCount").toInt(), laneSpacing = valueFor("laneSpacing"),
+            width = valueFor("width"), laneCount = valueFor("laneCount").roundToInt(), laneSpacing = valueFor("laneSpacing"),
             particleSize = number("particleSize"), spacing = number("spacing"),
             durationTicks = number("durationTicks").toInt(), color = color, targetDistance = number("targetDistance"),
         )
@@ -238,7 +239,7 @@ class SlashEditorScreen(
         length = if (key == "length") value else length, arcSpan = if (key == "arcSpan") value else arcSpan,
         curvature = if (key == "curvature") value else curvature, tilt = if (key == "tilt") value else tilt,
         yaw = if (key == "yaw") value else yaw, width = if (key == "width") value else width,
-        laneCount = if (key == "laneCount") value.toInt() else laneCount,
+        laneCount = if (key == "laneCount") value.roundToInt() else laneCount,
         laneSpacing = if (key == "laneSpacing") value else laneSpacing,
         particleSize = if (key == "particleSize") value else particleSize,
         spacing = if (key == "density") spacingForDensity(value) else spacing,
@@ -260,8 +261,17 @@ class SlashEditorScreen(
     ) {
         private var current = value
         override fun updateMessage() { message = Component.literal("${control.label}: ${format(current, control.decimals)}") }
-        override fun applyValue() { current = control.min + value * (control.max - control.min); changed(current); updateMessage() }
-        fun setParameterValue(value: Double) { current = value; setValue(normalized(value)); updateMessage() }
+        override fun applyValue() {
+            val raw = control.min + value * (control.max - control.min)
+            current = if (control.key == "laneCount") raw.roundToInt().toDouble() else raw
+            changed(current)
+            updateMessage()
+        }
+        fun setParameterValue(value: Double) {
+            current = if (control.key == "laneCount") value.roundToInt().toDouble() else value
+            setValue(normalized(current))
+            updateMessage()
+        }
         companion object {
             fun normalized(value: Double, min: Double = 0.0, max: Double = 1.0) = ((value - min) / (max - min)).coerceIn(0.0, 1.0)
             private fun format(value: Double, decimals: Int) = "% .${decimals}f".format(value).trim()

--- a/protocol/src/main/kotlin/dev/projects/protocol/Protocol.kt
+++ b/protocol/src/main/kotlin/dev/projects/protocol/Protocol.kt
@@ -12,7 +12,7 @@ import kotlin.math.sqrt
 const val PROJECTS_CHANNEL = "projects:protocol"
 
 object ProtocolVersion {
-    const val CURRENT = 8
+    const val CURRENT = 9
 
     fun requireCompatible(version: Int) {
         if (version != CURRENT) {
@@ -224,6 +224,10 @@ private object SlashEditorLimits {
     const val MAX_YAW = 180.0
     const val MIN_WIDTH = 0.0
     const val MAX_WIDTH = 1.5
+    const val MIN_LANE_COUNT = 1
+    const val MAX_LANE_COUNT = 3
+    const val MIN_LANE_SPACING = 0.05
+    const val MAX_LANE_SPACING = 2.0
     const val MIN_PARTICLE_SIZE = 0.05
     const val MAX_PARTICLE_SIZE = 2.0
     const val MIN_SPACING = 0.05
@@ -242,6 +246,8 @@ data class SlashEditorParameters(
     val tilt: Double = 12.0,
     val yaw: Double = 0.0,
     val width: Double = 0.28,
+    val laneCount: Int = 1,
+    val laneSpacing: Double = 0.18,
     val particleSize: Double = 0.28,
     val spacing: Double = 0.18,
     val durationTicks: Int = 8,
@@ -249,9 +255,10 @@ data class SlashEditorParameters(
     val targetDistance: Double = 5.0,
 ) {
     init {
-        require(listOf(originY, forwardOffset, length, arcSpan, curvature, tilt, yaw, width, particleSize, spacing, targetDistance).all { it.isFinite() }) {
+        require(listOf(originY, forwardOffset, length, arcSpan, curvature, tilt, yaw, width, laneSpacing, particleSize, spacing, targetDistance).all { it.isFinite() }) {
             "Slash editor values must be finite"
         }
+        require(laneCount in SlashEditorLimits.MIN_LANE_COUNT..SlashEditorLimits.MAX_LANE_COUNT) { "Slash editor lane count is out of range" }
         require(durationTicks in SlashEditorLimits.MIN_DURATION_TICKS..SlashEditorLimits.MAX_DURATION_TICKS) {
             "Slash editor duration is out of range"
         }
@@ -268,13 +275,15 @@ data class SlashEditorParameters(
             tilt: Double,
             yaw: Double,
             width: Double,
+            laneCount: Int,
+            laneSpacing: Double,
             particleSize: Double,
             spacing: Double,
             durationTicks: Int,
             color: Int,
             targetDistance: Double,
         ): SlashEditorParameters {
-            require(listOf(originY, forwardOffset, length, arcSpan, curvature, tilt, yaw, width, particleSize, spacing, targetDistance).all { it.isFinite() }) {
+            require(listOf(originY, forwardOffset, length, arcSpan, curvature, tilt, yaw, width, laneSpacing, particleSize, spacing, targetDistance).all { it.isFinite() }) {
                 "Slash editor values must be finite"
             }
             return SlashEditorParameters(
@@ -286,6 +295,8 @@ data class SlashEditorParameters(
                 tilt.coerceIn(SlashEditorLimits.MIN_TILT, SlashEditorLimits.MAX_TILT),
                 yaw.coerceIn(SlashEditorLimits.MIN_YAW, SlashEditorLimits.MAX_YAW),
                 width.coerceIn(SlashEditorLimits.MIN_WIDTH, SlashEditorLimits.MAX_WIDTH),
+                laneCount.coerceIn(SlashEditorLimits.MIN_LANE_COUNT, SlashEditorLimits.MAX_LANE_COUNT),
+                laneSpacing.coerceIn(SlashEditorLimits.MIN_LANE_SPACING, SlashEditorLimits.MAX_LANE_SPACING),
                 particleSize.coerceIn(SlashEditorLimits.MIN_PARTICLE_SIZE, SlashEditorLimits.MAX_PARTICLE_SIZE),
                 spacing.coerceIn(SlashEditorLimits.MIN_SPACING, SlashEditorLimits.MAX_SPACING),
                 durationTicks.coerceIn(SlashEditorLimits.MIN_DURATION_TICKS, SlashEditorLimits.MAX_DURATION_TICKS),
@@ -594,6 +605,8 @@ object ProtocolCodec {
         data.writeDouble(parameters.tilt)
         data.writeDouble(parameters.yaw)
         data.writeDouble(parameters.width)
+        data.writeInt(parameters.laneCount)
+        data.writeDouble(parameters.laneSpacing)
         data.writeDouble(parameters.particleSize)
         data.writeDouble(parameters.spacing)
         data.writeInt(parameters.durationTicks)
@@ -610,6 +623,8 @@ object ProtocolCodec {
         tilt = input.readDouble(),
         yaw = input.readDouble(),
         width = input.readDouble(),
+        laneCount = input.readInt(),
+        laneSpacing = input.readDouble(),
         particleSize = input.readDouble(),
         spacing = input.readDouble(),
         durationTicks = input.readInt(),

--- a/protocol/src/test/kotlin/dev/projects/protocol/ProtocolCodecTest.kt
+++ b/protocol/src/test/kotlin/dev/projects/protocol/ProtocolCodecTest.kt
@@ -204,17 +204,19 @@ class ProtocolCodecTest {
     fun `slash editor parameters reject non finite values and clamp bounds`() {
         assertFailsWith<IllegalArgumentException> {
             SlashEditorParameters.clamped(
-                Double.NaN, 0.0, 1.0, 90.0, 0.0, 0.0, 0.0, 0.1, 0.1, 0.1, 8, 0xffffff, 1.0,
+                Double.NaN, 0.0, 1.0, 90.0, 0.0, 0.0, 0.0, 0.1, 1, 0.1, 0.1, 0.1, 8, 0xffffff, 1.0,
             )
         }
         val parameters = SlashEditorParameters.clamped(
-            -100.0, 100.0, 100.0, -100.0, 100.0, -100.0, 100.0, 100.0, 100.0, -100.0, 1000, -1, 100.0,
+            -100.0, 100.0, 100.0, -100.0, 100.0, -100.0, 100.0, 100.0, 9, 100.0, 100.0, -100.0, 1000, -1, 100.0,
         )
         assertEquals(-4.0, parameters.originY)
         assertEquals(8.0, parameters.forwardOffset)
         assertEquals(12.0, parameters.length)
         assertEquals(10.0, parameters.arcSpan)
         assertEquals(4.0, parameters.curvature)
+        assertEquals(3, parameters.laneCount)
+        assertEquals(2.0, parameters.laneSpacing)
         assertEquals(0.05, parameters.spacing)
         assertEquals(80, parameters.durationTicks)
         assertEquals(0, parameters.color)

--- a/server-minestom/src/main/kotlin/dev/projects/server/SlashEditor.kt
+++ b/server-minestom/src/main/kotlin/dev/projects/server/SlashEditor.kt
@@ -10,7 +10,7 @@ import net.minestom.server.coordinate.Vec
 import java.nio.file.Files
 import java.nio.file.Path
 
-private const val DRAFT_SCHEMA_VERSION = 1
+private const val DRAFT_SCHEMA_VERSION = 2
 private const val MAX_DRAFTS = 16
 
 /** Fixed-path, deliberately small persistence for the in-game slash authoring tool. */
@@ -48,7 +48,9 @@ class SlashDraftStore(private val file: Path) {
     }
 
     private fun parseParameters(raw: String): SlashEditorParameters? = runCatching {
-        fun number(key: String): Double = Regex("\\\"$key\\\":([^,}]+)").find(raw)!!.groupValues[1].toDouble()
+        fun number(key: String, default: Double? = null): Double =
+            Regex("\\\"$key\\\":([^,}]+)").find(raw)?.groupValues?.get(1)?.toDouble() ?: default
+            ?: error("Missing numeric draft field: $key")
         fun integer(key: String): Int = Regex("\\\"$key\\\":([^,}]+)").find(raw)!!.groupValues[1].toInt()
         SlashEditorParameters.clamped(
             originY = number("originY"),
@@ -59,6 +61,8 @@ class SlashDraftStore(private val file: Path) {
             tilt = number("tilt"),
             yaw = number("yaw"),
             width = number("width"),
+            laneCount = Regex("\\\"laneCount\\\":([^,}]+)").find(raw)?.groupValues?.get(1)?.toInt() ?: 1,
+            laneSpacing = number("laneSpacing", 0.18),
             particleSize = number("particleSize"),
             spacing = number("spacing"),
             durationTicks = integer("durationTicks"),
@@ -82,6 +86,8 @@ class SlashDraftStore(private val file: Path) {
                 append(",\"tilt\":").append(parameters.tilt)
                 append(",\"yaw\":").append(parameters.yaw)
                 append(",\"width\":").append(parameters.width)
+                append(",\"laneCount\":").append(parameters.laneCount)
+                append(",\"laneSpacing\":").append(parameters.laneSpacing)
                 append(",\"particleSize\":").append(parameters.particleSize)
                 append(",\"spacing\":").append(parameters.spacing)
                 append(",\"durationTicks\":").append(parameters.durationTicks)
@@ -105,11 +111,6 @@ class SlashDraftStore(private val file: Path) {
 object SlashEditorPreview {
     fun create(origin: Point, direction: Vec, parameters: SlashEditorParameters): ParticleEffect {
         val radius = (parameters.length * (0.72 + parameters.curvature * 0.07)).coerceIn(0.5, 12.0)
-        val lanes = when {
-            parameters.width < 0.16 -> 1
-            parameters.width < 0.7 -> 2
-            else -> 3
-        }
         val degreeStep = (parameters.spacing * 42.0).coerceIn(2.0, 32.0)
         val arc = ParticleGeometry.drawCleaveArc(
             origin = origin,
@@ -118,14 +119,14 @@ object SlashEditorPreview {
             tiltAngle = parameters.tilt,
             startDegrees = -parameters.arcSpan / 2.0,
             endDegrees = parameters.arcSpan / 2.0,
-            rings = lanes,
+            rings = parameters.laneCount,
             extraYaw = parameters.yaw,
-            ringSpacing = parameters.width.coerceAtLeast(0.04),
+            ringSpacing = parameters.laneSpacing,
             degreesPerTick = parameters.arcSpan / parameters.durationTicks,
             degreeStep = degreeStep,
         ) { _, ring, _ ->
             ParticleStyle(
-                dust(parameters.color, parameters.particleSize.toFloat() * if (ring == 0) 1.0f else 0.72f),
+                dust(parameters.color, parameters.particleSize.toFloat() * (0.75f + parameters.width.toFloat() / 0.28f * 0.25f) * if (ring == 0) 1.0f else 0.72f),
                 count = if (ring == 0) 2 else 1,
             )
         }

--- a/server-minestom/src/main/kotlin/dev/projects/server/SlashEditor.kt
+++ b/server-minestom/src/main/kotlin/dev/projects/server/SlashEditor.kt
@@ -2,6 +2,7 @@ package dev.projects.server
 
 import dev.projects.protocol.SlashEditorParameters
 import dev.projects.server.particle.ParticleEffect
+import dev.projects.server.particle.ParticleBatch
 import dev.projects.server.particle.ParticleGeometry
 import dev.projects.server.particle.ParticleStyle
 import dev.projects.server.particle.dust
@@ -112,24 +113,30 @@ object SlashEditorPreview {
     fun create(origin: Point, direction: Vec, parameters: SlashEditorParameters): ParticleEffect {
         val radius = (parameters.length * (0.72 + parameters.curvature * 0.07)).coerceIn(0.5, 12.0)
         val degreeStep = (parameters.spacing * 42.0).coerceIn(2.0, 32.0)
-        val arc = ParticleGeometry.drawCleaveArc(
-            origin = origin,
-            facing = direction,
-            radius = radius,
-            tiltAngle = parameters.tilt,
-            startDegrees = -parameters.arcSpan / 2.0,
-            endDegrees = parameters.arcSpan / 2.0,
-            rings = parameters.laneCount,
-            extraYaw = parameters.yaw,
-            ringSpacing = parameters.laneSpacing,
-            degreesPerTick = parameters.arcSpan / parameters.durationTicks,
-            degreeStep = degreeStep,
-        ) { _, ring, _ ->
-            ParticleStyle(
-                dust(parameters.color, parameters.particleSize.toFloat() * (0.75f + parameters.width.toFloat() / 0.28f * 0.25f) * if (ring == 0) 1.0f else 0.72f),
-                count = if (ring == 0) 2 else 1,
-            )
+        val laneOffsets = when (parameters.laneCount) {
+            1 -> listOf(0.0)
+            2 -> listOf(-0.5, 0.5)
+            else -> listOf(-1.0, 0.0, 1.0)
         }
-        return arc
+        return ParticleBatch.of(*laneOffsets.map { laneOffset ->
+            ParticleGeometry.drawCleaveArc(
+                origin = origin,
+                facing = direction,
+                radius = radius,
+                tiltAngle = parameters.tilt,
+                startDegrees = -parameters.arcSpan / 2.0,
+                endDegrees = parameters.arcSpan / 2.0,
+                rings = 1,
+                extraYaw = parameters.yaw,
+                degreesPerTick = parameters.arcSpan / parameters.durationTicks,
+                degreeStep = degreeStep,
+                lateralOffset = laneOffset * parameters.laneSpacing,
+            ) { _, _, _ ->
+                ParticleStyle(
+                    dust(parameters.color, parameters.particleSize.toFloat() * (0.75f + parameters.width.toFloat() / 0.28f * 0.25f)),
+                    count = 2,
+                )
+            }
+        }.toTypedArray())
     }
 }

--- a/server-minestom/src/main/kotlin/dev/projects/server/particle/ParticleGeometry.kt
+++ b/server-minestom/src/main/kotlin/dev/projects/server/particle/ParticleGeometry.kt
@@ -22,6 +22,7 @@ object ParticleGeometry {
         ringSpacing: Double = 0.22,
         degreesPerTick: Double = 45.0,
         degreeStep: Double = 8.0,
+        lateralOffset: Double = 0.0,
         sample: (position: Point, ringIndex: Int, angleProgress: Double) -> ParticleStyle =
             { _, ring, progress -> ParticleStyle(if (ring == 0) dust(0xffdd33, 0.45f) else dust(0xff5522, 0.3f + progress.toFloat() * 0.15f)) },
     ): ParticleEffect {
@@ -38,6 +39,7 @@ object ParticleGeometry {
             ringSpacing = ringSpacing,
             degreesPerTick = degreesPerTick,
             degreeStep = degreeStep,
+            lateralOffset = lateralOffset,
             sample = sample,
         )
     }
@@ -89,6 +91,7 @@ object ParticleGeometry {
         ringSpacing: Double = 0.22,
         degreesPerTick: Double = 45.0,
         degreeStep: Double = 8.0,
+        lateralOffset: Double = 0.0,
         sample: (position: Point, ringIndex: Int, angleProgress: Double) -> ParticleStyle =
             { _, ring, progress -> ParticleStyle(if (ring == 0) dust(0xffdd33, 0.45f) else dust(0xff5522, 0.3f + progress.toFloat() * 0.15f)) },
     ): ParticleEffect {
@@ -116,7 +119,11 @@ object ParticleGeometry {
                         if (progress > progressEnd || progress < startProgress) continue
                         val angle = Math.toRadians(startDegrees + span * progress)
                         val radial = right.mul(cos(angle) * ringRadius).add(up.mul(sin(angle) * ringRadius))
-                        val point = origin.add(radial.x(), radial.y(), radial.z())
+                        val point = origin.add(
+                            radial.x() + right.x() * lateralOffset,
+                            radial.y() + right.y() * lateralOffset,
+                            radial.z() + right.z() * lateralOffset,
+                        )
                         emitStyle(point, sample(point, ring, progress), step + ring * (steps + 1), sink)
                     }
                 }

--- a/server-minestom/src/test/kotlin/dev/projects/server/SlashEditorTest.kt
+++ b/server-minestom/src/test/kotlin/dev/projects/server/SlashEditorTest.kt
@@ -26,6 +26,17 @@ class SlashEditorTest {
     }
 
     @Test
+    fun `legacy drafts load with safe lane defaults`() {
+        val file = Files.createTempFile("slash-editor-legacy", ".json")
+        Files.writeString(file, """
+            {"schemaVersion":1,"drafts":[{"name":"legacy","parameters":{"originY":1.2,"forwardOffset":1.7,"length":5.0,"arcSpan":160.0,"curvature":0.35,"tilt":12.0,"yaw":0.0,"width":0.8,"particleSize":0.28,"spacing":0.18,"durationTicks":8,"color":1190875,"targetDistance":5.0}}]}
+        """.trimIndent())
+        val loaded = SlashDraftStore(file).load("legacy")
+        assertEquals(1, loaded?.laneCount)
+        assertEquals(0.18, loaded?.laneSpacing)
+    }
+
+    @Test
     fun `draft store enforces the maximum number of drafts`() {
         val file = Files.createTempFile("slash-editor-test", ".json")
         val store = SlashDraftStore(file)
@@ -51,5 +62,16 @@ class SlashEditorTest {
             }
         }.toSet()
         assertEquals(setOf(color), dustColors)
+    }
+
+    @Test
+    fun `lane count is independent from thickness`() {
+        val oneLane = SlashEditorPreview.create(Pos.ZERO, Vec(0.0, 0.0, 1.0), SlashEditorParameters(laneCount = 1, width = 1.5))
+        val threeLanes = SlashEditorPreview.create(Pos.ZERO, Vec(0.0, 0.0, 1.0), SlashEditorParameters(laneCount = 3, laneSpacing = 0.5, width = 0.05))
+        val oneSink = RecordingParticleSink()
+        val threeSink = RecordingParticleSink()
+        oneLane.emit(0, oneSink)
+        threeLanes.emit(0, threeSink)
+        assertTrue(threeSink.spawns.size > oneSink.spawns.size)
     }
 }

--- a/server-minestom/src/test/kotlin/dev/projects/server/SlashEditorTest.kt
+++ b/server-minestom/src/test/kotlin/dev/projects/server/SlashEditorTest.kt
@@ -9,6 +9,7 @@ import java.nio.file.Files
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
 import kotlin.test.assertTrue
 
 class SlashEditorTest {
@@ -65,13 +66,22 @@ class SlashEditorTest {
     }
 
     @Test
-    fun `lane count is independent from thickness`() {
-        val oneLane = SlashEditorPreview.create(Pos.ZERO, Vec(0.0, 0.0, 1.0), SlashEditorParameters(laneCount = 1, width = 1.5))
-        val threeLanes = SlashEditorPreview.create(Pos.ZERO, Vec(0.0, 0.0, 1.0), SlashEditorParameters(laneCount = 3, laneSpacing = 0.5, width = 0.05))
-        val oneSink = RecordingParticleSink()
-        val threeSink = RecordingParticleSink()
-        oneLane.emit(0, oneSink)
-        threeLanes.emit(0, threeSink)
-        assertTrue(threeSink.spawns.size > oneSink.spawns.size)
+    fun `lane count creates distinct trajectories and spacing separates them`() {
+        fun positions(spacing: Double): List<Double> {
+            val effect = SlashEditorPreview.create(
+                Pos.ZERO,
+                Vec(0.0, 0.0, 1.0),
+                SlashEditorParameters(laneCount = 3, laneSpacing = spacing, arcSpan = 10.0, durationTicks = 1),
+            )
+            val sink = RecordingParticleSink()
+            effect.emit(0, sink)
+            return sink.spawns.map { it.position.x() }
+        }
+
+        val narrow = positions(0.1)
+        val wide = positions(0.5)
+        assertTrue(narrow.toSet().size >= 3)
+        assertTrue(wide.max() - wide.min() > narrow.max() - narrow.min())
+        assertNotEquals(narrow, wide)
     }
 }


### PR DESCRIPTION
Closes #84

## Summary
- Separate slash thickness from lane count and lane spacing
- Add laneCount/laneSpacing to Protocol v9 and draft persistence
- Keep old drafts compatible with safe defaults
- Render 1/2/3 lanes as explicit independent slash trajectories
- Preserve editor controls and 640x360 usability

## Verification
- Sol Review PASS
- User Manual Smoke PASS
- client/protocol/server tests PASS
- slash lane trajectory regression test PASS
- `git diff --check` PASS