### PR TITLE
VFX Editor Skill3 binding and choreography

### DIFF
--- a/client-fabric/src/main/kotlin/dev/projects/client/SlashEditorScreen.kt
+++ b/client-fabric/src/main/kotlin/dev/projects/client/SlashEditorScreen.kt
@@ -2,6 +2,7 @@ package dev.projects.client
 
 import dev.projects.protocol.SlashEditorParameters
 import dev.projects.protocol.VfxSlashDraftLoadRequest
+import dev.projects.protocol.VfxSlashApplySkill3
 import dev.projects.protocol.VfxSlashPreviewCancel
 import dev.projects.protocol.VfxSlashPreviewRequest
 import dev.projects.protocol.VfxSlashSaveRequest
@@ -96,6 +97,8 @@ class SlashEditorScreen(
             .bounds(panelX + 160, controlsY, 112, 20).build())
         detailsButton = addRenderableWidget(Button.builder(Component.literal(detailsLabel())) { showDetails = !showDetails; rebuildWidgets() }
             .bounds(panelX + 8, controlsY - 25, 120, 20).build())
+        addRenderableWidget(Button.builder(Component.literal("Skill3へ適用")) { applySkill3() }
+            .bounds(panelX + 132, controlsY - 25, 140, 20).build())
 
         val draftY = height - 43
         draftName = addRenderableWidget(EditBox(font, panelX + 136, draftY, 108, 18, Component.literal("Draft名")))
@@ -203,6 +206,13 @@ class SlashEditorScreen(
 
     private fun replay() { parseParameters()?.let { parameters = it; sendPreview() } }
     private fun sendPreview() { sendMessage(VfxSlashPreviewRequest(++requestId, parameters)) }
+
+    private fun applySkill3() {
+        parseParameters()?.let {
+            parameters = it
+            sendMessage(VfxSlashApplySkill3(it))
+        }
+    }
 
     private fun reset() {
         parameters = SlashEditorParameters()

--- a/protocol/src/main/kotlin/dev/projects/protocol/Protocol.kt
+++ b/protocol/src/main/kotlin/dev/projects/protocol/Protocol.kt
@@ -12,7 +12,7 @@ import kotlin.math.sqrt
 const val PROJECTS_CHANNEL = "projects:protocol"
 
 object ProtocolVersion {
-    const val CURRENT = 9
+    const val CURRENT = 10
 
     fun requireCompatible(version: Int) {
         if (version != CURRENT) {
@@ -314,6 +314,8 @@ data class VfxSlashPreviewRequest(
     val parameters: SlashEditorParameters,
 ) : ProtocolMessage
 
+data class VfxSlashApplySkill3(val parameters: SlashEditorParameters) : ProtocolMessage
+
 object VfxSlashPreviewCancel : ProtocolMessage
 
 data class VfxSlashSaveRequest(
@@ -380,6 +382,7 @@ object ProtocolCodec {
     private const val VFX_SLASH_DRAFT = 26
     private const val VFX_EDITOR_NOTICE = 27
     private const val VFX_SLASH_PREVIEW_CANCEL = 28
+    private const val VFX_SLASH_APPLY_SKILL3 = 29
 
     fun encode(message: ProtocolMessage): ByteArray {
         val output = ByteArrayOutputStream()
@@ -471,6 +474,10 @@ object ProtocolCodec {
                 is VfxSlashPreviewRequest -> {
                     data.writeByte(VFX_SLASH_PREVIEW_REQUEST)
                     data.writeLong(message.requestId)
+                    writeSlashParameters(data, message.parameters)
+                }
+                is VfxSlashApplySkill3 -> {
+                    data.writeByte(VFX_SLASH_APPLY_SKILL3)
                     writeSlashParameters(data, message.parameters)
                 }
                 VfxSlashPreviewCancel -> data.writeByte(VFX_SLASH_PREVIEW_CANCEL)
@@ -580,6 +587,7 @@ object ProtocolCodec {
             GROUND_TELEGRAPH_REMOVE -> GroundTelegraphRemove(input.readLong())
             VFX_EDITOR_OPEN -> VfxEditorOpen(readSlashParameters(input))
             VFX_SLASH_PREVIEW_REQUEST -> VfxSlashPreviewRequest(input.readLong(), readSlashParameters(input))
+            VFX_SLASH_APPLY_SKILL3 -> VfxSlashApplySkill3(readSlashParameters(input))
             VFX_SLASH_PREVIEW_CANCEL -> VfxSlashPreviewCancel
             VFX_SLASH_SAVE_REQUEST -> VfxSlashSaveRequest(readString(input), readSlashParameters(input))
             VFX_SLASH_DRAFT_LIST -> {

--- a/protocol/src/test/kotlin/dev/projects/protocol/ProtocolCodecTest.kt
+++ b/protocol/src/test/kotlin/dev/projects/protocol/ProtocolCodecTest.kt
@@ -229,6 +229,7 @@ class ProtocolCodecTest {
         listOf<ProtocolMessage>(
             VfxEditorOpen(parameters),
             VfxSlashPreviewRequest(42L, parameters),
+            VfxSlashApplySkill3(parameters),
             VfxSlashPreviewCancel,
             VfxSlashSaveRequest("blue slash", parameters),
             VfxSlashDraftList(listOf("blue slash")),

--- a/server-minestom/src/main/kotlin/dev/projects/server/ProjectSServer.kt
+++ b/server-minestom/src/main/kotlin/dev/projects/server/ProjectSServer.kt
@@ -25,6 +25,7 @@ import dev.projects.protocol.VfxSlashDraftLoadRequest
 import dev.projects.protocol.VfxSlashPreviewRequest
 import dev.projects.protocol.VfxSlashPreviewCancel
 import dev.projects.protocol.VfxSlashSaveRequest
+import dev.projects.protocol.VfxSlashApplySkill3
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.bossbar.BossBar
 import net.minestom.server.Auth
@@ -136,6 +137,7 @@ fun main() {
     val bossGroundTelegraphIds = mutableSetOf<Long>()
     val bossRiftTelegraphIds = mutableMapOf<Long, Long>()
     val slashDraftStore = SlashDraftStore(Path.of("config", "projects", "vfx-editor", "slash-drafts.json"))
+    val skill3SlashBindingStore = Skill3SlashBindingStore(Path.of("config", "projects", "vfx-editor", "twin-blades-skill3-slash.json"))
     val slashPreviewHandles = mutableMapOf<UUID, ParticleEffectHandle>()
 
     fun sendSlashDraftList(player: net.minestom.server.entity.Player) {
@@ -153,12 +155,7 @@ fun main() {
     fun previewSlash(player: net.minestom.server.entity.Player, parameters: SlashEditorParameters) {
         particleAnimations.cancel(slashPreviewHandles.remove(player.uuid))
         val direction = player.position.direction()
-        val forward = FixedAttackTester.normalizeHorizontal(direction)
-        val origin = player.position.add(
-            forward.x() * parameters.forwardOffset,
-            parameters.originY,
-            forward.z() * parameters.forwardOffset,
-        )
+        val origin = slashOrigin(player.position, direction, parameters)
         val sink = particleManager.sink(
             ParticleViewer(player.position, player),
             PlayerParticleSink(player),
@@ -896,6 +893,7 @@ fun main() {
                             target,
                             requireNotNull(skill3Tick.dashDirection),
                             pulseIndex,
+                            skill3SlashBindingStore,
                             particleAnimations,
                             particleManager,
                         )
@@ -1061,6 +1059,16 @@ fun main() {
                 }
                 is VfxSlashPreviewRequest -> previewSlash(event.player, message.parameters)
                 VfxSlashPreviewCancel -> particleAnimations.cancel(slashPreviewHandles.remove(event.player.uuid))
+                is VfxSlashApplySkill3 -> {
+                    val saved = skill3SlashBindingStore.save(message.parameters)
+                    event.player.sendPluginMessage(
+                        PROJECTS_CHANNEL,
+                        ProtocolCodec.encode(
+                            if (saved) VfxEditorNotice("Skill3へ適用しました")
+                            else VfxEditorNotice("Skill3への適用に失敗しました"),
+                        ),
+                    )
+                }
                 is VfxSlashSaveRequest -> {
                     val saved = slashDraftStore.save(message.name, message.parameters)
                     event.player.sendPluginMessage(
@@ -1752,23 +1760,26 @@ private fun showSkill3PulseVfx(
     target: CombatTarget,
     direction: Vec,
     pulseIndex: Int,
+    bindingStore: Skill3SlashBindingStore,
     scheduler: ParticleAnimationScheduler,
     manager: ParticleManager,
 ) {
-    val started = startParticlePreset(
-        player = player,
-        id = "projects:class/twin_blades/skill3_pulse",
-        scheduler = scheduler,
-        origin = target.position,
-        direction = direction,
-        manager = manager,
-        values = mapOf(
-            "pulse" to pulseIndex.toDouble(),
-            "duration" to 2.0,
-        ),
-    )
-    if (!started) {
-        System.err.println("Skill3 VFX preset failed to start: projects:class/twin_blades/skill3_pulse")
+    val authored = bindingStore.load()
+    if (authored == null) {
+        val started = startParticlePreset(
+            player = player,
+            id = "projects:class/twin_blades/skill3_pulse",
+            scheduler = scheduler,
+            origin = target.position,
+            direction = direction,
+            manager = manager,
+            values = mapOf("pulse" to pulseIndex.toDouble(), "duration" to 2.0),
+        )
+        if (!started) System.err.println("Skill3 VFX preset failed to start: projects:class/twin_blades/skill3_pulse")
+    } else {
+        val origin = slashOrigin(player.position, direction, authored)
+        val sink = manager.sink(ParticleViewer(player.position, player), PlayerParticleSink(player), "skill3:slash")
+        scheduler.start(SlashEditorPreview.create(origin, direction, authored), sink, id = "skill3:slash:${player.uuid}:$pulseIndex")
     }
     playTwinBladesSounds(player, target.position, twinBladesSkill3PulseSoundPlan(pulseIndex))
 }

--- a/server-minestom/src/main/kotlin/dev/projects/server/ProjectSServer.kt
+++ b/server-minestom/src/main/kotlin/dev/projects/server/ProjectSServer.kt
@@ -1777,9 +1777,14 @@ private fun showSkill3PulseVfx(
         )
         if (!started) System.err.println("Skill3 VFX preset failed to start: projects:class/twin_blades/skill3_pulse")
     } else {
-        val origin = slashOrigin(player.position, direction, authored)
+        val choreography = skill3SlashPulseSpec(authored, pulseIndex)
+        val origin = slashOrigin(player.position, direction, choreography.parameters)
         val sink = manager.sink(ParticleViewer(player.position, player), PlayerParticleSink(player), "skill3:slash")
-        scheduler.start(SlashEditorPreview.create(origin, direction, authored), sink, id = "skill3:slash:${player.uuid}:$pulseIndex")
+        scheduler.start(
+            SlashEditorPreview.create(origin, direction, choreography.parameters, choreography.reverseDraw),
+            sink,
+            id = "skill3:slash:${player.uuid}:$pulseIndex",
+        )
     }
     playTwinBladesSounds(player, target.position, twinBladesSkill3PulseSoundPlan(pulseIndex))
 }

--- a/server-minestom/src/main/kotlin/dev/projects/server/SlashEditor.kt
+++ b/server-minestom/src/main/kotlin/dev/projects/server/SlashEditor.kt
@@ -128,7 +128,7 @@ class Skill3SlashBindingStore(private val file: Path) {
 }
 
 object SlashEditorPreview {
-    fun create(origin: Point, direction: Vec, parameters: SlashEditorParameters): ParticleEffect {
+    fun create(origin: Point, direction: Vec, parameters: SlashEditorParameters, reverseDraw: Boolean = false): ParticleEffect {
         val radius = (parameters.length * (0.72 + parameters.curvature * 0.07)).coerceIn(0.5, 12.0)
         val degreeStep = (parameters.spacing * 42.0).coerceIn(2.0, 32.0)
         val laneOffsets = when (parameters.laneCount) {
@@ -142,8 +142,8 @@ object SlashEditorPreview {
                 facing = direction,
                 radius = radius,
                 tiltAngle = parameters.tilt,
-                startDegrees = -parameters.arcSpan / 2.0,
-                endDegrees = parameters.arcSpan / 2.0,
+                startDegrees = if (reverseDraw) parameters.arcSpan / 2.0 else -parameters.arcSpan / 2.0,
+                endDegrees = if (reverseDraw) -parameters.arcSpan / 2.0 else parameters.arcSpan / 2.0,
                 rings = 1,
                 extraYaw = parameters.yaw,
                 degreesPerTick = parameters.arcSpan / parameters.durationTicks,
@@ -158,6 +158,36 @@ object SlashEditorPreview {
         }.toTypedArray())
     }
 }
+
+data class Skill3SlashPulseSpec(
+    val parameters: SlashEditorParameters,
+    val reverseDraw: Boolean,
+)
+
+internal fun skill3SlashPulseSpec(authored: SlashEditorParameters, pulseIndex: Int): Skill3SlashPulseSpec {
+    val (yawOffset, tiltOffset, originYOffset, reverseDraw) = when (pulseIndex) {
+        1 -> PulseChoreography(-28.0, 28.0, -0.10, false)
+        2 -> PulseChoreography(30.0, -26.0, 0.15, true)
+        3 -> PulseChoreography(-42.0, 5.0, 0.30, false)
+        4 -> PulseChoreography(45.0, 32.0, 0.0, true)
+        else -> PulseChoreography(0.0, 0.0, 0.0, false)
+    }
+    return Skill3SlashPulseSpec(
+        parameters = authored.copy(
+            yaw = authored.yaw + yawOffset,
+            tilt = authored.tilt + tiltOffset,
+            originY = authored.originY + originYOffset,
+        ),
+        reverseDraw = reverseDraw,
+    )
+}
+
+private data class PulseChoreography(
+    val yawOffset: Double,
+    val tiltOffset: Double,
+    val originYOffset: Double,
+    val reverseDraw: Boolean,
+)
 
 internal fun slashOrigin(position: Point, direction: Vec, parameters: SlashEditorParameters): Point {
     val forward = FixedAttackTester.normalizeHorizontal(direction)

--- a/server-minestom/src/main/kotlin/dev/projects/server/SlashEditor.kt
+++ b/server-minestom/src/main/kotlin/dev/projects/server/SlashEditor.kt
@@ -177,6 +177,7 @@ internal fun skill3SlashPulseSpec(authored: SlashEditorParameters, pulseIndex: I
             yaw = authored.yaw + yawOffset,
             tilt = authored.tilt + tiltOffset,
             originY = authored.originY + originYOffset,
+            durationTicks = Skill3State.PULSE_INTERVAL_TICKS,
         ),
         reverseDraw = reverseDraw,
     )

--- a/server-minestom/src/main/kotlin/dev/projects/server/SlashEditor.kt
+++ b/server-minestom/src/main/kotlin/dev/projects/server/SlashEditor.kt
@@ -14,6 +14,39 @@ import java.nio.file.Path
 private const val DRAFT_SCHEMA_VERSION = 2
 private const val MAX_DRAFTS = 16
 
+private fun parseSlashParameters(raw: String): SlashEditorParameters? = runCatching {
+    fun number(key: String, default: Double? = null): Double =
+        Regex("\\\"$key\\\":([^,}]+)").find(raw)?.groupValues?.get(1)?.toDouble() ?: default
+        ?: error("Missing numeric slash field: $key")
+    fun integer(key: String): Int = Regex("\\\"$key\\\":([^,}]+)").find(raw)!!.groupValues[1].toInt()
+    SlashEditorParameters.clamped(
+        originY = number("originY"), forwardOffset = number("forwardOffset"), length = number("length"),
+        arcSpan = number("arcSpan"), curvature = number("curvature"), tilt = number("tilt"), yaw = number("yaw"),
+        width = number("width"), laneCount = Regex("\\\"laneCount\\\":([^,}]+)").find(raw)?.groupValues?.get(1)?.toInt() ?: 1,
+        laneSpacing = number("laneSpacing", 0.18),
+        particleSize = number("particleSize"), spacing = number("spacing"), durationTicks = integer("durationTicks"),
+        color = integer("color"), targetDistance = number("targetDistance"),
+    )
+}.getOrNull()
+
+private fun appendSlashParameters(json: StringBuilder, parameters: SlashEditorParameters) {
+    json.append("\"originY\":").append(parameters.originY)
+        .append(",\"forwardOffset\":").append(parameters.forwardOffset)
+        .append(",\"length\":").append(parameters.length)
+        .append(",\"arcSpan\":").append(parameters.arcSpan)
+        .append(",\"curvature\":").append(parameters.curvature)
+        .append(",\"tilt\":").append(parameters.tilt)
+        .append(",\"yaw\":").append(parameters.yaw)
+        .append(",\"width\":").append(parameters.width)
+        .append(",\"laneCount\":").append(parameters.laneCount)
+        .append(",\"laneSpacing\":").append(parameters.laneSpacing)
+        .append(",\"particleSize\":").append(parameters.particleSize)
+        .append(",\"spacing\":").append(parameters.spacing)
+        .append(",\"durationTicks\":").append(parameters.durationTicks)
+        .append(",\"color\":").append(parameters.color)
+        .append(",\"targetDistance\":").append(parameters.targetDistance)
+}
+
 /** Fixed-path, deliberately small persistence for the in-game slash authoring tool. */
 class SlashDraftStore(private val file: Path) {
     private val drafts = linkedMapOf<String, SlashEditorParameters>()
@@ -48,29 +81,7 @@ class SlashDraftStore(private val file: Path) {
         }
     }
 
-    private fun parseParameters(raw: String): SlashEditorParameters? = runCatching {
-        fun number(key: String, default: Double? = null): Double =
-            Regex("\\\"$key\\\":([^,}]+)").find(raw)?.groupValues?.get(1)?.toDouble() ?: default
-            ?: error("Missing numeric draft field: $key")
-        fun integer(key: String): Int = Regex("\\\"$key\\\":([^,}]+)").find(raw)!!.groupValues[1].toInt()
-        SlashEditorParameters.clamped(
-            originY = number("originY"),
-            forwardOffset = number("forwardOffset"),
-            length = number("length"),
-            arcSpan = number("arcSpan"),
-            curvature = number("curvature"),
-            tilt = number("tilt"),
-            yaw = number("yaw"),
-            width = number("width"),
-            laneCount = Regex("\\\"laneCount\\\":([^,}]+)").find(raw)?.groupValues?.get(1)?.toInt() ?: 1,
-            laneSpacing = number("laneSpacing", 0.18),
-            particleSize = number("particleSize"),
-            spacing = number("spacing"),
-            durationTicks = integer("durationTicks"),
-            color = integer("color"),
-            targetDistance = number("targetDistance"),
-        )
-    }.getOrNull()
+    private fun parseParameters(raw: String): SlashEditorParameters? = parseSlashParameters(raw)
 
     private fun writeToDisk(): Boolean = runCatching {
         file.parent?.let(Files::createDirectories)
@@ -79,21 +90,7 @@ class SlashDraftStore(private val file: Path) {
             drafts.entries.sortedBy { it.key }.forEachIndexed { index, (name, parameters) ->
                 if (index > 0) append(',')
                 append("{\"name\":\"").append(name).append("\",\"parameters\":{")
-                append("\"originY\":").append(parameters.originY)
-                append(",\"forwardOffset\":").append(parameters.forwardOffset)
-                append(",\"length\":").append(parameters.length)
-                append(",\"arcSpan\":").append(parameters.arcSpan)
-                append(",\"curvature\":").append(parameters.curvature)
-                append(",\"tilt\":").append(parameters.tilt)
-                append(",\"yaw\":").append(parameters.yaw)
-                append(",\"width\":").append(parameters.width)
-                append(",\"laneCount\":").append(parameters.laneCount)
-                append(",\"laneSpacing\":").append(parameters.laneSpacing)
-                append(",\"particleSize\":").append(parameters.particleSize)
-                append(",\"spacing\":").append(parameters.spacing)
-                append(",\"durationTicks\":").append(parameters.durationTicks)
-                append(",\"color\":").append(parameters.color)
-                append(",\"targetDistance\":").append(parameters.targetDistance)
+                appendSlashParameters(this, parameters)
                 append("}}")
             }
             append("]}")
@@ -107,6 +104,27 @@ class SlashDraftStore(private val file: Path) {
 
         fun isSafeName(name: String): Boolean = SAFE_NAME.matches(name)
     }
+}
+
+class Skill3SlashBindingStore(private val file: Path) {
+    private var binding: SlashEditorParameters? = readFromDisk()
+
+    fun load(): SlashEditorParameters? = binding
+
+    fun save(parameters: SlashEditorParameters): Boolean = runCatching {
+        file.parent?.let(Files::createDirectories)
+        val json = StringBuilder("{\"schemaVersion\":1,\"parameters\":{")
+        appendSlashParameters(json, parameters)
+        json.append("}}")
+        Files.writeString(file, json)
+        binding = parameters
+        true
+    }.getOrDefault(false)
+
+    private fun readFromDisk(): SlashEditorParameters? = runCatching {
+        if (!Files.isRegularFile(file)) return null
+        parseSlashParameters(Files.readString(file))
+    }.getOrNull()
 }
 
 object SlashEditorPreview {
@@ -139,4 +157,13 @@ object SlashEditorPreview {
             }
         }.toTypedArray())
     }
+}
+
+internal fun slashOrigin(position: Point, direction: Vec, parameters: SlashEditorParameters): Point {
+    val forward = FixedAttackTester.normalizeHorizontal(direction)
+    return position.add(
+        forward.x() * parameters.forwardOffset,
+        parameters.originY,
+        forward.z() * parameters.forwardOffset,
+    )
 }

--- a/server-minestom/src/test/kotlin/dev/projects/server/SlashEditorTest.kt
+++ b/server-minestom/src/test/kotlin/dev/projects/server/SlashEditorTest.kt
@@ -107,4 +107,33 @@ class SlashEditorTest {
         assertEquals(22.4, origin.y())
         assertEquals(33.6, origin.z())
     }
+
+    @Test
+    fun `skill3 pulse choreography varies orientation without changing authored parameters`() {
+        val authored = SlashEditorParameters(laneCount = 3, laneSpacing = 0.9, yaw = 7.0, tilt = 4.0, originY = 1.5)
+        val authoredBefore = authored
+        val specs = (1..4).map { skill3SlashPulseSpec(authored, it) }
+
+        assertEquals(authoredBefore, authored)
+        assertEquals(listOf(false, true, false, true), specs.map { it.reverseDraw })
+        assertEquals(4, specs.map { Triple(it.parameters.yaw, it.parameters.tilt, it.parameters.originY) }.toSet().size)
+        assertTrue(specs.all { it.parameters.laneCount == authored.laneCount && it.parameters.laneSpacing == authored.laneSpacing })
+        assertTrue(specs.all { it.parameters.length == authored.length && it.parameters.arcSpan == authored.arcSpan })
+        assertTrue(specs.all { it.parameters.width == authored.width && it.parameters.particleSize == authored.particleSize })
+        assertTrue(specs.all { it.parameters.spacing == authored.spacing && it.parameters.color == authored.color })
+    }
+
+    @Test
+    fun `reverse choreography swaps slash traversal direction`() {
+        val authored = SlashEditorParameters(arcSpan = 80.0, durationTicks = 4)
+        val forward = SlashEditorPreview.create(Pos.ZERO, Vec(0.0, 0.0, 1.0), authored)
+        val reverse = SlashEditorPreview.create(Pos.ZERO, Vec(0.0, 0.0, 1.0), authored, reverseDraw = true)
+        val forwardSink = RecordingParticleSink()
+        val reverseSink = RecordingParticleSink()
+
+        forward.emit(0, forwardSink)
+        reverse.emit(0, reverseSink)
+
+        assertNotEquals(forwardSink.spawns.map { it.position }, reverseSink.spawns.map { it.position })
+    }
 }

--- a/server-minestom/src/test/kotlin/dev/projects/server/SlashEditorTest.kt
+++ b/server-minestom/src/test/kotlin/dev/projects/server/SlashEditorTest.kt
@@ -47,6 +47,19 @@ class SlashEditorTest {
     }
 
     @Test
+    fun `skill3 binding survives reload and malformed binding falls back`() {
+        val directory = Files.createTempDirectory("skill3-binding-test")
+        val file = directory.resolve("binding.json")
+        val parameters = SlashEditorParameters(laneCount = 3, laneSpacing = 0.9, yaw = 42.0, forwardOffset = 3.2)
+
+        assertTrue(Skill3SlashBindingStore(file).save(parameters))
+        assertEquals(parameters, Skill3SlashBindingStore(file).load())
+
+        Files.writeString(file, "not-json")
+        assertEquals(null, Skill3SlashBindingStore(file).load())
+    }
+
+    @Test
     fun `preview emits finite positions with the requested color`() {
         val color = 0x123456
         val effect = SlashEditorPreview.create(Pos.ZERO, Vec(0.0, 0.0, 1.0), SlashEditorParameters(color = color))
@@ -83,5 +96,15 @@ class SlashEditorTest {
         assertTrue(narrow.toSet().size >= 3)
         assertTrue(wide.max() - wide.min() > narrow.max() - narrow.min())
         assertNotEquals(narrow, wide)
+    }
+
+    @Test
+    fun `runtime slash origin preserves authored anchor values`() {
+        val parameters = SlashEditorParameters(originY = 2.4, forwardOffset = 3.6, yaw = 27.0)
+        val origin = slashOrigin(Pos(10.0, 20.0, 30.0), Vec(0.0, 0.0, 1.0), parameters)
+
+        assertEquals(10.0, origin.x())
+        assertEquals(22.4, origin.y())
+        assertEquals(33.6, origin.z())
     }
 }

--- a/server-minestom/src/test/kotlin/dev/projects/server/SlashEditorTest.kt
+++ b/server-minestom/src/test/kotlin/dev/projects/server/SlashEditorTest.kt
@@ -110,11 +110,12 @@ class SlashEditorTest {
 
     @Test
     fun `skill3 pulse choreography varies orientation without changing authored parameters`() {
-        val authored = SlashEditorParameters(laneCount = 3, laneSpacing = 0.9, yaw = 7.0, tilt = 4.0, originY = 1.5)
+        val authored = SlashEditorParameters(laneCount = 3, laneSpacing = 0.9, yaw = 7.0, tilt = 4.0, originY = 1.5, durationTicks = 8)
         val authoredBefore = authored
         val specs = (1..4).map { skill3SlashPulseSpec(authored, it) }
 
         assertEquals(authoredBefore, authored)
+        assertTrue(specs.all { it.parameters.durationTicks == Skill3State.PULSE_INTERVAL_TICKS })
         assertEquals(listOf(false, true, false, true), specs.map { it.reverseDraw })
         assertEquals(4, specs.map { Triple(it.parameters.yaw, it.parameters.tilt, it.parameters.originY) }.toSet().size)
         assertTrue(specs.all { it.parameters.laneCount == authored.laneCount && it.parameters.laneSpacing == authored.laneSpacing })


### PR DESCRIPTION
Closes #87

## Summary
- Add `Skill3へ適用` from Slash Editor
- Persist authored Skill3 slash binding on the server
- Replace only Skill3 pulse VFX when a binding exists, with safe fallback to the legacy preset
- Keep hit / finisher / recoil / sound / gameplay unchanged
- Add four-pulse choreography with per-pulse yaw / tilt / height offsets and reverse traversal
- Match authored Skill3 slash runtime duration to the 2-tick pulse cadence while preserving Editor-authored duration

## Verification
- Sol Review PASS
- User Manual Smoke PASS
- protocol/server/client targeted tests and builds PASS across implementation steps
- binding persistence/fallback tests PASS
- choreography/reverse traversal tests PASS
- `git diff --check` PASS

Local `config/` contains the creator's smoke binding only and is intentionally not committed.