### PR TITLE
VFX Editor: Skill3 Finisher binding and 3D slash alignment

### DIFF
--- a/client-fabric/src/main/kotlin/dev/projects/client/SlashEditorScreen.kt
+++ b/client-fabric/src/main/kotlin/dev/projects/client/SlashEditorScreen.kt
@@ -1,6 +1,7 @@
 package dev.projects.client
 
 import dev.projects.protocol.SlashEditorParameters
+import dev.projects.protocol.Skill3VfxTarget
 import dev.projects.protocol.VfxSlashDraftLoadRequest
 import dev.projects.protocol.VfxSlashApplySkill3
 import dev.projects.protocol.VfxSlashPreviewCancel
@@ -40,6 +41,8 @@ class SlashEditorScreen(
     private lateinit var draftName: EditBox
     private lateinit var autoButton: Button
     private lateinit var detailsButton: Button
+    private lateinit var applyTargetButton: Button
+    private var applyTarget = Skill3VfxTarget.PULSE
 
     private data class BasicControl(
         val key: String,
@@ -97,8 +100,10 @@ class SlashEditorScreen(
             .bounds(panelX + 160, controlsY, 112, 20).build())
         detailsButton = addRenderableWidget(Button.builder(Component.literal(detailsLabel())) { showDetails = !showDetails; rebuildWidgets() }
             .bounds(panelX + 8, controlsY - 25, 120, 20).build())
-        addRenderableWidget(Button.builder(Component.literal("Skill3へ適用")) { applySkill3() }
-            .bounds(panelX + 132, controlsY - 25, 140, 20).build())
+        applyTargetButton = addRenderableWidget(Button.builder(Component.literal(applyTargetLabel())) { cycleApplyTarget() }
+            .bounds(panelX + 132, controlsY - 25, 92, 20).build())
+        addRenderableWidget(Button.builder(Component.literal("適用")) { applySkill3() }
+            .bounds(panelX + 228, controlsY - 25, 44, 20).build())
 
         val draftY = height - 43
         draftName = addRenderableWidget(EditBox(font, panelX + 136, draftY, 108, 18, Component.literal("Draft名")))
@@ -210,8 +215,18 @@ class SlashEditorScreen(
     private fun applySkill3() {
         parseParameters()?.let {
             parameters = it
-            sendMessage(VfxSlashApplySkill3(it))
+            sendMessage(VfxSlashApplySkill3(applyTarget, it))
         }
+    }
+
+    private fun cycleApplyTarget() {
+        applyTarget = if (applyTarget == Skill3VfxTarget.PULSE) Skill3VfxTarget.FINISHER else Skill3VfxTarget.PULSE
+        applyTargetButton.message = Component.literal(applyTargetLabel())
+    }
+
+    private fun applyTargetLabel() = when (applyTarget) {
+        Skill3VfxTarget.PULSE -> "適用先: Skill3連撃"
+        Skill3VfxTarget.FINISHER -> "適用先: Finisher"
     }
 
     private fun reset() {

--- a/protocol/src/main/kotlin/dev/projects/protocol/Protocol.kt
+++ b/protocol/src/main/kotlin/dev/projects/protocol/Protocol.kt
@@ -12,7 +12,7 @@ import kotlin.math.sqrt
 const val PROJECTS_CHANNEL = "projects:protocol"
 
 object ProtocolVersion {
-    const val CURRENT = 10
+    const val CURRENT = 11
 
     fun requireCompatible(version: Int) {
         if (version != CURRENT) {
@@ -314,7 +314,15 @@ data class VfxSlashPreviewRequest(
     val parameters: SlashEditorParameters,
 ) : ProtocolMessage
 
-data class VfxSlashApplySkill3(val parameters: SlashEditorParameters) : ProtocolMessage
+enum class Skill3VfxTarget {
+    PULSE,
+    FINISHER,
+}
+
+data class VfxSlashApplySkill3(
+    val target: Skill3VfxTarget,
+    val parameters: SlashEditorParameters,
+) : ProtocolMessage
 
 object VfxSlashPreviewCancel : ProtocolMessage
 
@@ -478,6 +486,7 @@ object ProtocolCodec {
                 }
                 is VfxSlashApplySkill3 -> {
                     data.writeByte(VFX_SLASH_APPLY_SKILL3)
+                    data.writeByte(message.target.ordinal)
                     writeSlashParameters(data, message.parameters)
                 }
                 VfxSlashPreviewCancel -> data.writeByte(VFX_SLASH_PREVIEW_CANCEL)
@@ -587,7 +596,12 @@ object ProtocolCodec {
             GROUND_TELEGRAPH_REMOVE -> GroundTelegraphRemove(input.readLong())
             VFX_EDITOR_OPEN -> VfxEditorOpen(readSlashParameters(input))
             VFX_SLASH_PREVIEW_REQUEST -> VfxSlashPreviewRequest(input.readLong(), readSlashParameters(input))
-            VFX_SLASH_APPLY_SKILL3 -> VfxSlashApplySkill3(readSlashParameters(input))
+            VFX_SLASH_APPLY_SKILL3 -> {
+                val targetId = input.readUnsignedByte()
+                val target = Skill3VfxTarget.entries.getOrNull(targetId)
+                    ?: throw IllegalArgumentException("Unknown Skill3 VFX target: $targetId")
+                VfxSlashApplySkill3(target, readSlashParameters(input))
+            }
             VFX_SLASH_PREVIEW_CANCEL -> VfxSlashPreviewCancel
             VFX_SLASH_SAVE_REQUEST -> VfxSlashSaveRequest(readString(input), readSlashParameters(input))
             VFX_SLASH_DRAFT_LIST -> {

--- a/protocol/src/test/kotlin/dev/projects/protocol/ProtocolCodecTest.kt
+++ b/protocol/src/test/kotlin/dev/projects/protocol/ProtocolCodecTest.kt
@@ -229,7 +229,8 @@ class ProtocolCodecTest {
         listOf<ProtocolMessage>(
             VfxEditorOpen(parameters),
             VfxSlashPreviewRequest(42L, parameters),
-            VfxSlashApplySkill3(parameters),
+            VfxSlashApplySkill3(Skill3VfxTarget.PULSE, parameters),
+            VfxSlashApplySkill3(Skill3VfxTarget.FINISHER, parameters),
             VfxSlashPreviewCancel,
             VfxSlashSaveRequest("blue slash", parameters),
             VfxSlashDraftList(listOf("blue slash")),

--- a/server-minestom/src/main/kotlin/dev/projects/server/ProjectSServer.kt
+++ b/server-minestom/src/main/kotlin/dev/projects/server/ProjectSServer.kt
@@ -1764,9 +1764,10 @@ private fun showSkill3PulseVfx(
     } else {
         val choreography = skill3SlashPulseSpec(authored, pulseIndex)
         val origin = skill3SlashOrigin(player.position, direction, choreography.parameters)
+        val visualDirection = skill3SlashVisualDirection(direction)
         val sink = manager.sink(ParticleViewer(player.position, player), PlayerParticleSink(player), "skill3:slash")
         scheduler.start(
-            SlashEditorPreview.create(origin, direction, choreography.parameters, choreography.reverseDraw),
+            SlashEditorPreview.create(origin, visualDirection, choreography.parameters, choreography.reverseDraw),
             sink,
             id = "skill3:slash:${player.uuid}:$pulseIndex",
         )
@@ -1797,9 +1798,10 @@ private fun showSkill3FinisherVfx(
         )
     } else {
         val origin = skill3SlashOrigin(player.position, direction, authored)
+        val visualDirection = skill3SlashVisualDirection(direction)
         val sink = manager.sink(ParticleViewer(player.position, player), PlayerParticleSink(player), "skill3:finisher-slash")
         scheduler.start(
-            SlashEditorPreview.create(origin, direction, authored),
+            SlashEditorPreview.create(origin, visualDirection, authored),
             sink,
             id = "skill3:finisher-slash:${player.uuid}",
         )

--- a/server-minestom/src/main/kotlin/dev/projects/server/ProjectSServer.kt
+++ b/server-minestom/src/main/kotlin/dev/projects/server/ProjectSServer.kt
@@ -868,8 +868,6 @@ fun main() {
                             start,
                             direction,
                             target,
-                            particleAnimations,
-                            particleManager,
                         )
                     }
                 } else {
@@ -1737,27 +1735,8 @@ private fun showSkill3CatchVfx(
     dashOrigin: Pos,
     dashDirection: Vec,
     target: CombatTarget,
-    scheduler: ParticleAnimationScheduler,
-    manager: ParticleManager,
 ) {
     val contact = twinBladesSkill3ContactPoint(dashOrigin, dashDirection, target.position, target.halfExtent)
-    val visual = TwinBladesSkill3Visual()
-    val started = startParticlePreset(
-        player = player,
-        id = "projects:class/twin_blades/skill3_hit",
-        scheduler = scheduler,
-        origin = contact,
-        direction = dashDirection,
-        manager = manager,
-        values = mapOf(
-            "length" to visual.primaryLength,
-            "aftercutLength" to visual.aftercutLength,
-            "duration" to visual.primaryDuration.toDouble(),
-        ),
-    )
-    if (!started) {
-        System.err.println("Skill3 VFX preset failed to start: projects:class/twin_blades/skill3_hit")
-    }
     playTwinBladesSounds(player, contact, twinBladesSkill3SoundPlan().confirmedHit)
 }
 

--- a/server-minestom/src/main/kotlin/dev/projects/server/ProjectSServer.kt
+++ b/server-minestom/src/main/kotlin/dev/projects/server/ProjectSServer.kt
@@ -1763,11 +1763,9 @@ private fun showSkill3PulseVfx(
         if (!started) System.err.println("Skill3 VFX preset failed to start: projects:class/twin_blades/skill3_pulse")
     } else {
         val choreography = skill3SlashPulseSpec(authored, pulseIndex)
-        val origin = skill3SlashOrigin(player.position, direction, choreography.parameters)
-        val visualDirection = skill3SlashVisualDirection(direction)
         val sink = manager.sink(ParticleViewer(player.position, player), PlayerParticleSink(player), "skill3:slash")
         scheduler.start(
-            SlashEditorPreview.create(origin, visualDirection, choreography.parameters, choreography.reverseDraw),
+            SlashEditorPreview.createSkill3(player.position, direction, choreography.parameters, choreography.reverseDraw),
             sink,
             id = "skill3:slash:${player.uuid}:$pulseIndex",
         )
@@ -1797,11 +1795,9 @@ private fun showSkill3FinisherVfx(
             values = mapOf("length" to visual.finisherLength, "duration" to visual.finisherDuration.toDouble()),
         )
     } else {
-        val origin = skill3SlashOrigin(player.position, direction, authored)
-        val visualDirection = skill3SlashVisualDirection(direction)
         val sink = manager.sink(ParticleViewer(player.position, player), PlayerParticleSink(player), "skill3:finisher-slash")
         scheduler.start(
-            SlashEditorPreview.create(origin, visualDirection, authored),
+            SlashEditorPreview.createSkill3(player.position, direction, authored),
             sink,
             id = "skill3:finisher-slash:${player.uuid}",
         )

--- a/server-minestom/src/main/kotlin/dev/projects/server/ProjectSServer.kt
+++ b/server-minestom/src/main/kotlin/dev/projects/server/ProjectSServer.kt
@@ -17,6 +17,7 @@ import dev.projects.protocol.ProtocolHello
 import dev.projects.protocol.ProtocolHelloAck
 import dev.projects.protocol.ProtocolVersion
 import dev.projects.protocol.SlashEditorParameters
+import dev.projects.protocol.Skill3VfxTarget
 import dev.projects.protocol.VfxEditorNotice
 import dev.projects.protocol.VfxEditorOpen
 import dev.projects.protocol.VfxSlashDraft
@@ -138,6 +139,7 @@ fun main() {
     val bossRiftTelegraphIds = mutableMapOf<Long, Long>()
     val slashDraftStore = SlashDraftStore(Path.of("config", "projects", "vfx-editor", "slash-drafts.json"))
     val skill3SlashBindingStore = Skill3SlashBindingStore(Path.of("config", "projects", "vfx-editor", "twin-blades-skill3-slash.json"))
+    val skill3FinisherBindingStore = Skill3SlashBindingStore(Path.of("config", "projects", "vfx-editor", "twin-blades-skill3-finisher-slash.json"))
     val slashPreviewHandles = mutableMapOf<UUID, ParticleEffectHandle>()
 
     fun sendSlashDraftList(player: net.minestom.server.entity.Player) {
@@ -907,6 +909,7 @@ fun main() {
                             event.player,
                             target,
                             requireNotNull(skill3Tick.dashDirection),
+                            skill3FinisherBindingStore,
                             particleAnimations,
                             particleManager,
                         )
@@ -1060,12 +1063,15 @@ fun main() {
                 is VfxSlashPreviewRequest -> previewSlash(event.player, message.parameters)
                 VfxSlashPreviewCancel -> particleAnimations.cancel(slashPreviewHandles.remove(event.player.uuid))
                 is VfxSlashApplySkill3 -> {
-                    val saved = skill3SlashBindingStore.save(message.parameters)
+                    val store = when (message.target) {
+                        Skill3VfxTarget.PULSE -> skill3SlashBindingStore
+                        Skill3VfxTarget.FINISHER -> skill3FinisherBindingStore
+                    }
                     event.player.sendPluginMessage(
                         PROJECTS_CHANNEL,
                         ProtocolCodec.encode(
-                            if (saved) VfxEditorNotice("Skill3へ適用しました")
-                            else VfxEditorNotice("Skill3への適用に失敗しました"),
+                            if (store.save(message.parameters)) VfxEditorNotice("${if (message.target == Skill3VfxTarget.PULSE) "Skill3連撃" else "Skill3 Finisher"}へ適用しました")
+                            else VfxEditorNotice("適用に失敗しました"),
                         ),
                     )
                 }
@@ -1793,20 +1799,33 @@ private fun showSkill3FinisherVfx(
     player: net.minestom.server.entity.Player,
     target: CombatTarget,
     direction: Vec,
+    bindingStore: Skill3SlashBindingStore,
     scheduler: ParticleAnimationScheduler,
     manager: ParticleManager,
 ) {
     val contact = target.position
     val visual = TwinBladesSkill3Visual()
-    val started = startParticlePreset(
-        player = player,
-        id = "projects:class/twin_blades/skill3_finisher",
-        scheduler = scheduler,
-        origin = contact,
-        direction = direction,
-        manager = manager,
-        values = mapOf("length" to visual.finisherLength, "duration" to visual.finisherDuration.toDouble()),
-    )
+    val authored = bindingStore.load()
+    val started = if (authored == null) {
+        startParticlePreset(
+            player = player,
+            id = "projects:class/twin_blades/skill3_finisher",
+            scheduler = scheduler,
+            origin = contact,
+            direction = direction,
+            manager = manager,
+            values = mapOf("length" to visual.finisherLength, "duration" to visual.finisherDuration.toDouble()),
+        )
+    } else {
+        val origin = slashOrigin(player.position, direction, authored)
+        val sink = manager.sink(ParticleViewer(player.position, player), PlayerParticleSink(player), "skill3:finisher-slash")
+        scheduler.start(
+            SlashEditorPreview.create(origin, direction, authored),
+            sink,
+            id = "skill3:finisher-slash:${player.uuid}",
+        )
+        true
+    }
     if (!started) {
         System.err.println("Skill3 VFX preset failed to start: projects:class/twin_blades/skill3_finisher")
     }

--- a/server-minestom/src/main/kotlin/dev/projects/server/ProjectSServer.kt
+++ b/server-minestom/src/main/kotlin/dev/projects/server/ProjectSServer.kt
@@ -1763,7 +1763,7 @@ private fun showSkill3PulseVfx(
         if (!started) System.err.println("Skill3 VFX preset failed to start: projects:class/twin_blades/skill3_pulse")
     } else {
         val choreography = skill3SlashPulseSpec(authored, pulseIndex)
-        val origin = slashOrigin(player.position, direction, choreography.parameters)
+        val origin = skill3SlashOrigin(player.position, direction, choreography.parameters)
         val sink = manager.sink(ParticleViewer(player.position, player), PlayerParticleSink(player), "skill3:slash")
         scheduler.start(
             SlashEditorPreview.create(origin, direction, choreography.parameters, choreography.reverseDraw),
@@ -1796,7 +1796,7 @@ private fun showSkill3FinisherVfx(
             values = mapOf("length" to visual.finisherLength, "duration" to visual.finisherDuration.toDouble()),
         )
     } else {
-        val origin = slashOrigin(player.position, direction, authored)
+        val origin = skill3SlashOrigin(player.position, direction, authored)
         val sink = manager.sink(ParticleViewer(player.position, player), PlayerParticleSink(player), "skill3:finisher-slash")
         scheduler.start(
             SlashEditorPreview.create(origin, direction, authored),

--- a/server-minestom/src/main/kotlin/dev/projects/server/SlashEditor.kt
+++ b/server-minestom/src/main/kotlin/dev/projects/server/SlashEditor.kt
@@ -198,3 +198,17 @@ internal fun slashOrigin(position: Point, direction: Vec, parameters: SlashEdito
         forward.z() * parameters.forwardOffset,
     )
 }
+
+internal fun skill3SlashOrigin(position: Point, direction: Vec, parameters: SlashEditorParameters): Point {
+    val length = direction.length()
+    val forward = if (length.isFinite() && length > 1.0e-9) {
+        direction.mul(1.0 / length)
+    } else {
+        Vec(0.0, 0.0, 1.0)
+    }
+    return position.add(
+        forward.x() * parameters.forwardOffset,
+        parameters.originY + forward.y() * parameters.forwardOffset,
+        forward.z() * parameters.forwardOffset,
+    )
+}

--- a/server-minestom/src/main/kotlin/dev/projects/server/SlashEditor.kt
+++ b/server-minestom/src/main/kotlin/dev/projects/server/SlashEditor.kt
@@ -10,10 +10,6 @@ import net.minestom.server.coordinate.Point
 import net.minestom.server.coordinate.Vec
 import java.nio.file.Files
 import java.nio.file.Path
-import kotlin.math.asin
-import kotlin.math.atan2
-import kotlin.math.cos
-import kotlin.math.sin
 
 private const val DRAFT_SCHEMA_VERSION = 2
 private const val MAX_DRAFTS = 16
@@ -221,10 +217,5 @@ internal fun skill3SlashVisualDirection(direction: Vec): Vec {
     val length = direction.length()
     if (!length.isFinite() || length <= 1.0e-9) return Vec(0.0, 0.0, 1.0)
 
-    val normalized = direction.mul(1.0 / length)
-    val yaw = atan2(normalized.x(), normalized.z())
-    val pitch = (asin(normalized.y().coerceIn(-1.0, 1.0)) * 0.5)
-        .coerceIn(Math.toRadians(-35.0), Math.toRadians(35.0))
-    val horizontal = cos(pitch)
-    return Vec(sin(yaw) * horizontal, sin(pitch), cos(yaw) * horizontal)
+    return direction.mul(1.0 / length)
 }

--- a/server-minestom/src/main/kotlin/dev/projects/server/SlashEditor.kt
+++ b/server-minestom/src/main/kotlin/dev/projects/server/SlashEditor.kt
@@ -5,7 +5,10 @@ import dev.projects.server.particle.ParticleEffect
 import dev.projects.server.particle.ParticleBatch
 import dev.projects.server.particle.ParticleGeometry
 import dev.projects.server.particle.ParticleStyle
+import dev.projects.server.particle.ParticleTransform
 import dev.projects.server.particle.dust
+import dev.projects.server.particle.localCoordinates
+import dev.projects.server.particle.translated
 import net.minestom.server.coordinate.Point
 import net.minestom.server.coordinate.Vec
 import java.nio.file.Files
@@ -156,6 +159,16 @@ object SlashEditorPreview {
                 )
             }
         }.toTypedArray())
+    }
+
+    /** Builds authored Skill3 geometry in canonical +Z local space, then maps the whole effect to the cast direction. */
+    fun createSkill3(origin: Point, direction: Vec, parameters: SlashEditorParameters, reverseDraw: Boolean = false): ParticleEffect {
+        val localOrigin = Vec(0.0, parameters.originY, parameters.forwardOffset)
+        val localParameters = parameters.copy(originY = 0.0, forwardOffset = 0.0)
+        val localEffect = create(Vec.ZERO, Vec(0.0, 0.0, 1.0), localParameters, reverseDraw)
+        return localEffect.translated(localOrigin).localCoordinates(
+            ParticleTransform.fromDirection(origin, skill3SlashVisualDirection(direction)),
+        )
     }
 }
 

--- a/server-minestom/src/main/kotlin/dev/projects/server/SlashEditor.kt
+++ b/server-minestom/src/main/kotlin/dev/projects/server/SlashEditor.kt
@@ -10,6 +10,10 @@ import net.minestom.server.coordinate.Point
 import net.minestom.server.coordinate.Vec
 import java.nio.file.Files
 import java.nio.file.Path
+import kotlin.math.asin
+import kotlin.math.atan2
+import kotlin.math.cos
+import kotlin.math.sin
 
 private const val DRAFT_SCHEMA_VERSION = 2
 private const val MAX_DRAFTS = 16
@@ -211,4 +215,16 @@ internal fun skill3SlashOrigin(position: Point, direction: Vec, parameters: Slas
         parameters.originY + forward.y() * parameters.forwardOffset,
         forward.z() * parameters.forwardOffset,
     )
+}
+
+internal fun skill3SlashVisualDirection(direction: Vec): Vec {
+    val length = direction.length()
+    if (!length.isFinite() || length <= 1.0e-9) return Vec(0.0, 0.0, 1.0)
+
+    val normalized = direction.mul(1.0 / length)
+    val yaw = atan2(normalized.x(), normalized.z())
+    val pitch = (asin(normalized.y().coerceIn(-1.0, 1.0)) * 0.5)
+        .coerceIn(Math.toRadians(-35.0), Math.toRadians(35.0))
+    val horizontal = cos(pitch)
+    return Vec(sin(yaw) * horizontal, sin(pitch), cos(yaw) * horizontal)
 }

--- a/server-minestom/src/test/kotlin/dev/projects/server/SlashEditorTest.kt
+++ b/server-minestom/src/test/kotlin/dev/projects/server/SlashEditorTest.kt
@@ -187,6 +187,33 @@ class SlashEditorTest {
     }
 
     @Test
+    fun `skill3 slash visual direction follows horizontal yaw and softened pitch`() {
+        val forward = skill3SlashVisualDirection(Vec(0.0, 0.0, 1.0))
+        assertEquals(0.0, forward.x(), absoluteTolerance = 0.000001)
+        assertEquals(0.0, forward.y(), absoluteTolerance = 0.000001)
+        assertEquals(1.0, forward.z(), absoluteTolerance = 0.000001)
+        val right = skill3SlashVisualDirection(Vec(1.0, 0.0, 0.0))
+        assertEquals(1.0, right.x(), absoluteTolerance = 0.000001)
+        assertEquals(0.0, right.y(), absoluteTolerance = 0.000001)
+        assertEquals(0.0, right.z(), absoluteTolerance = 0.000001)
+
+        val diagonal = skill3SlashVisualDirection(Vec(0.0, 1.0, 1.0))
+        assertEquals(0.3826834323650898, diagonal.y(), absoluteTolerance = 0.000001)
+        assertEquals(0.9238795325112867, diagonal.z(), absoluteTolerance = 0.000001)
+    }
+
+    @Test
+    fun `skill3 slash visual pitch is clamped while origin keeps full 3d direction`() {
+        val direction = Vec(0.0, 10.0, 1.0)
+        val visual = skill3SlashVisualDirection(direction)
+        assertEquals(Math.sin(Math.toRadians(35.0)), visual.y(), absoluteTolerance = 0.000001)
+        assertEquals(Math.cos(Math.toRadians(35.0)), visual.z(), absoluteTolerance = 0.000001)
+
+        val origin = skill3SlashOrigin(Pos.ZERO, direction, SlashEditorParameters(forwardOffset = 2.0))
+        assertEquals(1.2 + 20.0 / Math.sqrt(101.0), origin.y(), absoluteTolerance = 0.000001)
+    }
+
+    @Test
     fun `zero authored yaw follows locked direction while yaw remains local`() {
         val zeroYaw = SlashEditorParameters(yaw = 0.0, tilt = 0.0, arcSpan = 0.0, durationTicks = 1)
         val localYaw = SlashEditorParameters(yaw = 35.0, tilt = 0.0, arcSpan = 0.0, durationTicks = 1)

--- a/server-minestom/src/test/kotlin/dev/projects/server/SlashEditorTest.kt
+++ b/server-minestom/src/test/kotlin/dev/projects/server/SlashEditorTest.kt
@@ -158,6 +158,35 @@ class SlashEditorTest {
     }
 
     @Test
+    fun `skill3 slash origin follows full 3d direction`() {
+        val parameters = SlashEditorParameters(originY = 1.25, forwardOffset = 4.0)
+        val position = Pos(2.0, 10.0, -3.0)
+
+        val diagonal = skill3SlashOrigin(position, Vec(1.0, 2.0, 2.0), parameters)
+        assertEquals(2.0 + 4.0 / 3.0, diagonal.x(), absoluteTolerance = 0.000001)
+        assertEquals(10.0 + 1.25 + 8.0 / 3.0, diagonal.y(), absoluteTolerance = 0.000001)
+        assertEquals(-3.0 + 8.0 / 3.0, diagonal.z(), absoluteTolerance = 0.000001)
+
+        val upward = skill3SlashOrigin(position, Vec(0.0, 1.0, 0.0), parameters)
+        assertEquals(position.x(), upward.x(), absoluteTolerance = 0.000001)
+        assertEquals(position.y() + 1.25 + 4.0, upward.y(), absoluteTolerance = 0.000001)
+        assertEquals(position.z(), upward.z(), absoluteTolerance = 0.000001)
+
+        val downward = skill3SlashOrigin(position, Vec(0.0, -1.0, 0.0), parameters)
+        assertEquals(position.y() + 1.25 - 4.0, downward.y(), absoluteTolerance = 0.000001)
+    }
+
+    @Test
+    fun `skill3 slash origin uses positive z fallback for degenerate direction`() {
+        val parameters = SlashEditorParameters(originY = 0.5, forwardOffset = 2.0)
+        val origin = skill3SlashOrigin(Pos.ZERO, Vec.ZERO, parameters)
+
+        assertEquals(0.0, origin.x(), absoluteTolerance = 0.000001)
+        assertEquals(0.5, origin.y(), absoluteTolerance = 0.000001)
+        assertEquals(2.0, origin.z(), absoluteTolerance = 0.000001)
+    }
+
+    @Test
     fun `zero authored yaw follows locked direction while yaw remains local`() {
         val zeroYaw = SlashEditorParameters(yaw = 0.0, tilt = 0.0, arcSpan = 0.0, durationTicks = 1)
         val localYaw = SlashEditorParameters(yaw = 35.0, tilt = 0.0, arcSpan = 0.0, durationTicks = 1)

--- a/server-minestom/src/test/kotlin/dev/projects/server/SlashEditorTest.kt
+++ b/server-minestom/src/test/kotlin/dev/projects/server/SlashEditorTest.kt
@@ -60,6 +60,17 @@ class SlashEditorTest {
     }
 
     @Test
+    fun `pulse and finisher bindings are independent`() {
+        val directory = Files.createTempDirectory("skill3-binding-independent-test")
+        val pulse = SlashEditorParameters(color = 0x112233)
+        val finisher = SlashEditorParameters(color = 0xaabbcc, length = 9.0)
+        assertTrue(Skill3SlashBindingStore(directory.resolve("pulse.json")).save(pulse))
+        assertTrue(Skill3SlashBindingStore(directory.resolve("finisher.json")).save(finisher))
+        assertEquals(pulse, Skill3SlashBindingStore(directory.resolve("pulse.json")).load())
+        assertEquals(finisher, Skill3SlashBindingStore(directory.resolve("finisher.json")).load())
+    }
+
+    @Test
     fun `preview emits finite positions with the requested color`() {
         val color = 0x123456
         val effect = SlashEditorPreview.create(Pos.ZERO, Vec(0.0, 0.0, 1.0), SlashEditorParameters(color = color))

--- a/server-minestom/src/test/kotlin/dev/projects/server/SlashEditorTest.kt
+++ b/server-minestom/src/test/kotlin/dev/projects/server/SlashEditorTest.kt
@@ -2,6 +2,7 @@ package dev.projects.server
 
 import dev.projects.protocol.SlashEditorParameters
 import dev.projects.server.particle.RecordingParticleSink
+import dev.projects.server.particle.ParticleTransform
 import net.minestom.server.coordinate.Point
 import net.minestom.server.coordinate.Pos
 import net.minestom.server.coordinate.Vec
@@ -286,5 +287,54 @@ class SlashEditorTest {
         reverse.emit(0, reverseSink)
 
         assertNotEquals(forwardSink.spawns.map { it.position }, reverseSink.spawns.map { it.position })
+    }
+
+    @Test
+    fun `skill3 authored slash transforms its complete pulse and finisher geometry locally`() {
+        val origin = Pos(8.0, 12.0, -4.0)
+        val authored = SlashEditorParameters(
+            originY = 1.3,
+            forwardOffset = 2.1,
+            arcSpan = 84.0,
+            tilt = 17.0,
+            yaw = 23.0,
+            laneCount = 3,
+            laneSpacing = 0.7,
+            durationTicks = 2,
+        )
+        val specs = (1..4).map { skill3SlashPulseSpec(authored, it) } + Skill3SlashPulseSpec(authored, false)
+        val directions = listOf(
+            Vec(0.0, 0.0, 1.0),
+            Vec(0.0, 1.0, 0.0),
+            Vec(0.0, -1.0, 0.0),
+            Vec(1.0, 0.0, 0.0),
+            Vec(1.0, 2.0, 3.0),
+        )
+
+        fun positions(direction: Vec, spec: Skill3SlashPulseSpec): List<Point> {
+            val effect = SlashEditorPreview.createSkill3(origin, direction, spec.parameters, spec.reverseDraw)
+            val sink = RecordingParticleSink()
+            repeat(effect.durationTicks) { effect.emit(it, sink) }
+            return sink.spawns.map { it.position }
+        }
+
+        specs.forEach { spec ->
+            val baseline = positions(directions.first(), spec)
+            val baselineFrame = ParticleTransform.fromDirection(origin, directions.first())
+            directions.drop(1).forEach { direction ->
+                val transform = ParticleTransform.fromDirection(origin, direction)
+                val actual = positions(direction, spec)
+                assertEquals(baseline.size, actual.size)
+                baseline.zip(actual).forEach { (localPoint, worldPoint) ->
+                    val expected = transform.localPoint(baselineFrame.worldPoint(localPoint))
+                    assertEquals(expected.x(), worldPoint.x(), absoluteTolerance = 0.000001)
+                    assertEquals(expected.y(), worldPoint.y(), absoluteTolerance = 0.000001)
+                    assertEquals(expected.z(), worldPoint.z(), absoluteTolerance = 0.000001)
+                }
+            }
+        }
+
+        val fallback = positions(Vec(Double.NaN, 0.0, 1.0), specs.last())
+        assertEquals(positions(directions.first(), specs.last()), fallback)
     }
 }

--- a/server-minestom/src/test/kotlin/dev/projects/server/SlashEditorTest.kt
+++ b/server-minestom/src/test/kotlin/dev/projects/server/SlashEditorTest.kt
@@ -2,6 +2,7 @@ package dev.projects.server
 
 import dev.projects.protocol.SlashEditorParameters
 import dev.projects.server.particle.RecordingParticleSink
+import net.minestom.server.coordinate.Point
 import net.minestom.server.coordinate.Pos
 import net.minestom.server.coordinate.Vec
 import net.minestom.server.particle.Particle
@@ -117,6 +118,69 @@ class SlashEditorTest {
         assertEquals(10.0, origin.x())
         assertEquals(22.4, origin.y())
         assertEquals(33.6, origin.z())
+    }
+
+    @Test
+    fun `slash origin and geometry rotate with locked skill3 direction`() {
+        val parameters = SlashEditorParameters(
+            originY = 1.2,
+            forwardOffset = 2.5,
+            arcSpan = 96.0,
+            tilt = 11.0,
+            yaw = 23.0,
+            durationTicks = 1,
+        )
+        val position = Pos(4.0, 8.0, -3.0)
+        val forward = Vec(0.0, 0.0, 1.0)
+        val right = Vec(1.0, 0.0, 0.0)
+        val forwardOrigin = slashOrigin(position, forward, parameters)
+        val rightOrigin = slashOrigin(position, right, parameters)
+
+        assertEquals(position.x(), forwardOrigin.x(), absoluteTolerance = 0.000001)
+        assertEquals(position.z() + parameters.forwardOffset, forwardOrigin.z(), absoluteTolerance = 0.000001)
+        assertEquals(position.x() + parameters.forwardOffset, rightOrigin.x(), absoluteTolerance = 0.000001)
+        assertEquals(position.z(), rightOrigin.z(), absoluteTolerance = 0.000001)
+
+        fun emitted(direction: Vec, origin: Point): List<Point> {
+            val sink = RecordingParticleSink()
+            SlashEditorPreview.create(origin, direction, parameters).emit(0, sink)
+            return sink.spawns.map { it.position }
+        }
+
+        val forwardPositions = emitted(forward, forwardOrigin)
+        val rightPositions = emitted(right, rightOrigin)
+        assertEquals(forwardPositions.size, rightPositions.size)
+        forwardPositions.zip(rightPositions).forEach { (zFacing, xFacing) ->
+            assertEquals(zFacing.z() - forwardOrigin.z() + rightOrigin.x(), xFacing.x(), absoluteTolerance = 0.000001)
+            assertEquals(zFacing.y(), xFacing.y(), absoluteTolerance = 0.000001)
+            assertEquals(-(zFacing.x() - forwardOrigin.x()) + rightOrigin.z(), xFacing.z(), absoluteTolerance = 0.000001)
+        }
+    }
+
+    @Test
+    fun `zero authored yaw follows locked direction while yaw remains local`() {
+        val zeroYaw = SlashEditorParameters(yaw = 0.0, tilt = 0.0, arcSpan = 0.0, durationTicks = 1)
+        val localYaw = SlashEditorParameters(yaw = 35.0, tilt = 0.0, arcSpan = 0.0, durationTicks = 1)
+
+        fun firstOffset(direction: Vec, parameters: SlashEditorParameters): Vec {
+            val origin = slashOrigin(Pos.ZERO, direction, parameters)
+            val sink = RecordingParticleSink()
+            SlashEditorPreview.create(origin, direction, parameters).emit(0, sink)
+            val point = sink.spawns.first().position
+            return Vec(point.x() - origin.x(), point.y() - origin.y(), point.z() - origin.z())
+        }
+
+        val zeroZ = firstOffset(Vec(0.0, 0.0, 1.0), zeroYaw)
+        val zeroX = firstOffset(Vec(1.0, 0.0, 0.0), zeroYaw)
+        assertTrue(zeroZ.x() < 0.0)
+        assertEquals(zeroZ.z(), zeroX.x(), absoluteTolerance = 0.000001)
+        assertEquals(-zeroZ.x(), zeroX.z(), absoluteTolerance = 0.000001)
+
+        val localZ = firstOffset(Vec(0.0, 0.0, 1.0), localYaw)
+        val localX = firstOffset(Vec(1.0, 0.0, 0.0), localYaw)
+        assertEquals(localZ.z(), localX.x(), absoluteTolerance = 0.000001)
+        assertEquals(-localZ.x(), localX.z(), absoluteTolerance = 0.000001)
+        assertNotEquals(zeroZ, localZ)
     }
 
     @Test

--- a/server-minestom/src/test/kotlin/dev/projects/server/SlashEditorTest.kt
+++ b/server-minestom/src/test/kotlin/dev/projects/server/SlashEditorTest.kt
@@ -187,7 +187,7 @@ class SlashEditorTest {
     }
 
     @Test
-    fun `skill3 slash visual direction follows horizontal yaw and softened pitch`() {
+    fun `skill3 slash visual direction follows full 3d direction`() {
         val forward = skill3SlashVisualDirection(Vec(0.0, 0.0, 1.0))
         assertEquals(0.0, forward.x(), absoluteTolerance = 0.000001)
         assertEquals(0.0, forward.y(), absoluteTolerance = 0.000001)
@@ -198,19 +198,38 @@ class SlashEditorTest {
         assertEquals(0.0, right.z(), absoluteTolerance = 0.000001)
 
         val diagonal = skill3SlashVisualDirection(Vec(0.0, 1.0, 1.0))
-        assertEquals(0.3826834323650898, diagonal.y(), absoluteTolerance = 0.000001)
-        assertEquals(0.9238795325112867, diagonal.z(), absoluteTolerance = 0.000001)
+        assertEquals(1.0 / Math.sqrt(2.0), diagonal.y(), absoluteTolerance = 0.000001)
+        assertEquals(1.0 / Math.sqrt(2.0), diagonal.z(), absoluteTolerance = 0.000001)
     }
 
     @Test
-    fun `skill3 slash visual pitch is clamped while origin keeps full 3d direction`() {
+    fun `skill3 slash visual direction preserves vertical pitch while origin keeps full 3d direction`() {
+        val upward = skill3SlashVisualDirection(Vec(0.0, 1.0, 0.0))
+        assertEquals(0.0, upward.x(), absoluteTolerance = 0.000001)
+        assertEquals(1.0, upward.y(), absoluteTolerance = 0.000001)
+        assertEquals(0.0, upward.z(), absoluteTolerance = 0.000001)
+
+        val downward = skill3SlashVisualDirection(Vec(0.0, -1.0, 0.0))
+        assertEquals(0.0, downward.x(), absoluteTolerance = 0.000001)
+        assertEquals(-1.0, downward.y(), absoluteTolerance = 0.000001)
+        assertEquals(0.0, downward.z(), absoluteTolerance = 0.000001)
+
         val direction = Vec(0.0, 10.0, 1.0)
         val visual = skill3SlashVisualDirection(direction)
-        assertEquals(Math.sin(Math.toRadians(35.0)), visual.y(), absoluteTolerance = 0.000001)
-        assertEquals(Math.cos(Math.toRadians(35.0)), visual.z(), absoluteTolerance = 0.000001)
+        assertEquals(10.0 / Math.sqrt(101.0), visual.y(), absoluteTolerance = 0.000001)
+        assertEquals(1.0 / Math.sqrt(101.0), visual.z(), absoluteTolerance = 0.000001)
 
         val origin = skill3SlashOrigin(Pos.ZERO, direction, SlashEditorParameters(forwardOffset = 2.0))
         assertEquals(1.2 + 20.0 / Math.sqrt(101.0), origin.y(), absoluteTolerance = 0.000001)
+    }
+
+    @Test
+    fun `skill3 slash visual direction uses positive z fallback for invalid direction`() {
+        val visual = skill3SlashVisualDirection(Vec(Double.NaN, 0.0, 1.0))
+
+        assertEquals(0.0, visual.x(), absoluteTolerance = 0.000001)
+        assertEquals(0.0, visual.y(), absoluteTolerance = 0.000001)
+        assertEquals(1.0, visual.z(), absoluteTolerance = 0.000001)
     }
 
     @Test


### PR DESCRIPTION
Closes #89

## Summary
- Adds separate Skill3 pulse / Finisher Slash bindings from the VFX Editor.
- Removes the legacy cyan/black Skill3 catch particle while preserving catch sound/gameplay.
- Aligns authored Skill3 pulse + Finisher Slash geometry to the full 3D cast direction using local-to-world transformation.
- Preserves pulse choreography, recoil, sound, bounce, cooldown and gameplay behavior.

## Verification
- Sol Review: PASS
- User Manual Smoke: PASS
- Protocol/client/server targeted tests and builds passed during implementation/follow-ups.

Merge is intentionally left for explicit User approval.