### PR TITLE
Damage Core v0: pure Kotlin legacy parity

### DIFF
--- a/server-minestom/src/main/kotlin/dev/projects/server/combat/damage/DamageCalculator.kt
+++ b/server-minestom/src/main/kotlin/dev/projects/server/combat/damage/DamageCalculator.kt
@@ -1,0 +1,70 @@
+package dev.projects.server.combat.damage
+
+object DamageCalculator {
+    fun calculate(input: Input): DamageResult {
+        val attackPower = StatCalculator.nonNegative(input.attackPower)
+        val baseDamage = StatCalculator.baseDamage(input.fixedDamage, attackPower, input.coefficient)
+        val outgoing = StatCalculator.nonNegative(StatCalculator.saturatedAdd(1.0, input.damageIncreasePercent))
+        val taken = StatCalculator.nonNegative(StatCalculator.saturatedAdd(1.0, input.damageTakenIncreasePercent))
+        val criticalMultiplier = if (input.critical) maxOf(1.0, StatCalculator.finiteOrZero(input.criticalMultiplier)) else 1.0
+        var offenseDamage = StatCalculator.saturatedMultiply(baseDamage, outgoing)
+        offenseDamage = StatCalculator.saturatedMultiply(offenseDamage, criticalMultiplier)
+        offenseDamage = StatCalculator.saturatedMultiply(offenseDamage, StatCalculator.nonNegative(input.modeMultiplier))
+        val increase = StatCalculator.saturatedMultiply(outgoing, taken)
+        return finish(input, attackPower, baseDamage, increase, DamageOffenseSnapshot(offenseDamage, input.critical, criticalMultiplier), taken)
+    }
+
+    private fun finish(input: Input, attackPower: Double, baseDamage: Double, increase: Double, offense: DamageOffenseSnapshot, taken: Double): DamageResult {
+        val trueDamage = input.damageType == DamageType.TRUE
+        val defense = if (trueDamage) 0.0 else StatCalculator.nonNegative(input.defense)
+        val effectiveDefense = if (trueDamage) 0.0 else StatCalculator.effectiveDefense(defense, input.defenseReductionPercent, input.penetrationPercent, input.flatPenetration)
+        val defenseMultiplier = if (trueDamage) 1.0 else StatCalculator.defenseMultiplier(effectiveDefense, input.defenseConstant)
+        var reduction = 1.0
+        input.damageReductions().forEach { reduction = StatCalculator.saturatedMultiply(reduction, 1.0 - StatCalculator.clamp01(it)) }
+        val mode = input.mode ?: DamageMode.PVE
+        val reductionMultiplier = maxOf(1.0 - mode.reductionCap, reduction)
+        var beforeShield = StatCalculator.saturatedMultiply(offense.damage, taken)
+        beforeShield = StatCalculator.saturatedMultiply(beforeShield, defenseMultiplier)
+        beforeShield = StatCalculator.saturatedMultiply(beforeShield, reductionMultiplier)
+        val rounded = kotlin.math.round(StatCalculator.nonNegative(beforeShield) * 1_000.0) / 1_000.0
+        val shieldDamage = StatCalculator.shieldDamage(rounded, input.shield)
+        val healthDamage = StatCalculator.actualHealthDamage(rounded, input.shield, input.health)
+        val kind = input.damageKind ?: DamageKind.DIRECT_SKILL
+        val lifeStealEfficiency = if (trueDamage || kind !in setOf(DamageKind.NORMAL_ATTACK, DamageKind.DIRECT_SKILL)) 0.0 else input.lifeStealEfficiency
+        val lifeSteal = StatCalculator.lifeSteal(healthDamage, input.lifeStealPercent, lifeStealEfficiency, input.healingReductionPercent)
+        return DamageResult(attackPower, baseDamage, increase, offense.damage, offense.critical, offense.criticalMultiplier, defense, effectiveDefense, defenseMultiplier, reductionMultiplier, StatCalculator.nonNegative(input.modeMultiplier), beforeShield, shieldDamage, healthDamage, lifeSteal, rounded)
+    }
+
+    class Input(
+        val damageType: DamageType? = DamageType.PHYSICAL,
+        val mode: DamageMode? = DamageMode.PVE,
+        val damageKind: DamageKind? = DamageKind.DIRECT_SKILL,
+        val attackPower: Double = 0.0,
+        val fixedDamage: Double = 0.0,
+        val coefficient: Double = 0.0,
+        val damageIncreasePercent: Double = 0.0,
+        val damageTakenIncreasePercent: Double = 0.0,
+        val critical: Boolean = false,
+        val criticalMultiplier: Double = 1.5,
+        val defense: Double = 0.0,
+        val defenseReductionPercent: Double = 0.0,
+        val penetrationPercent: Double = 0.0,
+        val flatPenetration: Double = 0.0,
+        val defenseConstant: Double = StatCalculator.DEFAULT_DEFENSE_CONSTANT,
+        damageReductions: DoubleArray = doubleArrayOf(),
+        val modeMultiplier: Double = 1.0,
+        val shield: Double = 0.0,
+        val health: Double = 0.0,
+        val lifeStealPercent: Double = 0.0,
+        val lifeStealEfficiency: Double = 0.0,
+        val healingReductionPercent: Double = 0.0,
+    ) {
+        private val rawDamageReductions: DoubleArray
+
+        init {
+            rawDamageReductions = damageReductions.clone()
+        }
+
+        fun damageReductions(): DoubleArray = rawDamageReductions.clone()
+    }
+}

--- a/server-minestom/src/main/kotlin/dev/projects/server/combat/damage/DamageCalculator.kt
+++ b/server-minestom/src/main/kotlin/dev/projects/server/combat/damage/DamageCalculator.kt
@@ -26,7 +26,7 @@ object DamageCalculator {
         var beforeShield = StatCalculator.saturatedMultiply(offense.damage, taken)
         beforeShield = StatCalculator.saturatedMultiply(beforeShield, defenseMultiplier)
         beforeShield = StatCalculator.saturatedMultiply(beforeShield, reductionMultiplier)
-        val rounded = kotlin.math.round(StatCalculator.nonNegative(beforeShield) * 1_000.0) / 1_000.0
+        val rounded = Math.round(StatCalculator.nonNegative(beforeShield) * 1_000.0) / 1_000.0
         val shieldDamage = StatCalculator.shieldDamage(rounded, input.shield)
         val healthDamage = StatCalculator.actualHealthDamage(rounded, input.shield, input.health)
         val kind = input.damageKind ?: DamageKind.DIRECT_SKILL

--- a/server-minestom/src/main/kotlin/dev/projects/server/combat/damage/DamageModel.kt
+++ b/server-minestom/src/main/kotlin/dev/projects/server/combat/damage/DamageModel.kt
@@ -1,0 +1,56 @@
+package dev.projects.server.combat.damage
+
+enum class DamageType {
+    PHYSICAL,
+    MAGICAL,
+    TRUE,
+}
+
+enum class DamageKind(
+    val criticalAllowed: Boolean,
+    val defaultLifeStealEfficiency: Double,
+) {
+    NORMAL_ATTACK(true, 1.0),
+    DIRECT_SKILL(true, 1.0),
+    DAMAGE_OVER_TIME(false, 0.0),
+    REFLECTED(false, 0.0),
+    PERCENT_HEALTH(false, 0.0),
+}
+
+enum class DamageMode(
+    val baseCriticalMultiplier: Double,
+    val reductionCap: Double,
+) {
+    PVE(1.75, 0.80),
+    PVP(1.50, 0.75),
+}
+
+data class DamageOffenseSnapshot(
+    val damage: Double,
+    val critical: Boolean,
+    val criticalMultiplier: Double,
+) {
+    init {
+        require(damage.isFinite() && damage >= 0.0)
+        require(criticalMultiplier.isFinite() && criticalMultiplier >= 1.0)
+    }
+}
+
+data class DamageResult(
+    val resolvedAttackPower: Double,
+    val baseDamage: Double,
+    val damageIncreaseMultiplier: Double,
+    val offenseResolvedDamage: Double,
+    val critical: Boolean,
+    val criticalMultiplier: Double,
+    val defenseBeforePenetration: Double,
+    val effectiveDefense: Double,
+    val defenseMultiplier: Double,
+    val reductionMultiplier: Double,
+    val modeMultiplier: Double,
+    val damageBeforeShield: Double,
+    val shieldDamage: Double,
+    val healthDamage: Double,
+    val lifeStealHealing: Double,
+    val finalRoundedDamage: Double,
+)

--- a/server-minestom/src/main/kotlin/dev/projects/server/combat/damage/StatCalculator.kt
+++ b/server-minestom/src/main/kotlin/dev/projects/server/combat/damage/StatCalculator.kt
@@ -1,0 +1,64 @@
+package dev.projects.server.combat.damage
+
+import kotlin.math.max
+
+object StatCalculator {
+    const val DEFAULT_DEFENSE_CONSTANT: Double = 300.0
+    private const val MAX_SAFE_VALUE: Double = Long.MAX_VALUE / 1_000.0
+
+    fun attackPower(weaponAttack: Double, flatAttack: Double, percentAttack: Double): Double =
+        saturatedMultiply(nonNegative(saturatedAdd(nonNegative(weaponAttack), flatAttack)), nonNegative(saturatedAdd(1.0, percentAttack)))
+
+    fun baseDamage(fixedDamage: Double, attackPower: Double, coefficient: Double): Double =
+        saturatedAdd(nonNegative(fixedDamage), saturatedMultiply(nonNegative(attackPower), nonNegative(coefficient)))
+
+    fun defense(equipmentDefense: Double, flatDefense: Double, percentDefense: Double): Double =
+        saturatedMultiply(nonNegative(saturatedAdd(nonNegative(equipmentDefense), flatDefense)), nonNegative(saturatedAdd(1.0, percentDefense)))
+
+    fun effectiveDefense(defense: Double, reductionPercent: Double, penetrationPercent: Double, flatPenetration: Double): Double {
+        val afterReduction = saturatedMultiply(nonNegative(defense), 1.0 - clamp01(reductionPercent))
+        val afterPenetration = saturatedMultiply(afterReduction, 1.0 - clamp01(penetrationPercent))
+        return nonNegative(saturatedAdd(afterPenetration, -nonNegative(flatPenetration)))
+    }
+
+    fun defenseMultiplier(effectiveDefense: Double, constant: Double): Double {
+        val safeConstant = if (constant.isFinite() && constant > 0.0) constant else DEFAULT_DEFENSE_CONSTANT
+        return safeConstant / (safeConstant + nonNegative(effectiveDefense))
+    }
+
+    fun lifeSteal(actualHealthDamage: Double, percent: Double, efficiency: Double, healingReduction: Double): Double {
+        var result = saturatedMultiply(nonNegative(actualHealthDamage), nonNegative(percent))
+        result = saturatedMultiply(result, clamp01(efficiency))
+        return saturatedMultiply(result, 1.0 - clamp01(healingReduction))
+    }
+
+    fun shieldDamage(finalDamage: Double, shield: Double): Double = minOf(nonNegative(finalDamage), nonNegative(shield))
+
+    fun actualHealthDamage(finalDamage: Double, shield: Double, health: Double): Double =
+        minOf(nonNegative(health), nonNegative(finalDamage) - shieldDamage(finalDamage, shield))
+
+    fun clamp01(value: Double): Double = finiteOrZero(value).coerceIn(0.0, 1.0)
+
+    fun finiteOrZero(value: Double): Double = when {
+        value.isNaN() -> 0.0
+        value == Double.POSITIVE_INFINITY -> MAX_SAFE_VALUE
+        value == Double.NEGATIVE_INFINITY -> -MAX_SAFE_VALUE
+        else -> value.coerceIn(-MAX_SAFE_VALUE, MAX_SAFE_VALUE)
+    }
+
+    fun nonNegative(value: Double): Double = max(0.0, finiteOrZero(value))
+
+    fun saturatedAdd(left: Double, right: Double): Double {
+        val safeLeft = finiteOrZero(left)
+        val safeRight = finiteOrZero(right)
+        return finiteOrZero(safeLeft + safeRight)
+    }
+
+    fun saturatedMultiply(left: Double, right: Double): Double {
+        val safeLeft = nonNegative(left)
+        val safeRight = nonNegative(right)
+        if (safeLeft == 0.0 || safeRight == 0.0) return 0.0
+        if (safeLeft > MAX_SAFE_VALUE / safeRight) return MAX_SAFE_VALUE
+        return nonNegative(safeLeft * safeRight)
+    }
+}

--- a/server-minestom/src/test/kotlin/dev/projects/server/combat/damage/DamageCalculatorTest.kt
+++ b/server-minestom/src/test/kotlin/dev/projects/server/combat/damage/DamageCalculatorTest.kt
@@ -12,6 +12,13 @@ class DamageCalculatorTest {
     }
 
     @Test
+    fun `final damage uses legacy half-up rounding`() {
+        val result = DamageCalculator.calculate(DamageCalculator.Input(fixedDamage = 0.0005))
+
+        assertEquals(0.001, result.finalRoundedDamage)
+    }
+
+    @Test
     fun `true damage bypasses defense`() {
         val result = calculate(DamageType.TRUE, defense = 1_000_000.0)
         assertEquals(100.0, result.finalRoundedDamage)

--- a/server-minestom/src/test/kotlin/dev/projects/server/combat/damage/DamageCalculatorTest.kt
+++ b/server-minestom/src/test/kotlin/dev/projects/server/combat/damage/DamageCalculatorTest.kt
@@ -1,0 +1,99 @@
+package dev.projects.server.combat.damage
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class DamageCalculatorTest {
+    @Test
+    fun `physical damage is reduced by defense`() {
+        assertEquals(50.0, calculate(DamageType.PHYSICAL, defense = 300.0).finalRoundedDamage)
+        assertEquals(100.0, calculate(DamageType.MAGICAL).finalRoundedDamage)
+    }
+
+    @Test
+    fun `true damage bypasses defense`() {
+        val result = calculate(DamageType.TRUE, defense = 1_000_000.0)
+        assertEquals(100.0, result.finalRoundedDamage)
+        assertEquals(0.0, result.effectiveDefense)
+    }
+
+    @Test
+    fun `reduction shield and health are applied`() {
+        val result = DamageCalculator.calculate(
+            DamageCalculator.Input(
+                damageType = DamageType.PHYSICAL,
+                fixedDamage = 100.0,
+                damageReductions = doubleArrayOf(0.5),
+                shield = 30.0,
+                health = 50.0,
+                lifeStealPercent = 0.2,
+                lifeStealEfficiency = 1.0,
+            ),
+        )
+        assertEquals(50.0, result.finalRoundedDamage)
+        assertEquals(30.0, result.shieldDamage)
+        assertEquals(20.0, result.healthDamage)
+        assertEquals(4.0, result.lifeStealHealing)
+    }
+
+    @Test
+    fun `damage kinds that cannot lifesteal always return zero`() {
+        for (kind in listOf(DamageKind.DAMAGE_OVER_TIME, DamageKind.REFLECTED, DamageKind.PERCENT_HEALTH)) {
+            val result = DamageCalculator.calculate(
+                DamageCalculator.Input(
+                    damageKind = kind,
+                    fixedDamage = 100.0,
+                    health = 100.0,
+                    lifeStealPercent = 1.0,
+                    lifeStealEfficiency = 1.0,
+                ),
+            )
+            assertEquals(0.0, result.lifeStealHealing)
+        }
+        val trueDamage = DamageCalculator.calculate(
+            DamageCalculator.Input(
+                damageType = DamageType.TRUE,
+                fixedDamage = 100.0,
+                health = 100.0,
+                lifeStealPercent = 1.0,
+                lifeStealEfficiency = 1.0,
+            ),
+        )
+        assertEquals(0.0, trueDamage.lifeStealHealing)
+    }
+
+    @Test
+    fun `input is safe for mutation and non finite values`() {
+        val reductions = doubleArrayOf(0.5)
+        val input = DamageCalculator.Input(fixedDamage = 100.0, damageReductions = reductions)
+        reductions[0] = 0.0
+        input.damageReductions()[0] = 0.0
+        assertEquals(50.0, DamageCalculator.calculate(input).finalRoundedDamage)
+
+        val result = DamageCalculator.calculate(
+            DamageCalculator.Input(
+                attackPower = Double.NaN,
+                fixedDamage = Double.POSITIVE_INFINITY,
+                coefficient = Double.NaN,
+                defense = Double.NEGATIVE_INFINITY,
+                damageReductions = doubleArrayOf(Double.NaN),
+            ),
+        )
+        assertTrue(result.finalRoundedDamage.isFinite())
+        assertTrue(result.finalRoundedDamage >= 0.0)
+    }
+
+    @Test
+    fun `attack power and calculation are deterministic`() {
+        assertEquals(150.0, StatCalculator.attackPower(100.0, 0.0, 0.5))
+        val input = calculateInput(DamageType.PHYSICAL, 300.0)
+        assertEquals(DamageCalculator.calculate(input), DamageCalculator.calculate(input))
+    }
+
+    private fun calculate(type: DamageType, defense: Double = 0.0): DamageResult =
+        DamageCalculator.calculate(calculateInput(type, defense))
+
+    private fun calculateInput(type: DamageType, defense: Double): DamageCalculator.Input =
+        DamageCalculator.Input(damageType = type, fixedDamage = 100.0, defense = defense, health = 1_000.0)
+}


### PR DESCRIPTION
Closes #94

## Summary
- Ports the proven legacy Damage / Stat calculation semantics into a pure Kotlin domain.
- Keeps Bukkit/Minestom runtime integration out of scope.
- Preserves legacy defense, reduction, shield, lifesteal and final rounding semantics.

## Verification
- Sol Review: PASS
- Manual Smoke: not required (pure domain)
- Targeted server tests and git diff --check: PASS