### PR TITLE
Equipment / MOD Core v0: pure Kotlin legacy parity

### DIFF
--- a/server-minestom/src/main/kotlin/dev/projects/server/equipment/Equipment.kt
+++ b/server-minestom/src/main/kotlin/dev/projects/server/equipment/Equipment.kt
@@ -1,0 +1,91 @@
+package dev.projects.server.equipment
+
+import java.util.Collections
+import dev.projects.server.mod.ModSlotEntry
+
+enum class EquipmentSlot(val id: String) {
+    WEAPON("weapon"), HEAD("head"), CHEST("chest"), LEGS("legs"), BOOTS("boots"),
+    NECKLACE("necklace"), RING_1("ring_1"), RING_2("ring_2")
+}
+
+enum class EquipmentCategory {
+    WEAPON, ARMOR, ACCESSORY;
+
+    fun accepts(slot: EquipmentSlot): Boolean = when (this) {
+        WEAPON -> slot == EquipmentSlot.WEAPON
+        ARMOR -> slot in setOf(EquipmentSlot.HEAD, EquipmentSlot.CHEST, EquipmentSlot.LEGS, EquipmentSlot.BOOTS)
+        ACCESSORY -> slot in setOf(EquipmentSlot.NECKLACE, EquipmentSlot.RING_1, EquipmentSlot.RING_2)
+    }
+}
+
+enum class EquipmentTier(val minimumItemLevel: Int, val maximumItemLevel: Int) {
+    T1(1, 15), T2(16, 30), T3(31, 45);
+
+    fun contains(itemLevel: Int): Boolean = itemLevel in minimumItemLevel..maximumItemLevel
+}
+
+enum class EquipmentRarity(val modCapacity: Int) { COMMON(1), UNCOMMON(2), RARE(3), EPIC(4) }
+
+enum class EquipmentQuality { UNSPECIFIED }
+
+data class BaseStatRoll(val statId: String, val value: Double) {
+    init {
+        requireCanonicalId("statId", statId)
+        require(value.isFinite()) { "value must be finite" }
+    }
+}
+
+data class EquipmentModSlot(val index: Int, val entry: ModSlotEntry? = null) {
+    init {
+        require(index in 0..3) { "index must be 0..3" }
+        require(entry == null || entry.slotIndex == index) { "entry slot index does not match container" }
+    }
+
+    companion object { fun empty(index: Int) = EquipmentModSlot(index) }
+}
+
+class EquipmentItem(
+    val itemId: String,
+    val category: EquipmentCategory,
+    val slot: EquipmentSlot,
+    val tier: EquipmentTier,
+    val itemLevel: Int,
+    val rarity: EquipmentRarity,
+    baseStatRolls: List<BaseStatRoll>,
+    modSlots: List<EquipmentModSlot>,
+    val quality: EquipmentQuality = EquipmentQuality.UNSPECIFIED
+) {
+    val baseStatRolls: List<BaseStatRoll> = Collections.unmodifiableList(baseStatRolls.toList())
+    val modSlots: List<EquipmentModSlot> = Collections.unmodifiableList(modSlots.toList())
+
+    init {
+        require(itemId.isNotEmpty() && itemId.length <= 128 && '\u0000' !in itemId) { "invalid itemId" }
+        require(category.accepts(slot)) { "category does not accept slot" }
+        require(tier.contains(itemLevel)) { "item level is outside tier" }
+        require(modSlots.size == rarity.modCapacity) { "mod capacity mismatch" }
+        require(modSlots.map { it.index }.toSet().size == modSlots.size) { "duplicate mod slot" }
+        require(modSlots.all { it.index < rarity.modCapacity }) { "mod slot index out of range" }
+        require(baseStatRolls.map { it.statId }.toSet().size == baseStatRolls.size) { "duplicate base stat" }
+        require(quality == EquipmentQuality.UNSPECIFIED) { "unsupported quality" }
+        require(modSlots.all { it.entry == null || it.entry.rank.tier == tier }) { "MOD rank does not match tier" }
+    }
+
+}
+
+data class EquipmentValidation(val valid: Boolean, val issues: List<String>)
+
+data class EquipmentStatContribution(val statId: String, val value: Double, val sourceId: String) {
+    init {
+        requireCanonicalId("statId", statId)
+        requireCanonicalId("sourceId", sourceId)
+        require(value.isFinite()) { "value must be finite" }
+    }
+}
+
+typealias EquipmentItemV1 = EquipmentItem
+
+internal fun requireCanonicalId(name: String, value: String) {
+    require(Regex("[a-z0-9][a-z0-9_-]{0,31}:[a-z0-9][a-z0-9-]{0,63}").matches(value)) {
+        "$name must be a canonical namespaced ID"
+    }
+}

--- a/server-minestom/src/main/kotlin/dev/projects/server/mod/Mod.kt
+++ b/server-minestom/src/main/kotlin/dev/projects/server/mod/Mod.kt
@@ -1,0 +1,87 @@
+package dev.projects.server.mod
+
+import dev.projects.server.equipment.EquipmentSlot
+import dev.projects.server.equipment.EquipmentTier
+import dev.projects.server.equipment.EquipmentStatContribution
+import dev.projects.server.equipment.requireCanonicalId
+
+enum class AttackTag { MELEE, PROJECTILE, MAGIC, PHYSICAL, NORMAL_ATTACK, SKILL, SHATTER, FIRE, ICE, LIGHTNING }
+
+enum class ModRank(val value: Int, val tier: EquipmentTier) {
+    RANK_1(1, EquipmentTier.T1), RANK_2(2, EquipmentTier.T2), RANK_3(3, EquipmentTier.T3)
+}
+
+enum class ModStackingLayer { BASE_FLAT, BASE_PERCENT, INCREASED, CONDITIONAL, FINAL }
+enum class ModTagMatchPolicy { ALL_REQUIRED, EXACT }
+
+class ModDefinition(
+    val modId: String,
+    val rank: ModRank,
+    allowedSlots: Set<EquipmentSlot>,
+    requiredTags: Set<AttackTag>,
+    excludedTags: Set<AttackTag>,
+    val statId: String,
+    val minimumValue: Double,
+    val maximumValue: Double,
+    val stackingLayer: ModStackingLayer,
+    val definitionRevision: Long
+) {
+    val allowedSlots: Set<EquipmentSlot> = allowedSlots.toSet()
+    val requiredTags: Set<AttackTag> = requiredTags.toSet()
+    val excludedTags: Set<AttackTag> = excludedTags.toSet()
+
+    init {
+        requireCanonicalId("modId", modId)
+        require(allowedSlots.isNotEmpty()) { "allowedSlots must not be empty" }
+        require(requiredTags.intersect(excludedTags).isEmpty()) { "required/excluded tags overlap" }
+        requireCanonicalId("statId", statId)
+        require(minimumValue.isFinite() && maximumValue.isFinite() && minimumValue <= maximumValue) {
+            "MOD value range must be finite and ordered"
+        }
+        require(definitionRevision >= 0) { "definitionRevision must be non-negative" }
+    }
+
+    fun acceptsAttackTags(actualTags: Set<AttackTag>): Boolean {
+        if (actualTags.any { it in excludedTags }) return false
+        return actualTags == requiredTags
+    }
+}
+
+data class ModEntry(
+    val modId: String,
+    override val rank: ModRank,
+    val rolledValue: Double,
+    override val slotIndex: Int,
+    val definitionRevision: Long = 0
+) : ModSlotEntry {
+    init {
+        requireCanonicalId("modId", modId)
+        require(rolledValue.isFinite()) { "rolledValue must be finite" }
+        require(slotIndex in 0..3) { "slotIndex must be 0..3" }
+        require(definitionRevision >= 0) { "definitionRevision must be non-negative" }
+    }
+}
+
+interface ModSlotEntry {
+    val slotIndex: Int
+    val rank: ModRank
+}
+
+data class ModValidation(val valid: Boolean, val issues: List<String>, val contribution: EquipmentStatContribution? = null) {
+    companion object {
+        fun validate(entry: ModSlotEntry?, definition: ModDefinition?, equipmentSlot: EquipmentSlot): ModValidation {
+            if (entry !is ModEntry) return ModValidation(false, listOf("unsupported MOD entry"))
+            if (definition == null) return ModValidation(false, listOf("unknown MOD definition"))
+            val issues = buildList {
+                if (entry.modId != definition.modId) add("modId")
+                if (entry.rank != definition.rank) add("rank")
+                if (equipmentSlot !in definition.allowedSlots) add("equipmentSlot")
+                if (entry.definitionRevision != definition.definitionRevision) add("definitionRevision")
+                if (entry.rolledValue !in definition.minimumValue..definition.maximumValue) add("rolledValue")
+            }
+            return if (issues.isEmpty()) ModValidation(
+                true, emptyList(), EquipmentStatContribution(definition.statId, entry.rolledValue, entry.modId)
+            ) else ModValidation(false, issues)
+        }
+    }
+}

--- a/server-minestom/src/main/kotlin/dev/projects/server/mod/Mod.kt
+++ b/server-minestom/src/main/kotlin/dev/projects/server/mod/Mod.kt
@@ -24,7 +24,8 @@ class ModDefinition(
     val minimumValue: Double,
     val maximumValue: Double,
     val stackingLayer: ModStackingLayer,
-    val definitionRevision: Long
+    val definitionRevision: Long,
+    val tagMatchPolicy: ModTagMatchPolicy = ModTagMatchPolicy.EXACT
 ) {
     val allowedSlots: Set<EquipmentSlot> = allowedSlots.toSet()
     val requiredTags: Set<AttackTag> = requiredTags.toSet()
@@ -43,7 +44,10 @@ class ModDefinition(
 
     fun acceptsAttackTags(actualTags: Set<AttackTag>): Boolean {
         if (actualTags.any { it in excludedTags }) return false
-        return actualTags == requiredTags
+        return when (tagMatchPolicy) {
+            ModTagMatchPolicy.EXACT -> actualTags == requiredTags
+            ModTagMatchPolicy.ALL_REQUIRED -> actualTags.containsAll(requiredTags)
+        }
     }
 }
 

--- a/server-minestom/src/test/kotlin/dev/projects/server/equipment/EquipmentAndModFoundationTest.kt
+++ b/server-minestom/src/test/kotlin/dev/projects/server/equipment/EquipmentAndModFoundationTest.kt
@@ -1,0 +1,55 @@
+package dev.projects.server.equipment
+
+import dev.projects.server.mod.*
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class EquipmentAndModFoundationTest {
+    @Test
+    fun equipmentContractAndImmutability() {
+        assertEquals(8, EquipmentSlot.entries.size)
+        assertEquals(listOf(1, 2, 3, 4), EquipmentRarity.entries.map { it.modCapacity })
+        for (level in 1..45) assertEquals(1, EquipmentTier.entries.count { it.contains(level) })
+        assertEquals(EquipmentQuality.UNSPECIFIED, EquipmentQuality.entries.single())
+
+        val rolls = mutableListOf(BaseStatRoll("projects:physical-attack", 12.5))
+        val slots = mutableListOf(EquipmentModSlot.empty(0), EquipmentModSlot.empty(1))
+        val item = EquipmentItem("starter_sword", EquipmentCategory.WEAPON, EquipmentSlot.WEAPON,
+            EquipmentTier.T1, 1, EquipmentRarity.UNCOMMON, rolls, slots)
+        rolls.clear(); slots.clear()
+        assertEquals(1, item.baseStatRolls.size)
+        assertEquals(2, item.modSlots.size)
+        assertFailsWith<UnsupportedOperationException> { (item.baseStatRolls as MutableList).add(BaseStatRoll("projects:defense", 1.0)) }
+    }
+
+    @Test
+    fun invalidEquipmentAndModsAreRejected() {
+        assertFailsWith<IllegalArgumentException> { BaseStatRoll("projects:x", Double.NaN) }
+        assertFailsWith<IllegalArgumentException> { EquipmentModSlot.empty(4) }
+        assertFailsWith<IllegalArgumentException> {
+            EquipmentItem("bad", EquipmentCategory.WEAPON, EquipmentSlot.WEAPON, EquipmentTier.T1, 1,
+                EquipmentRarity.UNCOMMON, emptyList(), listOf(EquipmentModSlot.empty(0), EquipmentModSlot.empty(0)))
+        }
+        assertFailsWith<IllegalArgumentException> {
+            ModDefinition("projects:bad", ModRank.RANK_1, setOf(EquipmentSlot.WEAPON),
+                setOf(AttackTag.MELEE), setOf(AttackTag.MELEE), "projects:attack", 1.0, 2.0,
+                ModStackingLayer.BASE_FLAT, 0)
+        }
+    }
+
+    @Test
+    fun validationProducesExpectedContribution() {
+        val definition = ModDefinition("projects:keen-edge", ModRank.RANK_1, setOf(EquipmentSlot.WEAPON),
+            setOf(AttackTag.MELEE), setOf(AttackTag.MAGIC), "projects:physical-attack", 1.0, 3.0,
+            ModStackingLayer.BASE_FLAT, 7)
+        assertTrue(definition.acceptsAttackTags(setOf(AttackTag.MELEE)))
+        assertFalse(definition.acceptsAttackTags(setOf(AttackTag.MELEE, AttackTag.PHYSICAL)))
+        val result = ModValidation.validate(ModEntry("projects:keen-edge", ModRank.RANK_1, 2.5, 0, 7), definition, EquipmentSlot.WEAPON)
+        assertTrue(result.valid)
+        assertEquals(2.5, result.contribution!!.value)
+        assertFalse(ModValidation.validate(ModEntry("projects:keen-edge", ModRank.RANK_1, 2.5, 0, 7), definition, EquipmentSlot.HEAD).valid)
+    }
+}

--- a/server-minestom/src/test/kotlin/dev/projects/server/equipment/EquipmentAndModFoundationTest.kt
+++ b/server-minestom/src/test/kotlin/dev/projects/server/equipment/EquipmentAndModFoundationTest.kt
@@ -52,4 +52,18 @@ class EquipmentAndModFoundationTest {
         assertEquals(2.5, result.contribution!!.value)
         assertFalse(ModValidation.validate(ModEntry("projects:keen-edge", ModRank.RANK_1, 2.5, 0, 7), definition, EquipmentSlot.HEAD).valid)
     }
+
+    @Test
+    fun modTagMatchPolicyControlsRequiredTagMatching() {
+        fun definition(policy: ModTagMatchPolicy) = ModDefinition(
+            "projects:tagged", ModRank.RANK_1, setOf(EquipmentSlot.WEAPON),
+            setOf(AttackTag.MELEE), emptySet(), "projects:attack", 1.0, 2.0,
+            ModStackingLayer.BASE_FLAT, 0L, policy
+        )
+        val exact = definition(ModTagMatchPolicy.EXACT)
+        val allRequired = definition(ModTagMatchPolicy.ALL_REQUIRED)
+        val actualTags = setOf(AttackTag.MELEE, AttackTag.PHYSICAL)
+        assertFalse(exact.acceptsAttackTags(actualTags))
+        assertTrue(allRequired.acceptsAttackTags(actualTags))
+    }
 }


### PR DESCRIPTION
Closes #95

## Summary
- Ports the proven legacy Equipment / MOD domain into pure Kotlin.
- Preserves rarity MOD capacity, tier/slot validation, roll validation and tag-match semantics.
- Keeps inventory, persistence, RNG rolling, crafting and runtime integration out of scope.

## Verification
- Sol Review: PASS
- Manual Smoke: not required (pure domain)
- Targeted server tests and git diff --check: PASS