### PR TITLE
Dev Harness Hardening v0: safe auto workers and minimal CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,24 @@
+name: Build
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up JDK 25
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '25'
+          cache: gradle
+      - name: Build
+        run: ./gradlew build

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ client-fabric/run/
 server-minestom/run/
 .idea/
 *.iml
+__pycache__/
+*.pyc

--- a/opencode.jsonc
+++ b/opencode.jsonc
@@ -26,9 +26,9 @@
       "git push * --force*": "deny",
       "git push --force-with-lease*": "deny",
       "git push * --force-with-lease*": "deny",
-      "git reset --hard*": "ask",
-      "git clean*": "ask",
-      "rm -rf*": "ask"
+      "git reset --hard*": "deny",
+      "git clean*": "deny",
+      "rm -rf*": "deny"
     }
   },
 

--- a/scripts/review-context.sh
+++ b/scripts/review-context.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-BASE=${1:-main}
+BASE=${1:-origin/main}
 ROOT_DIR=$(git rev-parse --show-toplevel)
 BRANCH=$(git branch --show-current)
 HEAD_COMMIT=$(git rev-parse HEAD)


### PR DESCRIPTION
Closes #98

## Summary
- Denies destructive shell operations for non-interactive OpenCode workers.
- Uses `origin/main` as the default review base.
- Adds a minimal PR build workflow with Temurin JDK 25 and `./gradlew build`.
- Ignores Python cache artifacts.

## Verification
- Sol Review: PASS
- Manual Smoke: not required
- Local `./gradlew build`: PASS
- Workflow YAML / review-context / `git diff --check`: PASS

Merge remains gated on explicit User approval.