### PR TITLE
HUD Designer v0: live sync and lightweight snapping

### DIFF
--- a/client-fabric/src/main/kotlin/dev/projects/client/HudDesignerScreen.kt
+++ b/client-fabric/src/main/kotlin/dev/projects/client/HudDesignerScreen.kt
@@ -1,0 +1,166 @@
+package dev.projects.client
+
+import net.minecraft.client.gui.GuiGraphicsExtractor
+import net.minecraft.client.gui.components.Button
+import net.minecraft.client.gui.components.EditBox
+import net.minecraft.client.gui.screens.Screen
+import net.minecraft.client.input.KeyEvent
+import net.minecraft.client.input.MouseButtonEvent
+import net.minecraft.network.chat.Component
+import org.lwjgl.glfw.GLFW
+
+class HudDesignerScreen(
+    private val store: HudLayoutStore,
+    initialConfig: HudLayoutConfig,
+    private val onSaved: (HudLayoutConfig) -> Unit = {},
+) : Screen(Component.literal("HUD Designer")) {
+    private var config = initialConfig.copyLayouts()
+    private var selected = HudElementId.SKILLS
+    private var dragging = false
+    private var dragX = 0
+    private var dragY = 0
+    private lateinit var widthField: EditBox
+    private lateinit var heightField: EditBox
+
+    override fun isPauseScreen(): Boolean = false
+    override fun extractBackground(graphics: GuiGraphicsExtractor, mouseX: Int, mouseY: Int, delta: Float) = Unit
+
+    override fun init() {
+        widthField = addRenderableWidget(EditBox(font, width - 145, 48, 55, 18, Component.literal("Width")))
+        heightField = addRenderableWidget(EditBox(font, width - 75, 48, 55, 18, Component.literal("Height")))
+        widthField.setMaxLength(4)
+        heightField.setMaxLength(4)
+        addRenderableWidget(Button.builder(Component.literal("Center X")) { centerX() }
+            .bounds(width - 145, 74, 110, 20).build())
+        addRenderableWidget(Button.builder(Component.literal("Center Y")) { centerY() }
+            .bounds(width - 145, 98, 110, 20).build())
+        addRenderableWidget(Button.builder(Component.literal("Reset")) { config.elements[selected] = HudLayoutConfig.defaults().elements[selected]!!; syncFields() }
+            .bounds(width - 145, 122, 110, 20).build())
+        addRenderableWidget(Button.builder(Component.literal("Save")) { saveConfig() }
+            .bounds(width - 145, 146, 110, 20).build())
+        syncFields()
+    }
+
+    override fun extractRenderState(graphics: GuiGraphicsExtractor, mouseX: Int, mouseY: Int, delta: Float) {
+        super.extractRenderState(graphics, mouseX, mouseY, delta)
+        graphics.fill(width - 160, 0, width, height, 0xDD10151C.toInt())
+        graphics.text(font, "HUD Designer", width - 148, 12, 0xFFFFFFFF.toInt(), true)
+        graphics.text(font, "Width / Height", width - 145, 37, 0xFFB8C4CF.toInt(), false)
+        HudElementId.entries.forEach { id ->
+            val layout = config.elements[id]!!
+            val rect = layout.resolve(width, height)
+            val selectedColor = if (id == selected) 0xFFFFFFFF.toInt() else 0xFF78838D.toInt()
+            graphics.fill(rect.x, rect.y, rect.x + rect.width, rect.y + rect.height, 0x553F5968)
+            outline(graphics, rect, selectedColor)
+            graphics.text(font, id.label, rect.x + 3, rect.y + 3, selectedColor, false)
+        }
+        val layout = config.elements[selected]!!
+        graphics.text(font, "X ${layout.offsetX} / Y ${layout.offsetY}", width - 148, 178, 0xFFB8C4CF.toInt(), false)
+        graphics.text(font, "W ${layout.width} / H ${layout.height}", width - 148, 190, 0xFFB8C4CF.toInt(), false)
+    }
+
+    override fun mouseClicked(event: MouseButtonEvent, doubleClick: Boolean): Boolean {
+        applyDimensions()
+        val mouseX = event.x()
+        val mouseY = event.y()
+        val hit = HudElementId.entries.asReversed().firstOrNull { config.elements[it]!!.resolve(width, height).contains(mouseX, mouseY) }
+        if (hit != null) {
+            selected = hit
+            dragging = true
+            dragX = mouseX.toInt()
+            dragY = mouseY.toInt()
+            syncFields()
+            return true
+        }
+        return super.mouseClicked(event, doubleClick)
+    }
+
+    override fun mouseReleased(event: MouseButtonEvent): Boolean {
+        dragging = false
+        return super.mouseReleased(event)
+    }
+
+    override fun mouseDragged(event: MouseButtonEvent, deltaX: Double, deltaY: Double): Boolean {
+        val mouseX = event.x()
+        val mouseY = event.y()
+        if (!dragging) return super.mouseDragged(event, deltaX, deltaY)
+        val layout = config.elements[selected]!!
+        val rect = layout.resolve(width, height)
+        config.elements[selected] = layout.movedTo(rect.x + (mouseX.toInt() - this.dragX), rect.y + (mouseY.toInt() - this.dragY), width, height)
+        this.dragX = mouseX.toInt()
+        this.dragY = mouseY.toInt()
+        syncFields()
+        return true
+    }
+
+    override fun keyPressed(event: KeyEvent): Boolean {
+        val step = if (event.modifiers() and GLFW.GLFW_MOD_SHIFT != 0) 5 else 1
+        val delta = when (event.key()) {
+            GLFW.GLFW_KEY_LEFT -> -step to 0
+            GLFW.GLFW_KEY_RIGHT -> step to 0
+            GLFW.GLFW_KEY_UP -> 0 to -step
+            GLFW.GLFW_KEY_DOWN -> 0 to step
+            else -> return super.keyPressed(event)
+        }
+        val layout = config.elements[selected]!!
+        val rect = layout.resolve(width, height)
+        config.elements[selected] = layout.movedTo(rect.x + delta.first, rect.y + delta.second, width, height)
+        syncFields()
+        return true
+    }
+
+    override fun onClose() {
+        saveConfig()
+        super.onClose()
+    }
+
+    private fun syncFields() {
+        if (!::widthField.isInitialized) return
+        val layout = config.elements[selected]!!
+        widthField.setValue(layout.width.toString())
+        heightField.setValue(layout.height.toString())
+    }
+
+    private fun applyDimensions() {
+        val layout = config.elements[selected]!!
+        val newWidth = widthField.value.toIntOrNull() ?: layout.width
+        val newHeight = heightField.value.toIntOrNull() ?: layout.height
+        config.elements[selected] = layout.resized(newWidth, newHeight)
+    }
+
+    private fun updateSelected(update: HudElementLayout.() -> HudElementLayout) {
+        applyDimensions()
+        config.elements[selected] = config.elements[selected]!!.update()
+        syncFields()
+    }
+
+    private fun centerX() {
+        applyDimensions()
+        val layout = config.elements[selected]!!
+        val rect = layout.resolve(width, height)
+        config.elements[selected] = layout.movedTo((width - layout.width) / 2, rect.y, width, height)
+        syncFields()
+    }
+
+    private fun centerY() {
+        applyDimensions()
+        val layout = config.elements[selected]!!
+        val rect = layout.resolve(width, height)
+        config.elements[selected] = layout.movedTo(rect.x, (height - layout.height) / 2, width, height)
+        syncFields()
+    }
+
+    private fun saveConfig() {
+        applyDimensions()
+        store.save(config)
+        onSaved(config.copyLayouts())
+        syncFields()
+    }
+
+    private fun outline(graphics: GuiGraphicsExtractor, rect: HudRect, color: Int) {
+        graphics.fill(rect.x, rect.y, rect.x + rect.width, rect.y + 1, color)
+        graphics.fill(rect.x, rect.y + rect.height - 1, rect.x + rect.width, rect.y + rect.height, color)
+        graphics.fill(rect.x, rect.y, rect.x + 1, rect.y + rect.height, color)
+        graphics.fill(rect.x + rect.width - 1, rect.y, rect.x + rect.width, rect.y + rect.height, color)
+    }
+}

--- a/client-fabric/src/main/kotlin/dev/projects/client/HudDesignerScreen.kt
+++ b/client-fabric/src/main/kotlin/dev/projects/client/HudDesignerScreen.kt
@@ -13,12 +13,15 @@ class HudDesignerScreen(
     private val store: HudLayoutStore,
     initialConfig: HudLayoutConfig,
     private val onSaved: (HudLayoutConfig) -> Unit = {},
+    private val onChanged: (HudLayoutConfig) -> Unit = {},
 ) : Screen(Component.literal("HUD Designer")) {
     private var config = initialConfig.copyLayouts()
     private var selected = HudElementId.SKILLS
     private var dragging = false
     private var dragX = 0
     private var dragY = 0
+    private var guideX: Int? = null
+    private var guideY: Int? = null
     private lateinit var widthField: EditBox
     private lateinit var heightField: EditBox
 
@@ -34,7 +37,7 @@ class HudDesignerScreen(
             .bounds(width - 145, 74, 110, 20).build())
         addRenderableWidget(Button.builder(Component.literal("Center Y")) { centerY() }
             .bounds(width - 145, 98, 110, 20).build())
-        addRenderableWidget(Button.builder(Component.literal("Reset")) { config.elements[selected] = HudLayoutConfig.defaults().elements[selected]!!; syncFields() }
+        addRenderableWidget(Button.builder(Component.literal("Reset")) { config.elements[selected] = HudLayoutConfig.defaults().elements[selected]!!; changed() }
             .bounds(width - 145, 122, 110, 20).build())
         addRenderableWidget(Button.builder(Component.literal("Save")) { saveConfig() }
             .bounds(width - 145, 146, 110, 20).build())
@@ -54,6 +57,9 @@ class HudDesignerScreen(
             outline(graphics, rect, selectedColor)
             graphics.text(font, id.label, rect.x + 3, rect.y + 3, selectedColor, false)
         }
+        drawHotbarPreview(graphics, config.elements[HudElementId.HOTBAR]!!.resolve(width, height))
+        guideX?.let { graphics.fill(it, 0, it + 1, height, 0x8899D9FF.toInt()) }
+        guideY?.let { graphics.fill(0, it, width - CONTROL_PANEL_WIDTH, it + 1, 0x8899D9FF.toInt()) }
         val layout = config.elements[selected]!!
         graphics.text(font, "X ${layout.offsetX} / Y ${layout.offsetY}", width - 148, 178, 0xFFB8C4CF.toInt(), false)
         graphics.text(font, "W ${layout.width} / H ${layout.height}", width - 148, 190, 0xFFB8C4CF.toInt(), false)
@@ -90,9 +96,14 @@ class HudDesignerScreen(
         val layout = config.elements[selected]!!
         val rect = layout.resolve(width, height)
         config.elements[selected] = layout.movedTo(rect.x + (mouseX.toInt() - this.dragX), rect.y + (mouseY.toInt() - this.dragY), width, height)
+        val snapped = HudLayoutSnap.snap(selected, config.elements[selected]!!, config.elements, width, height)
+        config.elements[selected] = snapped.layout
+        guideX = snapped.guideX
+        guideY = snapped.guideY
         this.dragX = mouseX.toInt()
         this.dragY = mouseY.toInt()
         syncFields()
+        onChanged(config.copyLayouts())
         return true
     }
 
@@ -108,7 +119,9 @@ class HudDesignerScreen(
         val layout = config.elements[selected]!!
         val rect = layout.resolve(width, height)
         config.elements[selected] = layout.movedTo(rect.x + delta.first, rect.y + delta.second, width, height)
-        syncFields()
+        guideX = null
+        guideY = null
+        changed()
         return true
     }
 
@@ -129,12 +142,13 @@ class HudDesignerScreen(
         val newWidth = widthField.value.toIntOrNull() ?: layout.width
         val newHeight = heightField.value.toIntOrNull() ?: layout.height
         config.elements[selected] = layout.resizedFor(selected, newWidth, newHeight)
+        onChanged(config.copyLayouts())
     }
 
     private fun updateSelected(update: HudElementLayout.() -> HudElementLayout) {
         applyDimensions()
         config.elements[selected] = config.elements[selected]!!.update()
-        syncFields()
+        changed()
     }
 
     private fun centerX() {
@@ -142,7 +156,7 @@ class HudDesignerScreen(
         val layout = config.elements[selected]!!
         val rect = layout.resolve(width, height)
         config.elements[selected] = layout.movedTo((width - layout.width) / 2, rect.y, width, height)
-        syncFields()
+        changed()
     }
 
     private fun centerY() {
@@ -150,14 +164,31 @@ class HudDesignerScreen(
         val layout = config.elements[selected]!!
         val rect = layout.resolve(width, height)
         config.elements[selected] = layout.movedTo(rect.x, (height - layout.height) / 2, width, height)
-        syncFields()
+        changed()
     }
 
     private fun saveConfig() {
         applyDimensions()
         store.save(config)
         onSaved(config.copyLayouts())
+        onChanged(config.copyLayouts())
         syncFields()
+    }
+
+    private fun changed() {
+        guideX = null
+        guideY = null
+        syncFields()
+        onChanged(config.copyLayouts())
+    }
+
+    private fun drawHotbarPreview(graphics: GuiGraphicsExtractor, rect: HudRect) {
+        val slotWidth = (rect.width / 9).coerceAtLeast(1)
+        graphics.fill(rect.x, rect.y, rect.x + rect.width, rect.y + rect.height, 0xCC10151C.toInt())
+        repeat(9) { index ->
+            val x = rect.x + index * slotWidth
+            outline(graphics, HudRect(x, rect.y, slotWidth, rect.height), 0xFFB8C4CF.toInt())
+        }
     }
 
     private fun outline(graphics: GuiGraphicsExtractor, rect: HudRect, color: Int) {

--- a/client-fabric/src/main/kotlin/dev/projects/client/HudDesignerScreen.kt
+++ b/client-fabric/src/main/kotlin/dev/projects/client/HudDesignerScreen.kt
@@ -1,6 +1,7 @@
 package dev.projects.client
 
 import net.minecraft.client.gui.GuiGraphicsExtractor
+import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.components.Button
 import net.minecraft.client.gui.components.EditBox
 import net.minecraft.client.gui.screens.Screen
@@ -22,6 +23,7 @@ class HudDesignerScreen(
     private var dragY = 0
     private var guideX: Int? = null
     private var guideY: Int? = null
+    private var syncingFields = false
     private lateinit var widthField: EditBox
     private lateinit var heightField: EditBox
 
@@ -33,6 +35,8 @@ class HudDesignerScreen(
         heightField = addRenderableWidget(EditBox(font, width - 75, 48, 55, 18, Component.literal("Height")))
         widthField.setMaxLength(4)
         heightField.setMaxLength(4)
+        widthField.setResponder { if (!syncingFields) applyDimensions() }
+        heightField.setResponder { if (!syncingFields) applyDimensions() }
         addRenderableWidget(Button.builder(Component.literal("Center X")) { centerX() }
             .bounds(width - 145, 74, 110, 20).build())
         addRenderableWidget(Button.builder(Component.literal("Center Y")) { centerY() }
@@ -46,6 +50,7 @@ class HudDesignerScreen(
 
     override fun extractRenderState(graphics: GuiGraphicsExtractor, mouseX: Int, mouseY: Int, delta: Float) {
         super.extractRenderState(graphics, mouseX, mouseY, delta)
+        coverVanillaHotbar(graphics)
         graphics.fill(width - CONTROL_PANEL_WIDTH, 0, width, height, 0xDD10151C.toInt())
         graphics.text(font, "HUD Designer", width - 148, 12, 0xFFFFFFFF.toInt(), true)
         graphics.text(font, "Width / Height", width - 145, 37, 0xFFB8C4CF.toInt(), false)
@@ -86,6 +91,8 @@ class HudDesignerScreen(
 
     override fun mouseReleased(event: MouseButtonEvent): Boolean {
         dragging = false
+        guideX = null
+        guideY = null
         return super.mouseReleased(event)
     }
 
@@ -133,8 +140,13 @@ class HudDesignerScreen(
     private fun syncFields() {
         if (!::widthField.isInitialized) return
         val layout = config.elements[selected]!!
-        widthField.setValue(layout.width.toString())
-        heightField.setValue(layout.height.toString())
+        syncingFields = true
+        try {
+            widthField.setValue(layout.width.toString())
+            heightField.setValue(layout.height.toString())
+        } finally {
+            syncingFields = false
+        }
     }
 
     private fun applyDimensions() {
@@ -188,7 +200,21 @@ class HudDesignerScreen(
         repeat(9) { index ->
             val x = rect.x + index * slotWidth
             outline(graphics, HudRect(x, rect.y, slotWidth, rect.height), 0xFFB8C4CF.toInt())
+            Minecraft.getInstance().player?.inventory?.getItem(index)?.takeUnless { it.isEmpty }?.let { stack ->
+                val itemX = x + (slotWidth - 16) / 2
+                val itemY = rect.y + (rect.height - 16) / 2
+                graphics.item(stack, itemX, itemY)
+                graphics.itemDecorations(font, stack, itemX, itemY)
+            }
         }
+        Minecraft.getInstance().player?.inventory?.getSelectedSlot()?.let { index ->
+            if (index in 0..8) outline(graphics, HudRect(rect.x + index * slotWidth, rect.y, slotWidth, rect.height), 0xFFFFFF55.toInt())
+        }
+    }
+
+    private fun coverVanillaHotbar(graphics: GuiGraphicsExtractor) {
+        val vanilla = HudRect((width - 182) / 2, height - 22, 182, 22)
+        graphics.fill(vanilla.x, vanilla.y, vanilla.x + vanilla.width, vanilla.y + vanilla.height, 0xFF10151C.toInt())
     }
 
     private fun outline(graphics: GuiGraphicsExtractor, rect: HudRect, color: Int) {

--- a/client-fabric/src/main/kotlin/dev/projects/client/HudDesignerScreen.kt
+++ b/client-fabric/src/main/kotlin/dev/projects/client/HudDesignerScreen.kt
@@ -103,7 +103,14 @@ class HudDesignerScreen(
         val layout = config.elements[selected]!!
         val rect = layout.resolve(width, height)
         config.elements[selected] = layout.movedTo(rect.x + (mouseX.toInt() - this.dragX), rect.y + (mouseY.toInt() - this.dragY), width, height)
-        val snapped = HudLayoutSnap.snap(selected, config.elements[selected]!!, config.elements, width, height)
+        val snapped = HudLayoutSnap.snap(
+            selected,
+            config.elements[selected]!!,
+            config.elements,
+            width,
+            height,
+            enabled = event.modifiers() and GLFW.GLFW_MOD_ALT == 0,
+        )
         config.elements[selected] = snapped.layout
         guideX = snapped.guideX
         guideY = snapped.guideY

--- a/client-fabric/src/main/kotlin/dev/projects/client/HudDesignerScreen.kt
+++ b/client-fabric/src/main/kotlin/dev/projects/client/HudDesignerScreen.kt
@@ -43,7 +43,7 @@ class HudDesignerScreen(
 
     override fun extractRenderState(graphics: GuiGraphicsExtractor, mouseX: Int, mouseY: Int, delta: Float) {
         super.extractRenderState(graphics, mouseX, mouseY, delta)
-        graphics.fill(width - 160, 0, width, height, 0xDD10151C.toInt())
+        graphics.fill(width - CONTROL_PANEL_WIDTH, 0, width, height, 0xDD10151C.toInt())
         graphics.text(font, "HUD Designer", width - 148, 12, 0xFFFFFFFF.toInt(), true)
         graphics.text(font, "Width / Height", width - 145, 37, 0xFFB8C4CF.toInt(), false)
         HudElementId.entries.forEach { id ->
@@ -63,6 +63,9 @@ class HudDesignerScreen(
         applyDimensions()
         val mouseX = event.x()
         val mouseY = event.y()
+        if (mouseX >= width - CONTROL_PANEL_WIDTH) {
+            return super.mouseClicked(event, doubleClick)
+        }
         val hit = HudElementId.entries.asReversed().firstOrNull { config.elements[it]!!.resolve(width, height).contains(mouseX, mouseY) }
         if (hit != null) {
             selected = hit
@@ -125,7 +128,7 @@ class HudDesignerScreen(
         val layout = config.elements[selected]!!
         val newWidth = widthField.value.toIntOrNull() ?: layout.width
         val newHeight = heightField.value.toIntOrNull() ?: layout.height
-        config.elements[selected] = layout.resized(newWidth, newHeight)
+        config.elements[selected] = layout.resizedFor(selected, newWidth, newHeight)
     }
 
     private fun updateSelected(update: HudElementLayout.() -> HudElementLayout) {
@@ -162,5 +165,9 @@ class HudDesignerScreen(
         graphics.fill(rect.x, rect.y + rect.height - 1, rect.x + rect.width, rect.y + rect.height, color)
         graphics.fill(rect.x, rect.y, rect.x + 1, rect.y + rect.height, color)
         graphics.fill(rect.x + rect.width - 1, rect.y, rect.x + rect.width, rect.y + rect.height, color)
+    }
+
+    private companion object {
+        const val CONTROL_PANEL_WIDTH = 160
     }
 }

--- a/client-fabric/src/main/kotlin/dev/projects/client/HudLayout.kt
+++ b/client-fabric/src/main/kotlin/dev/projects/client/HudLayout.kt
@@ -87,6 +87,53 @@ data class HudRect(val x: Int, val y: Int, val width: Int, val height: Int) {
     )
 }
 
+data class HudSnapResult(val layout: HudElementLayout, val guideX: Int? = null, val guideY: Int? = null)
+
+object HudLayoutSnap {
+    const val THRESHOLD = 4
+
+    fun snap(
+        selected: HudElementId,
+        layout: HudElementLayout,
+        elements: Map<HudElementId, HudElementLayout>,
+        screenWidth: Int,
+        screenHeight: Int,
+    ): HudSnapResult {
+        val rect = layout.resolve(screenWidth, screenHeight)
+        val xCenterTargets = listOf(screenWidth / 2)
+        val yCenterTargets = listOf(screenHeight / 2)
+        val xAlignmentTargets = mutableListOf<Int>()
+        val yAlignmentTargets = mutableListOf<Int>()
+        elements.filterKeys { it != selected }.values.forEach { other ->
+            val otherRect = other.resolve(screenWidth, screenHeight)
+            xAlignmentTargets += listOf(otherRect.x, otherRect.x + otherRect.width / 2, otherRect.x + otherRect.width)
+            yAlignmentTargets += listOf(otherRect.y, otherRect.y + otherRect.height / 2, otherRect.y + otherRect.height)
+        }
+
+        val x = nearestSnap(rect.x, rect.width, xCenterTargets, xAlignmentTargets)
+        val y = nearestSnap(rect.y, rect.height, yCenterTargets, yAlignmentTargets)
+        return HudSnapResult(
+            layout.movedTo(x.position, y.position, screenWidth, screenHeight),
+            x.guide,
+            y.guide,
+        )
+    }
+
+    private data class AxisSnap(val position: Int, val guide: Int?)
+
+    private fun nearestSnap(start: Int, size: Int, centerTargets: List<Int>, alignmentTargets: List<Int>): AxisSnap {
+        val candidates = centerTargets.map { it - size / 2 to it } + alignmentTargets.flatMap { target ->
+            listOf(target - size / 2 to target, target - size to target, target to target)
+        }
+        val best = candidates.minByOrNull { (position, _) -> kotlin.math.abs(position - start) }
+        return if (best != null && kotlin.math.abs(best.first - start) <= THRESHOLD) {
+            AxisSnap(best.first, best.second)
+        } else {
+            AxisSnap(start, null)
+        }
+    }
+}
+
 data class HudLayoutConfig(val elements: MutableMap<HudElementId, HudElementLayout>) {
     fun copyLayouts(): HudLayoutConfig = HudLayoutConfig(elements.toMutableMap())
 

--- a/client-fabric/src/main/kotlin/dev/projects/client/HudLayout.kt
+++ b/client-fabric/src/main/kotlin/dev/projects/client/HudLayout.kt
@@ -56,8 +56,24 @@ data class HudElementLayout(
     fun resized(width: Int = this.width, height: Int = this.height): HudElementLayout =
         copy(width = width.coerceAtLeast(MIN_SIZE), height = height.coerceAtLeast(MIN_SIZE))
 
+    fun resizedFor(id: HudElementId, width: Int = this.width, height: Int = this.height): HudElementLayout =
+        copy(
+            width = width.coerceAtLeast(minimumWidth(id)),
+            height = height.coerceAtLeast(MIN_SIZE),
+        )
+
     companion object {
         const val MIN_SIZE = 4
+        const val SKILLS_SLOT_COUNT = 4
+        const val SKILLS_SLOT_GAP = 4
+        const val SKILLS_GAP_TOTAL = SKILLS_SLOT_GAP * (SKILLS_SLOT_COUNT - 1)
+        const val SKILLS_MIN_WIDTH = SKILLS_GAP_TOTAL + SKILLS_SLOT_COUNT
+
+        fun minimumWidth(id: HudElementId): Int =
+            if (id == HudElementId.SKILLS) SKILLS_MIN_WIDTH else MIN_SIZE
+
+        fun skillsSlotWidth(width: Int): Int =
+            ((width - SKILLS_GAP_TOTAL) / SKILLS_SLOT_COUNT).coerceAtLeast(1)
     }
 }
 
@@ -77,7 +93,7 @@ data class HudLayoutConfig(val elements: MutableMap<HudElementId, HudElementLayo
     companion object {
         fun defaults(): HudLayoutConfig = HudLayoutConfig(
             mutableMapOf(
-                HudElementId.SKILLS to HudElementLayout(HudAnchorX.CENTER, HudAnchorY.BOTTOM, 0, 84, 166, 28),
+                HudElementId.SKILLS to HudElementLayout(HudAnchorX.CENTER, HudAnchorY.BOTTOM, 0, 84, 94, 22),
                 HudElementId.HP to HudElementLayout(HudAnchorX.CENTER, HudAnchorY.BOTTOM, -44, 52, 82, 12),
                 HudElementId.RESOURCE to HudElementLayout(HudAnchorX.CENTER, HudAnchorY.BOTTOM, 44, 52, 82, 12),
                 HudElementId.HOTBAR to HudElementLayout(HudAnchorX.CENTER, HudAnchorY.BOTTOM, 0, 22, 182, 22),
@@ -99,9 +115,9 @@ class HudLayoutStore(private val file: Path) {
                         HudAnchorY.valueOf(json.get("anchorY").asString),
                         json.get("offsetX").asInt,
                         json.get("offsetY").asInt,
-                        json.get("width").asInt.coerceAtLeast(HudElementLayout.MIN_SIZE),
-                        json.get("height").asInt.coerceAtLeast(HudElementLayout.MIN_SIZE),
-                    )
+                        json.get("width").asInt,
+                        json.get("height").asInt,
+                    ).resizedFor(id)
                 }
             }
             config

--- a/client-fabric/src/main/kotlin/dev/projects/client/HudLayout.kt
+++ b/client-fabric/src/main/kotlin/dev/projects/client/HudLayout.kt
@@ -1,0 +1,129 @@
+package dev.projects.client
+
+import com.google.gson.JsonObject
+import com.google.gson.JsonParser
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.math.roundToInt
+
+enum class HudElementId(val label: String) {
+    SKILLS("Skills"),
+    HP("HP"),
+    RESOURCE("Resource"),
+    HOTBAR("Hotbar"),
+}
+
+enum class HudAnchorX { CENTER, LEFT, RIGHT }
+enum class HudAnchorY { BOTTOM, CENTER, TOP }
+
+data class HudElementLayout(
+    val anchorX: HudAnchorX,
+    val anchorY: HudAnchorY,
+    val offsetX: Int,
+    val offsetY: Int,
+    val width: Int,
+    val height: Int,
+) {
+    fun resolve(screenWidth: Int, screenHeight: Int): HudRect {
+        val x = when (anchorX) {
+            HudAnchorX.CENTER -> (screenWidth - width) / 2 + offsetX
+            HudAnchorX.LEFT -> offsetX
+            HudAnchorX.RIGHT -> screenWidth - width - offsetX
+        }
+        val y = when (anchorY) {
+            HudAnchorY.BOTTOM -> screenHeight - height - offsetY
+            HudAnchorY.CENTER -> (screenHeight - height) / 2 + offsetY
+            HudAnchorY.TOP -> offsetY
+        }
+        return HudRect(x, y, width, height)
+    }
+
+    fun movedTo(x: Int, y: Int, screenWidth: Int, screenHeight: Int): HudElementLayout {
+        val rect = HudRect(x, y, width, height).clamped(screenWidth, screenHeight)
+        val newX = when (anchorX) {
+            HudAnchorX.CENTER -> rect.x - (screenWidth - width) / 2
+            HudAnchorX.LEFT -> rect.x
+            HudAnchorX.RIGHT -> screenWidth - width - rect.x
+        }
+        val newY = when (anchorY) {
+            HudAnchorY.BOTTOM -> screenHeight - height - rect.y
+            HudAnchorY.CENTER -> rect.y - (screenHeight - height) / 2
+            HudAnchorY.TOP -> rect.y
+        }
+        return copy(offsetX = newX, offsetY = newY)
+    }
+
+    fun resized(width: Int = this.width, height: Int = this.height): HudElementLayout =
+        copy(width = width.coerceAtLeast(MIN_SIZE), height = height.coerceAtLeast(MIN_SIZE))
+
+    companion object {
+        const val MIN_SIZE = 4
+    }
+}
+
+data class HudRect(val x: Int, val y: Int, val width: Int, val height: Int) {
+    fun contains(mouseX: Double, mouseY: Double): Boolean =
+        mouseX >= x && mouseX < x + width && mouseY >= y && mouseY < y + height
+
+    fun clamped(screenWidth: Int, screenHeight: Int): HudRect = copy(
+        x = x.coerceIn(0, (screenWidth - width).coerceAtLeast(0)),
+        y = y.coerceIn(0, (screenHeight - height).coerceAtLeast(0)),
+    )
+}
+
+data class HudLayoutConfig(val elements: MutableMap<HudElementId, HudElementLayout>) {
+    fun copyLayouts(): HudLayoutConfig = HudLayoutConfig(elements.toMutableMap())
+
+    companion object {
+        fun defaults(): HudLayoutConfig = HudLayoutConfig(
+            mutableMapOf(
+                HudElementId.SKILLS to HudElementLayout(HudAnchorX.CENTER, HudAnchorY.BOTTOM, 0, 84, 166, 28),
+                HudElementId.HP to HudElementLayout(HudAnchorX.CENTER, HudAnchorY.BOTTOM, -44, 52, 82, 12),
+                HudElementId.RESOURCE to HudElementLayout(HudAnchorX.CENTER, HudAnchorY.BOTTOM, 44, 52, 82, 12),
+                HudElementId.HOTBAR to HudElementLayout(HudAnchorX.CENTER, HudAnchorY.BOTTOM, 0, 22, 182, 22),
+            ),
+        )
+    }
+}
+
+class HudLayoutStore(private val file: Path) {
+    fun load(): HudLayoutConfig {
+        if (!Files.exists(file)) return HudLayoutConfig.defaults()
+        return runCatching {
+            val root = JsonParser.parseString(Files.readString(file)).asJsonObject
+            val config = HudLayoutConfig.defaults()
+            config.elements.keys.forEach { id ->
+                root.getAsJsonObject(id.name.lowercase())?.let { json ->
+                    config.elements[id] = HudElementLayout(
+                        HudAnchorX.valueOf(json.get("anchorX").asString),
+                        HudAnchorY.valueOf(json.get("anchorY").asString),
+                        json.get("offsetX").asInt,
+                        json.get("offsetY").asInt,
+                        json.get("width").asInt.coerceAtLeast(HudElementLayout.MIN_SIZE),
+                        json.get("height").asInt.coerceAtLeast(HudElementLayout.MIN_SIZE),
+                    )
+                }
+            }
+            config
+        }.getOrElse { HudLayoutConfig.defaults() }
+    }
+
+    fun save(config: HudLayoutConfig) {
+        Files.createDirectories(file.parent)
+        val root = JsonObject()
+        config.elements.forEach { (id, layout) ->
+            root.add(id.name.lowercase(), JsonObject().apply {
+                addProperty("anchorX", layout.anchorX.name)
+                addProperty("anchorY", layout.anchorY.name)
+                addProperty("offsetX", layout.offsetX)
+                addProperty("offsetY", layout.offsetY)
+                addProperty("width", layout.width)
+                addProperty("height", layout.height)
+            })
+        }
+        Files.writeString(file, root.toString())
+    }
+}
+
+fun HudLayoutStore.defaultPath(gameDirectory: Path): Path =
+    gameDirectory.resolve("config").resolve("projects").resolve("hud-layout.json")

--- a/client-fabric/src/main/kotlin/dev/projects/client/HudLayout.kt
+++ b/client-fabric/src/main/kotlin/dev/projects/client/HudLayout.kt
@@ -100,14 +100,17 @@ object HudLayoutSnap {
         screenHeight: Int,
     ): HudSnapResult {
         val rect = layout.resolve(screenWidth, screenHeight)
-        val xCenterTargets = listOf(screenWidth / 2)
-        val yCenterTargets = listOf(screenHeight / 2)
+        val screenCenterX = screenWidth / 2
+        val screenCenterY = screenHeight / 2
+        val xCenterTargets = mutableListOf(screenCenterX to screenCenterX)
+        val yCenterTargets = mutableListOf(screenCenterY to screenCenterY)
         val xAlignmentTargets = mutableListOf<Int>()
         val yAlignmentTargets = mutableListOf<Int>()
         elements.filterKeys { it != selected }.values.forEach { other ->
             val otherRect = other.resolve(screenWidth, screenHeight)
             xAlignmentTargets += listOf(otherRect.x, otherRect.x + otherRect.width / 2, otherRect.x + otherRect.width)
             yAlignmentTargets += listOf(otherRect.y, otherRect.y + otherRect.height / 2, otherRect.y + otherRect.height)
+            xCenterTargets += 2 * screenCenterX - (otherRect.x + otherRect.width / 2) to screenCenterX
         }
 
         val x = nearestSnap(rect.x, rect.width, xCenterTargets, xAlignmentTargets)
@@ -121,8 +124,8 @@ object HudLayoutSnap {
 
     private data class AxisSnap(val position: Int, val guide: Int?)
 
-    private fun nearestSnap(start: Int, size: Int, centerTargets: List<Int>, alignmentTargets: List<Int>): AxisSnap {
-        val candidates = centerTargets.map { it - size / 2 to it } + alignmentTargets.flatMap { target ->
+    private fun nearestSnap(start: Int, size: Int, centerTargets: List<Pair<Int, Int>>, alignmentTargets: List<Int>): AxisSnap {
+        val candidates = centerTargets.map { (target, guide) -> target - size / 2 to guide } + alignmentTargets.flatMap { target ->
             listOf(target - size / 2 to target, target - size to target, target to target)
         }
         val best = candidates.minByOrNull { (position, _) -> kotlin.math.abs(position - start) }

--- a/client-fabric/src/main/kotlin/dev/projects/client/HudLayout.kt
+++ b/client-fabric/src/main/kotlin/dev/projects/client/HudLayout.kt
@@ -90,7 +90,7 @@ data class HudRect(val x: Int, val y: Int, val width: Int, val height: Int) {
 data class HudSnapResult(val layout: HudElementLayout, val guideX: Int? = null, val guideY: Int? = null)
 
 object HudLayoutSnap {
-    const val THRESHOLD = 4
+    const val THRESHOLD = 2
 
     fun snap(
         selected: HudElementId,
@@ -98,7 +98,9 @@ object HudLayoutSnap {
         elements: Map<HudElementId, HudElementLayout>,
         screenWidth: Int,
         screenHeight: Int,
+        enabled: Boolean = true,
     ): HudSnapResult {
+        if (!enabled) return HudSnapResult(layout)
         val rect = layout.resolve(screenWidth, screenHeight)
         val screenCenterX = screenWidth / 2
         val screenCenterY = screenHeight / 2

--- a/client-fabric/src/main/kotlin/dev/projects/client/ProjectSClient.kt
+++ b/client-fabric/src/main/kotlin/dev/projects/client/ProjectSClient.kt
@@ -76,6 +76,8 @@ object ProjectSClient : ClientModInitializer {
     private var attackDebugTicksRemaining = 0
     private var attackDebugEnabled = true
     private var slashDraftNames: List<String> = emptyList()
+    private lateinit var hudLayoutStore: HudLayoutStore
+    private var hudLayout = HudLayoutConfig.defaults()
     private val skillCategory = KeyMapping.Category.register(
         Identifier.fromNamespaceAndPath("projects", "skills"),
     )
@@ -91,6 +93,12 @@ object ProjectSClient : ClientModInitializer {
         InputConstants.KEY_F6,
         KeyMapping.Category.GAMEPLAY,
     )
+    private val hudDesignerKey = KeyMapping(
+        "key.projects.hud_designer",
+        InputConstants.Type.KEYSYM,
+        InputConstants.KEY_F7,
+        KeyMapping.Category.GAMEPLAY,
+    )
     private val skill1Key = skillKey("key.projects.skill_1", InputConstants.KEY_Z)
     private val skill2Key = skillKey("key.projects.skill_2", InputConstants.KEY_X)
     private val skill3Key = skillKey("key.projects.skill_3", InputConstants.KEY_C)
@@ -99,6 +107,7 @@ object ProjectSClient : ClientModInitializer {
     override fun onInitializeClient() {
         KeyMappingHelper.registerKeyMapping(dodgeKey)
         KeyMappingHelper.registerKeyMapping(attackDebugKey)
+        KeyMappingHelper.registerKeyMapping(hudDesignerKey)
         KeyMappingHelper.registerKeyMapping(skill1Key)
         KeyMappingHelper.registerKeyMapping(skill2Key)
         KeyMappingHelper.registerKeyMapping(skill3Key)
@@ -106,6 +115,8 @@ object ProjectSClient : ClientModInitializer {
         PayloadTypeRegistry.clientboundPlay().register(ProjectSPayload.TYPE, ProjectSPayload.CODEC)
         PayloadTypeRegistry.serverboundPlay().register(ProjectSPayload.TYPE, ProjectSPayload.CODEC)
         GroundTelegraphRenderer.register()
+        hudLayoutStore = HudLayoutStore(Minecraft.getInstance().gameDirectory.toPath().resolve("config/projects/hud-layout.json"))
+        hudLayout = hudLayoutStore.load()
 
         ClientPlayNetworking.registerGlobalReceiver(ProjectSPayload.TYPE) { payload, context ->
             try {
@@ -205,6 +216,9 @@ object ProjectSClient : ClientModInitializer {
             if (client.gui.screen() is SlashEditorScreen) client.gui.setScreen(null)
             return
         }
+        if (hudDesignerKey.consumeClick() && client.gui.screen() == null) {
+            client.gui.setScreen(HudDesignerScreen(hudLayoutStore, hudLayout) { saved -> hudLayout = saved })
+        }
         renderAttackDebugShape(client)
         if (hitMarkerTicksRemaining > 0) hitMarkerTicksRemaining--
         if (attackDebugKey.consumeClick()) {
@@ -278,11 +292,9 @@ object ProjectSClient : ClientModInitializer {
             (if (client.options.keyDown.isDown()) 1.0 else 0.0)
 
     private fun renderResourceHud(context: GuiGraphicsExtractor, tickCounter: DeltaTracker) {
-        val barWidth = 130
-        val barHeight = 5
-        val x = (context.guiWidth() - barWidth) / 2
-        val y = context.guiHeight() - 52
-        drawResourceBar(context, "MANA $mana / $maxMana", mana, maxMana, x, y, barWidth, barHeight, 0xFF4C9BFF.toInt())
+        val resource = hudLayout.elements[HudElementId.RESOURCE]!!
+        val resourceRect = resource.resolve(context.guiWidth(), context.guiHeight())
+        drawResourceBar(context, "MANA $mana / $maxMana", mana, maxMana, resourceRect.x, resourceRect.y, resourceRect.width, resourceRect.height, 0xFF4C9BFF.toInt())
         renderSkillHud(context)
         renderHitMarker(context)
     }
@@ -301,12 +313,13 @@ object ProjectSClient : ClientModInitializer {
     }
 
     private fun renderSkillHud(context: GuiGraphicsExtractor) {
-        val slotWidth = 38
-        val slotHeight = 28
+        val layout = hudLayout.elements[HudElementId.SKILLS]!!
+        val rect = layout.resolve(context.guiWidth(), context.guiHeight())
+        val slotWidth = (rect.width - 12) / 4
+        val slotHeight = rect.height
         val gap = 4
-        val totalWidth = slotWidth * 4 + gap * 3
-        val startX = (context.guiWidth() - totalWidth) / 2
-        val y = context.guiHeight() - 84
+        val startX = rect.x
+        val y = rect.y
         val slots = listOf(
             SkillHudSlot("S1", skill1Key, skill1CooldownTicks, skill1CooldownMaxTicks, true),
             SkillHudSlot("S2", skill2Key, skill2CooldownTicks, skill2CooldownMaxTicks, true),

--- a/client-fabric/src/main/kotlin/dev/projects/client/ProjectSClient.kt
+++ b/client-fabric/src/main/kotlin/dev/projects/client/ProjectSClient.kt
@@ -217,7 +217,12 @@ object ProjectSClient : ClientModInitializer {
             return
         }
         if (hudDesignerKey.consumeClick() && client.gui.screen() == null) {
-            client.gui.setScreen(HudDesignerScreen(hudLayoutStore, hudLayout) { saved -> hudLayout = saved })
+            client.gui.setScreen(
+                HudDesignerScreen(hudLayoutStore, hudLayout,
+                    onSaved = { saved -> hudLayout = saved },
+                    onChanged = { changed -> hudLayout = changed },
+                ),
+            )
         }
         renderAttackDebugShape(client)
         if (hitMarkerTicksRemaining > 0) hitMarkerTicksRemaining--

--- a/client-fabric/src/main/kotlin/dev/projects/client/ProjectSClient.kt
+++ b/client-fabric/src/main/kotlin/dev/projects/client/ProjectSClient.kt
@@ -315,9 +315,9 @@ object ProjectSClient : ClientModInitializer {
     private fun renderSkillHud(context: GuiGraphicsExtractor) {
         val layout = hudLayout.elements[HudElementId.SKILLS]!!
         val rect = layout.resolve(context.guiWidth(), context.guiHeight())
-        val slotWidth = (rect.width - 12) / 4
+        val slotWidth = HudElementLayout.skillsSlotWidth(rect.width)
         val slotHeight = rect.height
-        val gap = 4
+        val gap = HudElementLayout.SKILLS_SLOT_GAP
         val startX = rect.x
         val y = rect.y
         val slots = listOf(

--- a/client-fabric/src/test/kotlin/dev/projects/client/HudLayoutTest.kt
+++ b/client-fabric/src/test/kotlin/dev/projects/client/HudLayoutTest.kt
@@ -63,4 +63,20 @@ class HudLayoutTest {
         assertEquals(320, result.guideX)
         assertEquals(100, result.guideY)
     }
+
+    @Test
+    fun `snap mirrors another element around screen center`() {
+        val selected = HudElementLayout(HudAnchorX.LEFT, HudAnchorY.TOP, 407, 40, 20, 10)
+        val other = HudElementLayout(HudAnchorX.LEFT, HudAnchorY.TOP, 210, 40, 20, 10)
+        val result = HudLayoutSnap.snap(
+            HudElementId.RESOURCE,
+            selected,
+            mapOf(HudElementId.RESOURCE to selected, HudElementId.HP to other),
+            640,
+            360,
+        )
+
+        assertEquals(410, result.layout.resolve(640, 360).x)
+        assertEquals(320, result.guideX)
+    }
 }

--- a/client-fabric/src/test/kotlin/dev/projects/client/HudLayoutTest.kt
+++ b/client-fabric/src/test/kotlin/dev/projects/client/HudLayoutTest.kt
@@ -1,0 +1,40 @@
+package dev.projects.client
+
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class HudLayoutTest {
+    @Test
+    fun `center bottom resolves and remains inside 640x360`() {
+        val layout = HudElementLayout(HudAnchorX.CENTER, HudAnchorY.BOTTOM, 0, 22, 182, 22)
+        val rect = layout.resolve(640, 360)
+        assertEquals(HudRect(229, 316, 182, 22), rect)
+        assertTrue(rect.x >= 0 && rect.y >= 0)
+    }
+
+    @Test
+    fun `moving outside clamps and recalculates anchored offsets`() {
+        val layout = HudElementLayout(HudAnchorX.CENTER, HudAnchorY.BOTTOM, 0, 10, 80, 12)
+        val moved = layout.movedTo(-100, 500, 640, 360)
+        assertEquals(HudRect(0, 348, 80, 12), moved.resolve(640, 360))
+    }
+
+    @Test
+    fun `resize clamps invalid dimensions`() {
+        val resized = HudElementLayout(HudAnchorX.LEFT, HudAnchorY.TOP, 0, 0, 20, 20).resized(0, -3)
+        assertEquals(HudElementLayout.MIN_SIZE, resized.width)
+        assertEquals(HudElementLayout.MIN_SIZE, resized.height)
+    }
+
+    @Test
+    fun `config round trips through local store`() {
+        val directory = Files.createTempDirectory("projects-hud-test")
+        val store = HudLayoutStore(directory.resolve("config/projects/hud-layout.json"))
+        val config = HudLayoutConfig.defaults()
+        config.elements[HudElementId.HP] = HudElementLayout(HudAnchorX.RIGHT, HudAnchorY.TOP, 7, 9, 55, 11)
+        store.save(config)
+        assertEquals(config, store.load())
+    }
+}

--- a/client-fabric/src/test/kotlin/dev/projects/client/HudLayoutTest.kt
+++ b/client-fabric/src/test/kotlin/dev/projects/client/HudLayoutTest.kt
@@ -29,6 +29,15 @@ class HudLayoutTest {
     }
 
     @Test
+    fun `skills resize keeps four runtime slots usable`() {
+        val layout = HudLayoutConfig.defaults().elements[HudElementId.SKILLS]!!
+        val resized = layout.resizedFor(HudElementId.SKILLS, 4, 22)
+
+        assertEquals(HudElementLayout.SKILLS_MIN_WIDTH, resized.width)
+        assertTrue(HudElementLayout.skillsSlotWidth(resized.width) > 0)
+    }
+
+    @Test
     fun `config round trips through local store`() {
         val directory = Files.createTempDirectory("projects-hud-test")
         val store = HudLayoutStore(directory.resolve("config/projects/hud-layout.json"))

--- a/client-fabric/src/test/kotlin/dev/projects/client/HudLayoutTest.kt
+++ b/client-fabric/src/test/kotlin/dev/projects/client/HudLayoutTest.kt
@@ -66,7 +66,7 @@ class HudLayoutTest {
 
     @Test
     fun `snap mirrors another element around screen center`() {
-        val selected = HudElementLayout(HudAnchorX.LEFT, HudAnchorY.TOP, 407, 40, 20, 10)
+        val selected = HudElementLayout(HudAnchorX.LEFT, HudAnchorY.TOP, 408, 40, 20, 10)
         val other = HudElementLayout(HudAnchorX.LEFT, HudAnchorY.TOP, 210, 40, 20, 10)
         val result = HudLayoutSnap.snap(
             HudElementId.RESOURCE,
@@ -78,5 +78,46 @@ class HudLayoutTest {
 
         assertEquals(410, result.layout.resolve(640, 360).x)
         assertEquals(320, result.guideX)
+    }
+
+    @Test
+    fun `snap only applies within two pixels`() {
+        val selected = HudElementLayout(HudAnchorX.LEFT, HudAnchorY.TOP, 318, 40, 8, 8)
+        val result = HudLayoutSnap.snap(
+            HudElementId.SKILLS,
+            selected,
+            mapOf(HudElementId.SKILLS to selected),
+            640,
+            360,
+        )
+
+        assertEquals(316, result.layout.resolve(640, 360).x)
+
+        val outside = selected.copy(offsetX = 319)
+        val outsideResult = HudLayoutSnap.snap(
+            HudElementId.SKILLS,
+            outside,
+            mapOf(HudElementId.SKILLS to outside),
+            640,
+            360,
+        )
+        assertEquals(319, outsideResult.layout.resolve(640, 360).x)
+    }
+
+    @Test
+    fun `disabled snap keeps raw position within threshold`() {
+        val selected = HudElementLayout(HudAnchorX.LEFT, HudAnchorY.TOP, 318, 40, 8, 8)
+        val result = HudLayoutSnap.snap(
+            HudElementId.SKILLS,
+            selected,
+            mapOf(HudElementId.SKILLS to selected),
+            640,
+            360,
+            enabled = false,
+        )
+
+        assertEquals(318, result.layout.resolve(640, 360).x)
+        assertEquals(null, result.guideX)
+        assertEquals(null, result.guideY)
     }
 }

--- a/client-fabric/src/test/kotlin/dev/projects/client/HudLayoutTest.kt
+++ b/client-fabric/src/test/kotlin/dev/projects/client/HudLayoutTest.kt
@@ -46,4 +46,21 @@ class HudLayoutTest {
         store.save(config)
         assertEquals(config, store.load())
     }
+
+    @Test
+    fun `snap aligns to screen center and other element edges`() {
+        val selected = HudElementLayout(HudAnchorX.LEFT, HudAnchorY.TOP, 316, 97, 8, 8)
+        val other = HudElementLayout(HudAnchorX.LEFT, HudAnchorY.TOP, 100, 100, 40, 20)
+        val result = HudLayoutSnap.snap(
+            HudElementId.SKILLS,
+            selected,
+            mapOf(HudElementId.SKILLS to selected, HudElementId.HP to other),
+            640,
+            360,
+        )
+        assertEquals(316, result.layout.resolve(640, 360).x)
+        assertEquals(96, result.layout.resolve(640, 360).y)
+        assertEquals(320, result.guideX)
+        assertEquals(100, result.guideY)
+    }
 }


### PR DESCRIPTION
Closes #92

## Summary
- Adds live HUD synchronization while editing.
- Keeps the actual visible hotbar preview aligned with the edited layout.
- Adds Lunar-like alignment snapping with a reduced 2px threshold.
- Alt-drag disables snapping for unrestricted placement.
- Preserves save/load, resizing, center helpers and precise arrow movement.

## Verification
- Sol Review: PASS
- User Manual Smoke: PASS
- `:client-fabric:test`: PASS
- `:client-fabric:build`: PASS
- `git diff --check`: PASS

Merge remains gated on explicit User approval.