### PR TITLE
Equipment Presentation Bridge v0: ProjectS data on ItemStack

### DIFF
--- a/protocol/src/main/kotlin/dev/projects/protocol/EquipmentPresentation.kt
+++ b/protocol/src/main/kotlin/dev/projects/protocol/EquipmentPresentation.kt
@@ -1,0 +1,123 @@
+package dev.projects.protocol
+
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.DataInputStream
+import java.io.DataOutputStream
+import java.io.IOException
+
+const val EQUIPMENT_PRESENTATION_SCHEMA = 1
+
+data class EquipmentPresentationStat(val statId: String, val value: Double)
+
+data class EquipmentPresentationMod(
+    val slotIndex: Int,
+    val modId: String,
+    val rank: Int,
+    val rolledValue: Double,
+    val statId: String,
+    val stackingLayer: String,
+)
+
+data class EquipmentPresentationSnapshot(
+    val itemId: String,
+    val displayName: String,
+    val category: String,
+    val slot: String,
+    val tier: String,
+    val itemLevel: Int,
+    val rarity: String,
+    val baseStats: List<EquipmentPresentationStat>,
+    val installedMods: List<EquipmentPresentationMod>,
+    val schema: Int = EQUIPMENT_PRESENTATION_SCHEMA,
+) {
+    init {
+        require(schema == EQUIPMENT_PRESENTATION_SCHEMA) { "Unsupported equipment presentation schema" }
+        require(itemId.isNotBlank() && displayName.isNotBlank()) { "Equipment presentation identity is required" }
+        require(itemLevel > 0) { "Equipment presentation item level must be positive" }
+        require(baseStats.size <= 16 && installedMods.size <= 4) { "Equipment presentation has too many rows" }
+        require(baseStats.zipWithNext().all { it.first.statId < it.second.statId }) { "Base stats must be sorted" }
+        require(installedMods.zipWithNext().all { it.first.slotIndex < it.second.slotIndex }) { "MOD rows must be sorted" }
+        require(baseStats.all { it.statId.isNotBlank() && it.value.isFinite() }) { "Invalid base stat" }
+        require(installedMods.all {
+            it.slotIndex in 0..3 && it.modId.isNotBlank() && it.rank > 0 && it.rolledValue.isFinite() &&
+                it.statId.isNotBlank() && it.stackingLayer.isNotBlank()
+        }) { "Invalid MOD row" }
+    }
+}
+
+object EquipmentPresentationCodec {
+    private const val MAX_BYTES = 4096
+
+    fun encode(snapshot: EquipmentPresentationSnapshot): ByteArray = ByteArrayOutputStream().also { output ->
+        DataOutputStream(output).use { data ->
+            data.writeByte(snapshot.schema)
+            writeString(data, snapshot.itemId)
+            writeString(data, snapshot.displayName)
+            writeString(data, snapshot.category)
+            writeString(data, snapshot.slot)
+            writeString(data, snapshot.tier)
+            data.writeInt(snapshot.itemLevel)
+            writeString(data, snapshot.rarity)
+            data.writeByte(snapshot.baseStats.size)
+            snapshot.baseStats.forEach {
+                writeString(data, it.statId)
+                data.writeDouble(it.value)
+            }
+            data.writeByte(snapshot.installedMods.size)
+            snapshot.installedMods.forEach {
+                data.writeByte(it.slotIndex)
+                writeString(data, it.modId)
+                data.writeByte(it.rank)
+                data.writeDouble(it.rolledValue)
+                writeString(data, it.statId)
+                writeString(data, it.stackingLayer)
+            }
+        }
+    }.toByteArray().also { require(it.size <= MAX_BYTES) { "Equipment presentation is too large" } }
+
+    fun decodeOrNull(bytes: ByteArray): EquipmentPresentationSnapshot? = try {
+        require(bytes.size <= MAX_BYTES)
+        DataInputStream(ByteArrayInputStream(bytes)).use { input ->
+            val schema = input.readUnsignedByte()
+            val snapshot = EquipmentPresentationSnapshot(
+                itemId = readString(input),
+                displayName = readString(input),
+                category = readString(input),
+                slot = readString(input),
+                tier = readString(input),
+                itemLevel = input.readInt(),
+                rarity = readString(input),
+                baseStats = List(input.readUnsignedByte()) {
+                    EquipmentPresentationStat(readString(input), input.readDouble())
+                }.sortedBy { it.statId },
+                installedMods = List(input.readUnsignedByte()) {
+                    EquipmentPresentationMod(
+                        input.readUnsignedByte(), readString(input), input.readUnsignedByte(), input.readDouble(),
+                        readString(input), readString(input),
+                    )
+                }.sortedBy { it.slotIndex },
+                schema = schema,
+            )
+            require(input.available() == 0) { "Unexpected equipment presentation data" }
+            snapshot
+        }
+    } catch (_: IOException) {
+        null
+    } catch (_: IllegalArgumentException) {
+        null
+    }
+
+    private fun writeString(data: DataOutputStream, value: String) {
+        val bytes = value.toByteArray(Charsets.UTF_8)
+        require(bytes.size in 1..255) { "Equipment presentation string is invalid" }
+        data.writeByte(bytes.size)
+        data.write(bytes)
+    }
+
+    private fun readString(input: DataInputStream): String {
+        val size = input.readUnsignedByte()
+        require(size > 0)
+        return ByteArray(size).also(input::readFully).toString(Charsets.UTF_8)
+    }
+}

--- a/protocol/src/test/kotlin/dev/projects/protocol/EquipmentPresentationCodecTest.kt
+++ b/protocol/src/test/kotlin/dev/projects/protocol/EquipmentPresentationCodecTest.kt
@@ -1,0 +1,36 @@
+package dev.projects.protocol
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class EquipmentPresentationCodecTest {
+    private val snapshot = EquipmentPresentationSnapshot(
+        itemId = "projects:twin-blades",
+        displayName = "Twin Blades",
+        category = "weapon",
+        slot = "weapon",
+        tier = "T1",
+        itemLevel = 5,
+        rarity = "uncommon",
+        baseStats = listOf(EquipmentPresentationStat("projects:physical-attack", 12.5)),
+        installedMods = listOf(
+            EquipmentPresentationMod(0, "projects:keen-edge", 1, 2.5, "projects:physical-attack", "base_flat"),
+        ),
+    )
+
+    @Test
+    fun `snapshot codec round trips deterministically`() {
+        val first = EquipmentPresentationCodec.encode(snapshot)
+        assertEquals(first.toList(), EquipmentPresentationCodec.encode(snapshot).toList())
+        assertEquals(snapshot, EquipmentPresentationCodec.decodeOrNull(first))
+    }
+
+    @Test
+    fun `unknown and malformed schema are ignored`() {
+        val encoded = EquipmentPresentationCodec.encode(snapshot)
+        encoded[0] = 99
+        assertNull(EquipmentPresentationCodec.decodeOrNull(encoded))
+        assertNull(EquipmentPresentationCodec.decodeOrNull(byteArrayOf(1, 0)))
+    }
+}

--- a/server-minestom/src/main/kotlin/dev/projects/server/ProjectSServer.kt
+++ b/server-minestom/src/main/kotlin/dev/projects/server/ProjectSServer.kt
@@ -81,6 +81,19 @@ import dev.projects.server.particle.startParticleV2Diagnostic
 import dev.projects.server.particle.ParticleEffectHandle
 import dev.projects.server.particle.ParticleViewer
 import dev.projects.server.particle.PlayerParticleSink
+import dev.projects.server.equipment.BaseStatRoll
+import dev.projects.server.equipment.EquipmentCategory
+import dev.projects.server.equipment.EquipmentItem
+import dev.projects.server.equipment.EquipmentModSlot
+import dev.projects.server.equipment.EquipmentRarity
+import dev.projects.server.equipment.EquipmentSlot as ProjectSEquipmentSlot
+import dev.projects.server.equipment.EquipmentTier
+import dev.projects.server.equipment.toPresentationItemStack
+import dev.projects.server.mod.AttackTag
+import dev.projects.server.mod.ModDefinition
+import dev.projects.server.mod.ModEntry
+import dev.projects.server.mod.ModRank
+import dev.projects.server.mod.ModStackingLayer
 
 private const val SERVER_ADDRESS = "127.0.0.1"
 private const val SERVER_PORT = 25565
@@ -89,6 +102,41 @@ private val SUPPORTED_ATTACK_SPEEDS = setOf(1.0, 1.5, 2.0)
 private const val DODGE_PLAYER_WIDTH = 0.6
 private const val DODGE_PLAYER_HEIGHT = 1.8
 private val TWIN_BLADES_AUTO_OFFHAND = Tag.Boolean("projects_twin_blades_auto_offhand").defaultValue(false)
+
+private val TWIN_BLADES_DEFINITIONS = mapOf(
+    "projects:keen-edge" to ModDefinition(
+        modId = "projects:keen-edge",
+        rank = ModRank.RANK_1,
+        allowedSlots = setOf(ProjectSEquipmentSlot.WEAPON),
+        requiredTags = setOf(AttackTag.MELEE),
+        excludedTags = emptySet(),
+        statId = "projects:physical-attack",
+        minimumValue = 1.0,
+        maximumValue = 3.0,
+        stackingLayer = ModStackingLayer.BASE_FLAT,
+        definitionRevision = 1,
+    ),
+)
+
+private fun twinBladesItem(): EquipmentItem = EquipmentItem(
+    itemId = "projects:twin-blades",
+    category = EquipmentCategory.WEAPON,
+    slot = ProjectSEquipmentSlot.WEAPON,
+    tier = EquipmentTier.T1,
+    itemLevel = 5,
+    rarity = EquipmentRarity.UNCOMMON,
+    baseStatRolls = listOf(BaseStatRoll("projects:physical-attack", 12.5)),
+    modSlots = listOf(
+        EquipmentModSlot(0, ModEntry("projects:keen-edge", ModRank.RANK_1, 2.5, 0, 1)),
+        EquipmentModSlot.empty(1),
+    ),
+)
+
+private fun twinBladesItemStack() = twinBladesItem().toPresentationItemStack(
+    material = Material.IRON_SWORD,
+    displayName = "Twin Blades",
+    definitions = TWIN_BLADES_DEFINITIONS,
+)
 
 internal data class SkillCooldowns(
     val skill1: Int,
@@ -579,7 +627,7 @@ fun main() {
                 ItemStack.builder(Material.NETHERITE_SWORD).customName(Component.text("Heavy Blade")).build(),
             )
             event.player.inventory.addItemStack(
-                ItemStack.builder(Material.IRON_SWORD).customName(Component.text("Twin Blades")).build(),
+                twinBladesItemStack(),
             )
             if (dummy == null) {
                 dummy = Entity(EntityType.RAVAGER).apply {
@@ -1144,10 +1192,7 @@ private fun synchronizeTwinBladesOffhand(player: net.minestom.server.entity.Play
         if (offhand.isAir) {
             player.setEquipment(
                 EquipmentSlot.OFF_HAND,
-                ItemStack.builder(Material.IRON_SWORD)
-                    .customName(Component.text("Twin Blades"))
-                    .set(TWIN_BLADES_AUTO_OFFHAND, true)
-                    .build(),
+                twinBladesItemStack().withTag(TWIN_BLADES_AUTO_OFFHAND, true),
             )
         }
     } else if (offhand.getTag(TWIN_BLADES_AUTO_OFFHAND)) {

--- a/server-minestom/src/main/kotlin/dev/projects/server/equipment/EquipmentPresentationBridge.kt
+++ b/server-minestom/src/main/kotlin/dev/projects/server/equipment/EquipmentPresentationBridge.kt
@@ -1,0 +1,62 @@
+package dev.projects.server.equipment
+
+import dev.projects.protocol.EquipmentPresentationCodec
+import dev.projects.protocol.EquipmentPresentationMod
+import dev.projects.protocol.EquipmentPresentationSnapshot
+import dev.projects.protocol.EquipmentPresentationStat
+import dev.projects.server.mod.ModDefinition
+import dev.projects.server.mod.ModEntry
+import dev.projects.server.mod.ModValidation
+import net.kyori.adventure.text.Component
+import net.minestom.server.item.ItemStack
+import net.minestom.server.item.Material
+import net.minestom.server.tag.Tag
+import java.util.Base64
+
+private val PRESENTATION_TAG = Tag.String("projects_equipment_presentation")
+
+fun EquipmentItem.toPresentationSnapshot(
+    displayName: String,
+    definitions: Map<String, ModDefinition>,
+): EquipmentPresentationSnapshot = EquipmentPresentationSnapshot(
+    itemId = itemId,
+    displayName = displayName,
+    category = category.name.lowercase(),
+    slot = slot.id,
+    tier = tier.name,
+    itemLevel = itemLevel,
+    rarity = rarity.name.lowercase(),
+    baseStats = baseStatRolls.map { EquipmentPresentationStat(it.statId, it.value) }.sortedBy { it.statId },
+    installedMods = modSlots.mapNotNull { slot ->
+        val entry = slot.entry as? ModEntry ?: return@mapNotNull null
+        val definition = definitions[entry.modId] ?: return@mapNotNull null
+        if (!ModValidation.validate(entry, definition, this.slot).valid) return@mapNotNull null
+        EquipmentPresentationMod(
+            slotIndex = slot.index,
+            modId = entry.modId,
+            rank = entry.rank.value,
+            rolledValue = entry.rolledValue,
+            statId = definition.statId,
+            stackingLayer = definition.stackingLayer.name.lowercase(),
+        )
+    }.sortedBy { it.slotIndex },
+)
+
+fun EquipmentItem.toPresentationItemStack(
+    material: Material,
+    displayName: String,
+    definitions: Map<String, ModDefinition>,
+): ItemStack {
+    val encoded = Base64.getEncoder().encodeToString(
+        EquipmentPresentationCodec.encode(toPresentationSnapshot(displayName, definitions)),
+    )
+    return ItemStack.builder(material)
+        .customName(Component.text(displayName))
+        .set(PRESENTATION_TAG, encoded)
+        .build()
+}
+
+fun ItemStack.readEquipmentPresentation(): EquipmentPresentationSnapshot? =
+    getTag(PRESENTATION_TAG)?.let { encoded ->
+        runCatching { EquipmentPresentationCodec.decodeOrNull(Base64.getDecoder().decode(encoded)) }.getOrNull()
+    }

--- a/server-minestom/src/test/kotlin/dev/projects/server/equipment/EquipmentPresentationBridgeTest.kt
+++ b/server-minestom/src/test/kotlin/dev/projects/server/equipment/EquipmentPresentationBridgeTest.kt
@@ -1,0 +1,39 @@
+package dev.projects.server.equipment
+
+import dev.projects.server.mod.AttackTag
+import dev.projects.server.mod.ModDefinition
+import dev.projects.server.mod.ModEntry
+import dev.projects.server.mod.ModRank
+import dev.projects.server.mod.ModStackingLayer
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import net.minestom.server.Auth
+import net.minestom.server.MinecraftServer
+import net.minestom.server.item.Material
+
+class EquipmentPresentationBridgeTest {
+    @Test
+    fun `equipment presentation survives item stack bridge`() {
+        MinecraftServer.init(Auth.Offline())
+        val definition = ModDefinition(
+            "projects:keen-edge", ModRank.RANK_1, setOf(EquipmentSlot.WEAPON), setOf(AttackTag.MELEE),
+            emptySet(), "projects:physical-attack", 1.0, 3.0, ModStackingLayer.BASE_FLAT, 1,
+        )
+        val item = EquipmentItem(
+            "projects:twin-blades", EquipmentCategory.WEAPON, EquipmentSlot.WEAPON, EquipmentTier.T1, 5,
+            EquipmentRarity.UNCOMMON, listOf(BaseStatRoll("projects:physical-attack", 12.5)), listOf(
+                EquipmentModSlot(0, ModEntry("projects:keen-edge", ModRank.RANK_1, 2.5, 0, 1)),
+                EquipmentModSlot.empty(1),
+            ),
+        )
+
+        val restored = item.toPresentationItemStack(Material.IRON_SWORD, "Twin Blades", mapOf(definition.modId to definition))
+            .readEquipmentPresentation()
+
+        assertNotNull(restored)
+        assertEquals(item.itemId, restored.itemId)
+        assertEquals(1, restored.installedMods.size)
+        assertEquals(2.5, restored.installedMods.single().rolledValue)
+    }
+}


### PR DESCRIPTION
Closes #99

## Summary
- Adds a compact equipment presentation snapshot and shared codec.
- Bridges validated ProjectS Equipment/MOD data onto real Minecraft ItemStacks.
- Converts prototype Twin Blades to use the bridge.
- Keeps the equipment domain free of Minecraft types and leaves final tooltip rendering to #105.

## Verification
- Sol Review: PASS
- User Manual Smoke: PASS
- protocol test: PASS
- server test/build: PASS
- `git diff --check`: PASS

Merge remains gated on explicit User approval.