### PR TITLE
Production Combat HUD v0

### DIFF
--- a/client-fabric/src/main/kotlin/dev/projects/client/CooldownHud.kt
+++ b/client-fabric/src/main/kotlin/dev/projects/client/CooldownHud.kt
@@ -10,6 +10,9 @@ internal fun cooldownFillRatio(remainingTicks: Int, maxTicks: Int): Float {
 internal fun cooldownSecondsText(remainingTicks: Int): String =
     String.format(Locale.ROOT, "%.1f", remainingTicks.coerceAtLeast(0) / 20.0)
 
+internal fun skillHudReady(available: Boolean, remainingTicks: Int): Boolean =
+    available && remainingTicks == 0
+
 internal fun meterFillWidth(value: Int, maximum: Int, width: Int): Int {
     if (maximum <= 0 || width <= 0) return 0
     return (width.toLong() * value.coerceIn(0, maximum) / maximum).toInt()

--- a/client-fabric/src/main/kotlin/dev/projects/client/CooldownHud.kt
+++ b/client-fabric/src/main/kotlin/dev/projects/client/CooldownHud.kt
@@ -9,3 +9,8 @@ internal fun cooldownFillRatio(remainingTicks: Int, maxTicks: Int): Float {
 
 internal fun cooldownSecondsText(remainingTicks: Int): String =
     String.format(Locale.ROOT, "%.1f", remainingTicks.coerceAtLeast(0) / 20.0)
+
+internal fun meterFillWidth(value: Int, maximum: Int, width: Int): Int {
+    if (maximum <= 0 || width <= 0) return 0
+    return (width.toLong() * value.coerceIn(0, maximum) / maximum).toInt()
+}

--- a/client-fabric/src/main/kotlin/dev/projects/client/ProjectSClient.kt
+++ b/client-fabric/src/main/kotlin/dev/projects/client/ProjectSClient.kt
@@ -195,6 +195,9 @@ object ProjectSClient : ClientModInitializer {
             Identifier.fromNamespaceAndPath("projects", "class_resources"),
             ::renderResourceHud,
         )
+        HudElementRegistry.replaceElement(VanillaHudElements.HOTBAR) { _ ->
+            { context, tickCounter -> renderProductionHotbar(context, tickCounter) }
+        }
         ClientTickEvents.END_CLIENT_TICK.register(::handleAttackInput)
     }
 
@@ -299,7 +302,6 @@ object ProjectSClient : ClientModInitializer {
     private fun renderResourceHud(context: GuiGraphicsExtractor, tickCounter: DeltaTracker) {
         val screenWidth = context.guiWidth()
         val screenHeight = context.guiHeight()
-        renderMovedHotbar(context, hudLayout.elements[HudElementId.HOTBAR]!!.resolve(screenWidth, screenHeight))
         val resource = hudLayout.elements[HudElementId.RESOURCE]!!
         val resourceRect = resource.resolve(screenWidth, screenHeight)
         drawResourceBar(context, "MANA", mana, maxMana, resourceRect, 0xFF3F9694.toInt())
@@ -333,10 +335,10 @@ object ProjectSClient : ClientModInitializer {
         val startX = rect.x
         val y = rect.y
         val slots = listOf(
-            SkillHudSlot("S1", skill1Key, skill1CooldownTicks, skill1CooldownMaxTicks, 0),
-            SkillHudSlot("S2", skill2Key, skill2CooldownTicks, skill2CooldownMaxTicks, 1),
-            SkillHudSlot("S3", skill3Key, skill3CooldownTicks, skill3CooldownMaxTicks, 2),
-            SkillHudSlot("ULT", ultimateKey, 0, 1, 3),
+            SkillHudSlot("S1", skill1Key, skill1CooldownTicks, skill1CooldownMaxTicks, 0, true),
+            SkillHudSlot("S2", skill2Key, skill2CooldownTicks, skill2CooldownMaxTicks, 1, true),
+            SkillHudSlot("S3", skill3Key, skill3CooldownTicks, skill3CooldownMaxTicks, 2, true),
+            SkillHudSlot("ULT", ultimateKey, 0, 1, 3, false),
         )
         for ((index, slot) in slots.withIndex()) {
             val slotX = startX + index * (slotWidth + gap)
@@ -352,13 +354,17 @@ object ProjectSClient : ClientModInitializer {
         width: Int,
         height: Int,
     ) {
-        val ready = slot.remainingTicks == 0
+        val ready = skillHudReady(slot.available, slot.remainingTicks)
         context.fill(x, y, x + width, y + height, if (ready) 0xCC26383A.toInt() else 0xCC1B2026.toInt())
         outline(context, HudRect(x, y, width, height), if (ready) 0xFF638B83.toInt() else 0xFF4A4D53.toInt())
         val cooldownHeight = (height * cooldownFillRatio(slot.remainingTicks, slot.maxTicks)).toInt()
-        if (!ready && cooldownHeight > 0) context.fill(x + 1, y + 1, x + width - 1, y + cooldownHeight, 0x9A080B10.toInt())
-        val cooldownStripWidth = ((width - 2) * (1f - cooldownFillRatio(slot.remainingTicks, slot.maxTicks))).toInt()
-        context.fill(x + 1, y + height - 3, x + 1 + cooldownStripWidth, y + height - 1, if (ready) 0xFF638B83.toInt() else 0xFF68777A.toInt())
+        if (slot.available && !ready && cooldownHeight > 0) {
+            context.fill(x + 1, y + 1, x + width - 1, y + cooldownHeight, 0x9A080B10.toInt())
+        }
+        if (slot.available) {
+            val cooldownStripWidth = ((width - 2) * (1f - cooldownFillRatio(slot.remainingTicks, slot.maxTicks))).toInt()
+            context.fill(x + 1, y + height - 3, x + 1 + cooldownStripWidth, y + height - 1, if (ready) 0xFF638B83.toInt() else 0xFF68777A.toInt())
+        }
         drawSkillIcon(context, x + (width - 16) / 2, y + 2, slot.iconIndex, ready)
         val keyLabel = slot.key.getTranslatedKeyMessage().getString()
         val keyColor = if (ready) 0xFFE3E8E4.toInt() else 0xFF9AA1A4.toInt()
@@ -399,9 +405,6 @@ object ProjectSClient : ClientModInitializer {
     }
 
     private fun renderMovedHotbar(context: GuiGraphicsExtractor, rect: HudRect) {
-        val vanilla = HudRect((context.guiWidth() - 182) / 2, context.guiHeight() - 22, 182, 22)
-        if (rect == vanilla) return
-        context.fill(vanilla.x, vanilla.y, vanilla.x + vanilla.width, vanilla.y + vanilla.height, 0xFF10151C.toInt())
         val slotWidth = (rect.width / 9).coerceAtLeast(1)
         context.fill(rect.x, rect.y, rect.x + rect.width, rect.y + rect.height, 0xCC10151C.toInt())
         repeat(9) { index ->
@@ -415,6 +418,13 @@ object ProjectSClient : ClientModInitializer {
                 context.itemDecorations(Minecraft.getInstance().font, stack, itemX, itemY)
             }
         }
+    }
+
+    private fun renderProductionHotbar(context: GuiGraphicsExtractor, tickCounter: DeltaTracker) {
+        renderMovedHotbar(
+            context,
+            hudLayout.elements[HudElementId.HOTBAR]!!.resolve(context.guiWidth(), context.guiHeight()),
+        )
     }
 
     private fun outline(context: GuiGraphicsExtractor, rect: HudRect, color: Int) {
@@ -622,6 +632,7 @@ object ProjectSClient : ClientModInitializer {
         val remainingTicks: Int,
         val maxTicks: Int,
         val iconIndex: Int,
+        val available: Boolean,
     )
 
     private fun showSwingEffect(client: Minecraft, player: net.minecraft.client.player.LocalPlayer) {

--- a/client-fabric/src/main/kotlin/dev/projects/client/ProjectSClient.kt
+++ b/client-fabric/src/main/kotlin/dev/projects/client/ProjectSClient.kt
@@ -195,9 +195,6 @@ object ProjectSClient : ClientModInitializer {
             Identifier.fromNamespaceAndPath("projects", "class_resources"),
             ::renderResourceHud,
         )
-        HudElementRegistry.replaceElement(VanillaHudElements.HOTBAR) { _ ->
-            { context, tickCounter -> renderProductionHotbar(context, tickCounter) }
-        }
         ClientTickEvents.END_CLIENT_TICK.register(::handleAttackInput)
     }
 
@@ -304,10 +301,28 @@ object ProjectSClient : ClientModInitializer {
         val screenHeight = context.guiHeight()
         val resource = hudLayout.elements[HudElementId.RESOURCE]!!
         val resourceRect = resource.resolve(screenWidth, screenHeight)
-        drawResourceBar(context, "MANA", mana, maxMana, resourceRect, 0xFF3F9694.toInt())
+        drawResourceBar(
+            context,
+            "MANA",
+            mana,
+            maxMana,
+            resourceRect,
+            0xFF3F9694.toInt(),
+            0xFF245A5A.toInt(),
+            0xFF90C7BF.toInt(),
+        )
         Minecraft.getInstance().player?.let { player ->
             val hp = hudLayout.elements[HudElementId.HP]!!.resolve(screenWidth, screenHeight)
-            drawResourceBar(context, "HP", player.health.toInt(), player.maxHealth.toInt(), hp, 0xFF9B4E56.toInt())
+            drawResourceBar(
+                context,
+                "HP",
+                player.health.toInt(),
+                player.maxHealth.toInt(),
+                hp,
+                0xFF9B4E56.toInt(),
+                0xFF63353D.toInt(),
+                0xFFD18A88.toInt(),
+            )
         }
         renderSkillHud(context)
         renderHitMarker(context)
@@ -346,6 +361,49 @@ object ProjectSClient : ClientModInitializer {
         }
     }
 
+    private val skillIconPatterns = listOf(
+        listOf(
+            "00011000",
+            "00011000",
+            "00111100",
+            "01111110",
+            "01111110",
+            "00011000",
+            "00111100",
+            "01111110",
+        ),
+        listOf(
+            "00100100",
+            "01011010",
+            "10011001",
+            "01111110",
+            "01111110",
+            "10011001",
+            "01011010",
+            "00100100",
+        ),
+        listOf(
+            "00000110",
+            "00001100",
+            "00011000",
+            "00110000",
+            "01100000",
+            "11000000",
+            "01100110",
+            "00111100",
+        ),
+        listOf(
+            "00111000",
+            "01111100",
+            "11111110",
+            "01111100",
+            "00111000",
+            "00010000",
+            "00111000",
+            "00010000",
+        ),
+    )
+
     private fun drawSkillSlot(
         context: GuiGraphicsExtractor,
         slot: SkillHudSlot,
@@ -355,7 +413,13 @@ object ProjectSClient : ClientModInitializer {
         height: Int,
     ) {
         val ready = skillHudReady(slot.available, slot.remainingTicks)
-        context.fill(x, y, x + width, y + height, if (ready) 0xCC26383A.toInt() else 0xCC1B2026.toInt())
+        val background = when {
+            !slot.available -> 0xCC151B1E.toInt()
+            ready -> 0xCC26383A.toInt()
+            else -> 0xCC1B2026.toInt()
+        }
+        context.fill(x, y, x + width, y + height, background)
+        context.fill(x + 2, y + 1, x + width - 2, y + 2, if (slot.available) 0xFF657F7C.toInt() else 0xFF3B4548.toInt())
         outline(context, HudRect(x, y, width, height), if (ready) 0xFF638B83.toInt() else 0xFF4A4D53.toInt())
         val cooldownHeight = (height * cooldownFillRatio(slot.remainingTicks, slot.maxTicks)).toInt()
         if (slot.available && !ready && cooldownHeight > 0) {
@@ -365,12 +429,16 @@ object ProjectSClient : ClientModInitializer {
             val cooldownStripWidth = ((width - 2) * (1f - cooldownFillRatio(slot.remainingTicks, slot.maxTicks))).toInt()
             context.fill(x + 1, y + height - 3, x + 1 + cooldownStripWidth, y + height - 1, if (ready) 0xFF638B83.toInt() else 0xFF68777A.toInt())
         }
-        drawSkillIcon(context, x + (width - 16) / 2, y + 2, slot.iconIndex, ready)
+        drawSkillIcon(context, x + (width - 16) / 2, y + 2, slot.iconIndex, slot.available, ready)
         val keyLabel = slot.key.getTranslatedKeyMessage().getString()
-        val keyColor = if (ready) 0xFFE3E8E4.toInt() else 0xFF9AA1A4.toInt()
+        val keyColor = when {
+            !slot.available -> 0xFF687276.toInt()
+            ready -> 0xFFE3E8E4.toInt()
+            else -> 0xFF9AA1A4.toInt()
+        }
         context.text(Minecraft.getInstance().font, slot.name, x + 3, y + 3, keyColor, true)
         context.text(Minecraft.getInstance().font, keyLabel, x + 3, y + height - 10, keyColor, true)
-        if (!ready) {
+        if (slot.available && !ready) {
             val cooldown = cooldownSecondsText(slot.remainingTicks)
             context.text(Minecraft.getInstance().font, cooldown, x + width - Minecraft.getInstance().font.width(cooldown) - 2, y + height - 10, keyColor, true)
         }
@@ -382,49 +450,51 @@ object ProjectSClient : ClientModInitializer {
         value: Int,
         maximum: Int,
         rect: HudRect,
-        color: Int,
+        fillColor: Int,
+        shadowColor: Int,
+        highlightColor: Int,
     ) {
-        context.text(Minecraft.getInstance().font, label, rect.x, rect.y - 9, 0xFFD6D9D5.toInt(), true)
-        context.fill(rect.x, rect.y, rect.x + rect.width, rect.y + rect.height, 0xCC10151C.toInt())
-        val filled = meterFillWidth(value, maximum, rect.width - 2)
-        if (filled > 0) context.fill(rect.x + 1, rect.y + 1, rect.x + 1 + filled, rect.y + rect.height - 1, color)
-        context.fill(rect.x, rect.y + rect.height - 2, rect.x + rect.width, rect.y + rect.height, color)
-        outline(context, rect, 0xFF4D555A.toInt())
+        val width = rect.width.coerceAtLeast(4)
+        val height = rect.height.coerceAtLeast(4)
         val valueText = "$value / $maximum"
-        context.text(Minecraft.getInstance().font, valueText, rect.x + rect.width - Minecraft.getInstance().font.width(valueText) - 2, rect.y + 2, 0xFFE8EAE7.toInt(), true)
-    }
+        context.text(Minecraft.getInstance().font, label, rect.x, rect.y - 9, highlightColor, true)
+        context.fill(rect.x, rect.y, rect.x + width, rect.y + height, 0xCC0D1418.toInt())
+        outline(context, HudRect(rect.x, rect.y, width, height), 0xFF414C50.toInt())
 
-    private fun drawSkillIcon(context: GuiGraphicsExtractor, x: Int, y: Int, index: Int, ready: Boolean) {
-        val color = if (ready) 0xFFB5D1C8.toInt() else 0xFF68777A.toInt()
-        val pattern = listOf("0110", "1111", "0110", "1001", "0110")
-        pattern.forEachIndexed { row, line -> line.forEachIndexed { column, pixel ->
-            if (pixel == '1' && ((column + row + index) % 2 == 0 || index == 3)) {
-                context.fill(x + column * 3, y + row * 3, x + column * 3 + 3, y + row * 3 + 3, color)
+        if (width >= 8 && height >= 8) {
+            context.fill(rect.x + 2, rect.y + 2, rect.x + width - 2, rect.y + height - 2, 0xD8192428.toInt())
+            context.fill(rect.x + 2, rect.y + 2, rect.x + width - 2, rect.y + 3, 0xFF667276.toInt())
+            context.fill(rect.x + 2, rect.y + height - 3, rect.x + width - 2, rect.y + height - 2, 0xFF0B1013.toInt())
+            val filled = meterFillWidth(value, maximum, width - 4)
+            if (filled > 0) {
+                val fillEnd = rect.x + 2 + filled
+                context.fill(rect.x + 2, rect.y + 3, fillEnd, rect.y + height - 3, shadowColor)
+                context.fill(rect.x + 2, rect.y + 3, fillEnd, rect.y + 4, highlightColor)
+                context.fill(rect.x + 2, rect.y + 4, fillEnd, rect.y + height - 3, fillColor)
+                context.fill(fillEnd - 1, rect.y + 3, fillEnd, rect.y + height - 3, highlightColor)
             }
-        } }
+        } else {
+            val filled = meterFillWidth(value, maximum, (width - 2).coerceAtLeast(0))
+            if (filled > 0) context.fill(rect.x + 1, rect.y + 1, rect.x + 1 + filled, rect.y + height - 1, fillColor)
+        }
+
+        context.text(Minecraft.getInstance().font, valueText, rect.x + width - Minecraft.getInstance().font.width(valueText) - 3, rect.y + 2, 0xFFE8EAE7.toInt(), true)
     }
 
-    private fun renderMovedHotbar(context: GuiGraphicsExtractor, rect: HudRect) {
-        val slotWidth = (rect.width / 9).coerceAtLeast(1)
-        context.fill(rect.x, rect.y, rect.x + rect.width, rect.y + rect.height, 0xCC10151C.toInt())
-        repeat(9) { index ->
-            val slot = HudRect(rect.x + index * slotWidth, rect.y, slotWidth, rect.height)
-            val selected = index == Minecraft.getInstance().player?.inventory?.getSelectedSlot()
-            outline(context, slot, if (selected) 0xFFE0D58A.toInt() else 0xFF50585D.toInt())
-            Minecraft.getInstance().player?.inventory?.getItem(index)?.takeUnless { it.isEmpty }?.let { stack ->
-                val itemX = slot.x + (slot.width - 16) / 2
-                val itemY = slot.y + (slot.height - 16) / 2
-                context.item(stack, itemX, itemY)
-                context.itemDecorations(Minecraft.getInstance().font, stack, itemX, itemY)
+    private fun drawSkillIcon(context: GuiGraphicsExtractor, x: Int, y: Int, index: Int, available: Boolean, ready: Boolean) {
+        val color = when {
+            !available -> 0xFF4D585B.toInt()
+            ready -> 0xFFB5D1C8.toInt()
+            else -> 0xFF68777A.toInt()
+        }
+        val pattern = skillIconPatterns[index.coerceIn(0, skillIconPatterns.lastIndex)]
+        pattern.forEachIndexed { row, line ->
+            line.forEachIndexed { column, pixel ->
+                if (pixel == '1') {
+                    context.fill(x + column * 2, y + row * 2, x + column * 2 + 2, y + row * 2 + 2, color)
+                }
             }
         }
-    }
-
-    private fun renderProductionHotbar(context: GuiGraphicsExtractor, tickCounter: DeltaTracker) {
-        renderMovedHotbar(
-            context,
-            hudLayout.elements[HudElementId.HOTBAR]!!.resolve(context.guiWidth(), context.guiHeight()),
-        )
     }
 
     private fun outline(context: GuiGraphicsExtractor, rect: HudRect, color: Int) {

--- a/client-fabric/src/main/kotlin/dev/projects/client/ProjectSClient.kt
+++ b/client-fabric/src/main/kotlin/dev/projects/client/ProjectSClient.kt
@@ -297,9 +297,16 @@ object ProjectSClient : ClientModInitializer {
             (if (client.options.keyDown.isDown()) 1.0 else 0.0)
 
     private fun renderResourceHud(context: GuiGraphicsExtractor, tickCounter: DeltaTracker) {
+        val screenWidth = context.guiWidth()
+        val screenHeight = context.guiHeight()
+        renderMovedHotbar(context, hudLayout.elements[HudElementId.HOTBAR]!!.resolve(screenWidth, screenHeight))
         val resource = hudLayout.elements[HudElementId.RESOURCE]!!
-        val resourceRect = resource.resolve(context.guiWidth(), context.guiHeight())
-        drawResourceBar(context, "MANA $mana / $maxMana", mana, maxMana, resourceRect.x, resourceRect.y, resourceRect.width, resourceRect.height, 0xFF4C9BFF.toInt())
+        val resourceRect = resource.resolve(screenWidth, screenHeight)
+        drawResourceBar(context, "MANA", mana, maxMana, resourceRect, 0xFF3F9694.toInt())
+        Minecraft.getInstance().player?.let { player ->
+            val hp = hudLayout.elements[HudElementId.HP]!!.resolve(screenWidth, screenHeight)
+            drawResourceBar(context, "HP", player.health.toInt(), player.maxHealth.toInt(), hp, 0xFF9B4E56.toInt())
+        }
         renderSkillHud(context)
         renderHitMarker(context)
     }
@@ -326,10 +333,10 @@ object ProjectSClient : ClientModInitializer {
         val startX = rect.x
         val y = rect.y
         val slots = listOf(
-            SkillHudSlot("S1", skill1Key, skill1CooldownTicks, skill1CooldownMaxTicks, true),
-            SkillHudSlot("S2", skill2Key, skill2CooldownTicks, skill2CooldownMaxTicks, true),
-            SkillHudSlot("S3", skill3Key, skill3CooldownTicks, skill3CooldownMaxTicks, true),
-            SkillHudSlot("ULT", ultimateKey, 0, 1, false),
+            SkillHudSlot("S1", skill1Key, skill1CooldownTicks, skill1CooldownMaxTicks, 0),
+            SkillHudSlot("S2", skill2Key, skill2CooldownTicks, skill2CooldownMaxTicks, 1),
+            SkillHudSlot("S3", skill3Key, skill3CooldownTicks, skill3CooldownMaxTicks, 2),
+            SkillHudSlot("ULT", ultimateKey, 0, 1, 3),
         )
         for ((index, slot) in slots.withIndex()) {
             val slotX = startX + index * (slotWidth + gap)
@@ -345,33 +352,22 @@ object ProjectSClient : ClientModInitializer {
         width: Int,
         height: Int,
     ) {
-        val ready = slot.implemented && slot.remainingTicks == 0
-        val background = if (ready) 0xDD1E6B78.toInt() else 0xDD18202A.toInt()
-        context.fill(x, y, x + width, y + height, background)
-        if (!ready) {
-            val fillHeight = (height * cooldownFillRatio(slot.remainingTicks, slot.maxTicks)).toInt()
-            if (fillHeight > 0) {
-                context.fill(x, y, x + width, y + fillHeight, 0xAA080B10.toInt())
-            }
-        }
+        val ready = slot.remainingTicks == 0
+        context.fill(x, y, x + width, y + height, if (ready) 0xCC26383A.toInt() else 0xCC1B2026.toInt())
+        outline(context, HudRect(x, y, width, height), if (ready) 0xFF638B83.toInt() else 0xFF4A4D53.toInt())
+        val cooldownHeight = (height * cooldownFillRatio(slot.remainingTicks, slot.maxTicks)).toInt()
+        if (!ready && cooldownHeight > 0) context.fill(x + 1, y + 1, x + width - 1, y + cooldownHeight, 0x9A080B10.toInt())
+        val cooldownStripWidth = ((width - 2) * (1f - cooldownFillRatio(slot.remainingTicks, slot.maxTicks))).toInt()
+        context.fill(x + 1, y + height - 3, x + 1 + cooldownStripWidth, y + height - 1, if (ready) 0xFF638B83.toInt() else 0xFF68777A.toInt())
+        drawSkillIcon(context, x + (width - 16) / 2, y + 2, slot.iconIndex, ready)
         val keyLabel = slot.key.getTranslatedKeyMessage().getString()
-        val keyColor = if (slot.implemented) 0xFFFFFFFF.toInt() else 0xFF707780.toInt()
+        val keyColor = if (ready) 0xFFE3E8E4.toInt() else 0xFF9AA1A4.toInt()
         context.text(Minecraft.getInstance().font, slot.name, x + 3, y + 3, keyColor, true)
         context.text(Minecraft.getInstance().font, keyLabel, x + 3, y + height - 10, keyColor, true)
-        val centerText = when {
-            !slot.implemented -> "--"
-            ready -> "READY"
-            else -> cooldownSecondsText(slot.remainingTicks)
+        if (!ready) {
+            val cooldown = cooldownSecondsText(slot.remainingTicks)
+            context.text(Minecraft.getInstance().font, cooldown, x + width - Minecraft.getInstance().font.width(cooldown) - 2, y + height - 10, keyColor, true)
         }
-        val textWidth = Minecraft.getInstance().font.width(centerText)
-        context.text(
-            Minecraft.getInstance().font,
-            centerText,
-            x + (width - textWidth) / 2,
-            y + 9,
-            keyColor,
-            true,
-        )
     }
 
     private fun drawResourceBar(
@@ -379,16 +375,53 @@ object ProjectSClient : ClientModInitializer {
         label: String,
         value: Int,
         maximum: Int,
-        x: Int,
-        y: Int,
-        width: Int,
-        height: Int,
+        rect: HudRect,
         color: Int,
     ) {
-        context.fill(x, y, x + width, y + height, 0xAA10151C.toInt())
-        val filled = if (maximum > 0) width * value.coerceIn(0, maximum) / maximum else 0
-        if (filled > 0) context.fill(x, y, x + filled, y + height, color)
-        context.text(Minecraft.getInstance().font, label, x, y + 6, 0xFFFFFFFF.toInt(), true)
+        context.text(Minecraft.getInstance().font, label, rect.x, rect.y - 9, 0xFFD6D9D5.toInt(), true)
+        context.fill(rect.x, rect.y, rect.x + rect.width, rect.y + rect.height, 0xCC10151C.toInt())
+        val filled = meterFillWidth(value, maximum, rect.width - 2)
+        if (filled > 0) context.fill(rect.x + 1, rect.y + 1, rect.x + 1 + filled, rect.y + rect.height - 1, color)
+        context.fill(rect.x, rect.y + rect.height - 2, rect.x + rect.width, rect.y + rect.height, color)
+        outline(context, rect, 0xFF4D555A.toInt())
+        val valueText = "$value / $maximum"
+        context.text(Minecraft.getInstance().font, valueText, rect.x + rect.width - Minecraft.getInstance().font.width(valueText) - 2, rect.y + 2, 0xFFE8EAE7.toInt(), true)
+    }
+
+    private fun drawSkillIcon(context: GuiGraphicsExtractor, x: Int, y: Int, index: Int, ready: Boolean) {
+        val color = if (ready) 0xFFB5D1C8.toInt() else 0xFF68777A.toInt()
+        val pattern = listOf("0110", "1111", "0110", "1001", "0110")
+        pattern.forEachIndexed { row, line -> line.forEachIndexed { column, pixel ->
+            if (pixel == '1' && ((column + row + index) % 2 == 0 || index == 3)) {
+                context.fill(x + column * 3, y + row * 3, x + column * 3 + 3, y + row * 3 + 3, color)
+            }
+        } }
+    }
+
+    private fun renderMovedHotbar(context: GuiGraphicsExtractor, rect: HudRect) {
+        val vanilla = HudRect((context.guiWidth() - 182) / 2, context.guiHeight() - 22, 182, 22)
+        if (rect == vanilla) return
+        context.fill(vanilla.x, vanilla.y, vanilla.x + vanilla.width, vanilla.y + vanilla.height, 0xFF10151C.toInt())
+        val slotWidth = (rect.width / 9).coerceAtLeast(1)
+        context.fill(rect.x, rect.y, rect.x + rect.width, rect.y + rect.height, 0xCC10151C.toInt())
+        repeat(9) { index ->
+            val slot = HudRect(rect.x + index * slotWidth, rect.y, slotWidth, rect.height)
+            val selected = index == Minecraft.getInstance().player?.inventory?.getSelectedSlot()
+            outline(context, slot, if (selected) 0xFFE0D58A.toInt() else 0xFF50585D.toInt())
+            Minecraft.getInstance().player?.inventory?.getItem(index)?.takeUnless { it.isEmpty }?.let { stack ->
+                val itemX = slot.x + (slot.width - 16) / 2
+                val itemY = slot.y + (slot.height - 16) / 2
+                context.item(stack, itemX, itemY)
+                context.itemDecorations(Minecraft.getInstance().font, stack, itemX, itemY)
+            }
+        }
+    }
+
+    private fun outline(context: GuiGraphicsExtractor, rect: HudRect, color: Int) {
+        context.fill(rect.x, rect.y, rect.x + rect.width, rect.y + 1, color)
+        context.fill(rect.x, rect.y + rect.height - 1, rect.x + rect.width, rect.y + rect.height, color)
+        context.fill(rect.x, rect.y, rect.x + 1, rect.y + rect.height, color)
+        context.fill(rect.x + rect.width - 1, rect.y, rect.x + rect.width, rect.y + rect.height, color)
     }
 
     private fun renderAttackDebugShape(client: Minecraft) {
@@ -588,7 +621,7 @@ object ProjectSClient : ClientModInitializer {
         val key: KeyMapping,
         val remainingTicks: Int,
         val maxTicks: Int,
-        val implemented: Boolean,
+        val iconIndex: Int,
     )
 
     private fun showSwingEffect(client: Minecraft, player: net.minecraft.client.player.LocalPlayer) {

--- a/client-fabric/src/main/kotlin/dev/projects/client/ProjectSClient.kt
+++ b/client-fabric/src/main/kotlin/dev/projects/client/ProjectSClient.kt
@@ -350,10 +350,10 @@ object ProjectSClient : ClientModInitializer {
         val startX = rect.x
         val y = rect.y
         val slots = listOf(
-            SkillHudSlot("S1", skill1Key, skill1CooldownTicks, skill1CooldownMaxTicks, 0, true),
-            SkillHudSlot("S2", skill2Key, skill2CooldownTicks, skill2CooldownMaxTicks, 1, true),
-            SkillHudSlot("S3", skill3Key, skill3CooldownTicks, skill3CooldownMaxTicks, 2, true),
-            SkillHudSlot("ULT", ultimateKey, 0, 1, 3, false),
+            SkillHudSlot(skill1CooldownTicks, skill1CooldownMaxTicks, 0, true),
+            SkillHudSlot(skill2CooldownTicks, skill2CooldownMaxTicks, 1, true),
+            SkillHudSlot(skill3CooldownTicks, skill3CooldownMaxTicks, 2, true),
+            SkillHudSlot(0, 1, 3, false),
         )
         for ((index, slot) in slots.withIndex()) {
             val slotX = startX + index * (slotWidth + gap)
@@ -430,18 +430,6 @@ object ProjectSClient : ClientModInitializer {
             context.fill(x + 1, y + height - 3, x + 1 + cooldownStripWidth, y + height - 1, if (ready) 0xFF638B83.toInt() else 0xFF68777A.toInt())
         }
         drawSkillIcon(context, x + (width - 16) / 2, y + 2, slot.iconIndex, slot.available, ready)
-        val keyLabel = slot.key.getTranslatedKeyMessage().getString()
-        val keyColor = when {
-            !slot.available -> 0xFF687276.toInt()
-            ready -> 0xFFE3E8E4.toInt()
-            else -> 0xFF9AA1A4.toInt()
-        }
-        context.text(Minecraft.getInstance().font, slot.name, x + 3, y + 3, keyColor, true)
-        context.text(Minecraft.getInstance().font, keyLabel, x + 3, y + height - 10, keyColor, true)
-        if (slot.available && !ready) {
-            val cooldown = cooldownSecondsText(slot.remainingTicks)
-            context.text(Minecraft.getInstance().font, cooldown, x + width - Minecraft.getInstance().font.width(cooldown) - 2, y + height - 10, keyColor, true)
-        }
     }
 
     private fun drawResourceBar(
@@ -697,8 +685,6 @@ object ProjectSClient : ClientModInitializer {
     )
 
     private data class SkillHudSlot(
-        val name: String,
-        val key: KeyMapping,
         val remainingTicks: Int,
         val maxTicks: Int,
         val iconIndex: Int,

--- a/client-fabric/src/main/kotlin/dev/projects/client/ProjectSClient.kt
+++ b/client-fabric/src/main/kotlin/dev/projects/client/ProjectSClient.kt
@@ -195,6 +195,12 @@ object ProjectSClient : ClientModInitializer {
             Identifier.fromNamespaceAndPath("projects", "class_resources"),
             ::renderResourceHud,
         )
+        HudElementRegistry.replaceElement(VanillaHudElements.HEALTH_BAR) { _ ->
+            { _, _ -> }
+        }
+        HudElementRegistry.replaceElement(VanillaHudElements.FOOD_BAR) { _ ->
+            { _, _ -> }
+        }
         ClientTickEvents.END_CLIENT_TICK.register(::handleAttackInput)
     }
 

--- a/client-fabric/src/test/kotlin/dev/projects/client/CooldownHudTest.kt
+++ b/client-fabric/src/test/kotlin/dev/projects/client/CooldownHudTest.kt
@@ -19,6 +19,13 @@ class CooldownHudTest {
     }
 
     @Test
+    fun `unavailable skill is not ready`() {
+        assertEquals(false, skillHudReady(false, 0))
+        assertEquals(true, skillHudReady(true, 0))
+        assertEquals(false, skillHudReady(true, 1))
+    }
+
+    @Test
     fun `meter fill is clamped to its layout width`() {
         assertEquals(0, meterFillWidth(0, 100, 82))
         assertEquals(41, meterFillWidth(50, 100, 82))

--- a/client-fabric/src/test/kotlin/dev/projects/client/CooldownHudTest.kt
+++ b/client-fabric/src/test/kotlin/dev/projects/client/CooldownHudTest.kt
@@ -17,4 +17,12 @@ class CooldownHudTest {
         assertEquals("2.4", cooldownSecondsText(48))
         assertEquals("0.0", cooldownSecondsText(0))
     }
+
+    @Test
+    fun `meter fill is clamped to its layout width`() {
+        assertEquals(0, meterFillWidth(0, 100, 82))
+        assertEquals(41, meterFillWidth(50, 100, 82))
+        assertEquals(82, meterFillWidth(120, 100, 82))
+        assertEquals(0, meterFillWidth(20, 0, 82))
+    }
 }


### PR DESCRIPTION
Closes #104

## Summary
- ProjectS production HP/Mana pixel bars
- icon-first S1/S2/S3/ULT HUD
- Vanilla Hotbar preserved
- Vanilla Health/Food HUD hidden in favor of ProjectS HP/Mana
- #92 HUD layout remains the production layout source

## Validation
- `./gradlew :client-fabric:test :client-fabric:build` PASS
- `git diff --check` PASS
- Sol Product / Architecture Gate PASS
- User Manual Smoke PASS

## Follow-up
- Current skill glyphs are accepted for v0; authored image assets can replace them later.

Merge is intentionally left for explicit User approval.