### PR TITLE
feat: add global player progression v0

### DIFF
--- a/client-fabric/src/main/kotlin/dev/projects/client/ProgressionTreeLayout.kt
+++ b/client-fabric/src/main/kotlin/dev/projects/client/ProgressionTreeLayout.kt
@@ -1,0 +1,66 @@
+package dev.projects.client
+
+import kotlin.math.min
+
+data class ProgressionTreeLayout(
+    val panel: HudRect,
+    val detail: HudRect,
+    val purchase: HudRect,
+    val notice: HudRect,
+    val footer: HudRect,
+    val compact: Boolean,
+)
+
+data class ProgressionTreeNodePosition(val x: Int, val y: Int)
+
+fun progressionTreeLayout(screenWidth: Int, screenHeight: Int): ProgressionTreeLayout {
+    require(screenWidth > 0 && screenHeight > 0) { "Progression tree viewport must be positive" }
+    val panelWidth = min(560, (screenWidth - 16).coerceAtLeast(120))
+    val compact = panelWidth < 500
+    val panelHeight = min(if (compact) 430 else 320, (screenHeight - 16).coerceAtLeast(120))
+    val panel = HudRect(
+        x = (screenWidth - panelWidth) / 2,
+        y = (screenHeight - panelHeight) / 2,
+        width = panelWidth,
+        height = panelHeight,
+    )
+    val footer = HudRect(panel.x + 16, panel.bottom - 18, panel.width - 32, 10)
+    val notice = HudRect(panel.x + 16, footer.y - 18, panel.width - 32, 10)
+
+    if (!compact) {
+        return ProgressionTreeLayout(
+            panel = panel,
+            detail = HudRect(panel.x + 330, panel.y + 48, panel.width - 344, 172),
+            purchase = HudRect(panel.x + 350, panel.y + 236, 110, 20),
+            notice = notice,
+            footer = footer,
+            compact = false,
+        )
+    }
+
+    // Keep the detail column beside the tree so short GUI viewports do not overflow vertically.
+    val detailWidth = (panel.width - 314).coerceAtLeast(120)
+    val purchaseY = notice.y - 28
+    val detailTop = panel.y + 48
+    val detail = HudRect(panel.x + panel.width - detailWidth - 14, detailTop, detailWidth, (purchaseY - detailTop - 8).coerceAtLeast(80))
+    return ProgressionTreeLayout(
+        panel = panel,
+        detail = detail,
+        purchase = HudRect(detail.x, purchaseY, min(110, detail.width), 20),
+        notice = notice,
+        footer = footer,
+        compact = true,
+    )
+}
+
+fun progressionTreeNodePositions(panel: HudRect): Map<String, ProgressionTreeNodePosition> = mapOf(
+    "projects:passive/force" to ProgressionTreeNodePosition(panel.x + 112, panel.y + 174),
+    "projects:passive/overpower" to ProgressionTreeNodePosition(panel.x + 62, panel.y + 124),
+    "projects:passive/tempo" to ProgressionTreeNodePosition(panel.x + 232, panel.y + 174),
+    "projects:passive/flow" to ProgressionTreeNodePosition(panel.x + 282, panel.y + 124),
+    "projects:passive/vitality" to ProgressionTreeNodePosition(panel.x + 172, panel.y + 124),
+    "projects:passive/guard" to ProgressionTreeNodePosition(panel.x + 172, panel.y + 74),
+)
+
+private val HudRect.bottom: Int
+    get() = y + height

--- a/client-fabric/src/main/kotlin/dev/projects/client/ProgressionTreeScreen.kt
+++ b/client-fabric/src/main/kotlin/dev/projects/client/ProgressionTreeScreen.kt
@@ -1,0 +1,266 @@
+package dev.projects.client
+
+import dev.projects.protocol.PassiveNodeSpendRequest
+import dev.projects.protocol.PassiveNodeSpendResponse
+import dev.projects.protocol.PassiveNodeSpendResult
+import dev.projects.protocol.ProgressionSnapshot
+import net.minecraft.client.gui.GuiGraphicsExtractor
+import net.minecraft.client.gui.components.Button
+import net.minecraft.client.gui.screens.Screen
+import net.minecraft.client.input.KeyEvent
+import net.minecraft.client.input.MouseButtonEvent
+import net.minecraft.network.chat.Component
+import org.lwjgl.glfw.GLFW
+import kotlin.math.abs
+import kotlin.math.max
+import kotlin.math.min
+
+class ProgressionTreeScreen(
+    initialSnapshot: ProgressionSnapshot,
+    private val sendMessage: (PassiveNodeSpendRequest) -> Unit,
+) : Screen(Component.literal("Global Passive Tree")) {
+    private var snapshot = initialSnapshot
+    private var selectedNodeId: String? = null
+    private var notice: String? = null
+    private var purchaseButton: Button? = null
+
+    override fun isPauseScreen(): Boolean = false
+
+    override fun extractBackground(graphics: GuiGraphicsExtractor, mouseX: Int, mouseY: Int, delta: Float) = Unit
+
+    override fun init() {
+        purchaseButton = addRenderableWidget(
+            Button.builder(Component.literal("取得")) { purchaseSelected() }
+                .bounds(
+                    if (isCompact()) panelLeft() + panelWidth() - 124 else panelLeft() + 350,
+                    if (isCompact()) panelTop() + panelHeight() - 44 else panelTop() + 236,
+                    110,
+                    20,
+                )
+                .build(),
+        )
+        updatePurchaseButton()
+    }
+
+    override fun extractRenderState(graphics: GuiGraphicsExtractor, mouseX: Int, mouseY: Int, delta: Float) {
+        super.extractRenderState(graphics, mouseX, mouseY, delta)
+        val left = panelLeft()
+        val top = panelTop()
+        val panelWidth = panelWidth()
+        val panelHeight = panelHeight()
+        graphics.fill(0, 0, width, height, 0x88060A0D.toInt())
+        graphics.fill(left, top, left + panelWidth, top + panelHeight, 0xF0131B20.toInt())
+        graphics.fill(left, top, left + 2, top + panelHeight, 0xFF638B83.toInt())
+        outline(graphics, HudRect(left, top, panelWidth, panelHeight), 0xFF4E625F.toInt())
+        graphics.text(font, "GLOBAL PASSIVE TREE", left + 16, top + 12, 0xFFE5F0E9.toInt(), true)
+        graphics.text(font, "Kで閉じる / サーバーが状態を確定", left + 16, top + 27, 0xFF91AAA3.toInt(), false)
+
+        val available = snapshot.grantedPassivePoints - snapshot.spentPassivePoints
+        graphics.text(
+            font,
+            "Lv ${snapshot.level}   XP ${snapshot.xp} / ${snapshot.xpRequiredForNextLevel}   Point $available",
+            left + 16,
+            top + panelHeight - 22,
+            if (available > 0) 0xFFE5C878.toInt() else 0xFFAFC0BA.toInt(),
+            true,
+        )
+
+        val positions = nodePositions(left, top)
+        drawConnections(graphics, positions)
+        positions.forEach { (nodeId, position) ->
+            drawNode(graphics, nodeId, position.x, position.y, nodeId == selectedNodeId)
+        }
+
+        val detailLeft = if (isCompact()) left + 14 else left + 330
+        val detailTop = if (isCompact()) top + 235 else top + 48
+        val detailWidth = if (isCompact()) panelWidth - 28 else panelWidth - 344
+        val detailHeight = if (isCompact()) 130 else 172
+        graphics.fill(detailLeft, detailTop, detailLeft + detailWidth, detailTop + detailHeight, 0xAA1B272B.toInt())
+        outline(graphics, HudRect(detailLeft, detailTop, detailWidth, detailHeight), 0xFF374744.toInt())
+        val node = selectedNodeId?.let(::nodeFor)
+        if (node == null) {
+            graphics.text(font, "Nodeを選択", detailLeft + 12, detailTop + 16, 0xFFB7C8C1.toInt(), true)
+            graphics.text(font, "6つの固定Nodeから選べます", detailLeft + 12, detailTop + 36, 0xFF7F9790.toInt(), false)
+        } else {
+            val state = nodeState(node.id)
+            graphics.text(font, node.label, detailLeft + 12, detailTop + 16, nodeColor(state), true)
+            drawWrapped(graphics, node.description, detailLeft + 12, detailTop + 36, detailWidth - 24, 0xFFD5E1DB.toInt())
+            graphics.text(font, "Cost: ${node.cost}", detailLeft + 12, detailTop + 76, 0xFFE5C878.toInt(), false)
+            val prerequisite = if (node.prerequisites.isEmpty()) "なし" else node.prerequisites.joinToString { nodeFor(it)?.label ?: it }
+            graphics.text(font, "Prerequisite: $prerequisite", detailLeft + 12, detailTop + 94, 0xFF9BAFA8.toInt(), false)
+            graphics.text(font, stateLabel(state), detailLeft + 12, detailTop + 114, nodeColor(state), true)
+        }
+        notice?.let { text ->
+            graphics.text(font, text, left + 16, top + panelHeight - 42, 0xFFE5C878.toInt(), false)
+        }
+    }
+
+    override fun mouseClicked(event: MouseButtonEvent, doubleClick: Boolean): Boolean {
+        val positions = nodePositions(panelLeft(), panelTop())
+        val selected = positions.entries.firstOrNull { (_, position) ->
+            abs(event.x() - position.x) <= NODE_RADIUS && abs(event.y() - position.y) <= NODE_RADIUS
+        }?.key
+        if (selected != null) {
+            selectedNodeId = selected
+            notice = null
+            updatePurchaseButton()
+            return true
+        }
+        return super.mouseClicked(event, doubleClick)
+    }
+
+    override fun keyPressed(event: KeyEvent): Boolean {
+        if (event.key() == GLFW.GLFW_KEY_K) {
+            onClose()
+            return true
+        }
+        return super.keyPressed(event)
+    }
+
+    fun setSnapshot(updated: ProgressionSnapshot) {
+        snapshot = updated
+        updatePurchaseButton()
+    }
+
+    fun setSpendResponse(response: PassiveNodeSpendResponse) {
+        notice = when (response.result) {
+            PassiveNodeSpendResult.ACCEPTED -> "取得しました"
+            PassiveNodeSpendResult.UNKNOWN_NODE -> "不明なNodeです"
+            PassiveNodeSpendResult.ALREADY_ACQUIRED -> "取得済みです"
+            PassiveNodeSpendResult.INSUFFICIENT_POINTS -> "Pointが足りません"
+            PassiveNodeSpendResult.MISSING_PREREQUISITE -> "Prerequisiteが必要です"
+            PassiveNodeSpendResult.STALE_REVISION -> "状態が更新されました"
+            PassiveNodeSpendResult.PERSISTENCE_FAILURE -> "保存に失敗しました"
+        }
+        updatePurchaseButton()
+    }
+
+    private fun purchaseSelected() {
+        val nodeId = selectedNodeId ?: return
+        if (nodeState(nodeId) != NodeState.AVAILABLE) return
+        sendMessage(PassiveNodeSpendRequest(snapshot.revision, nodeId))
+        purchaseButton?.active = false
+        notice = "サーバーで確認中..."
+    }
+
+    private fun updatePurchaseButton() {
+        purchaseButton?.active = selectedNodeId?.let { nodeState(it) == NodeState.AVAILABLE } == true
+    }
+
+    private fun nodeFor(nodeId: String): ClientNode? = CLIENT_NODES.firstOrNull { it.id == nodeId }
+
+    private fun nodeState(nodeId: String): NodeState {
+        if (nodeId in snapshot.allocatedPassiveNodeIds) return NodeState.ACQUIRED
+        val node = nodeFor(nodeId) ?: return NodeState.LOCKED
+        val available = snapshot.grantedPassivePoints - snapshot.spentPassivePoints
+        return if (available >= node.cost && node.prerequisites.all(snapshot.allocatedPassiveNodeIds::contains)) {
+            NodeState.AVAILABLE
+        } else {
+            NodeState.LOCKED
+        }
+    }
+
+    private fun drawConnections(graphics: GuiGraphicsExtractor, positions: Map<String, NodePosition>) {
+        CLIENT_NODES.forEach { node ->
+            node.prerequisites.forEach { prerequisite ->
+                val from = positions[prerequisite] ?: return@forEach
+                val to = positions[node.id] ?: return@forEach
+                drawLine(graphics, from.x, from.y, to.x, to.y, 0xFF40524E.toInt())
+            }
+        }
+    }
+
+    private fun drawNode(graphics: GuiGraphicsExtractor, nodeId: String, x: Int, y: Int, selected: Boolean) {
+        val state = nodeState(nodeId)
+        val color = nodeColor(state)
+        graphics.fill(x - NODE_RADIUS, y - NODE_RADIUS, x + NODE_RADIUS + 1, y + NODE_RADIUS + 1, 0xFF10171A.toInt())
+        graphics.fill(x - NODE_RADIUS + 2, y - NODE_RADIUS + 2, x + NODE_RADIUS - 1, y + NODE_RADIUS - 1, color)
+        outline(graphics, HudRect(x - NODE_RADIUS, y - NODE_RADIUS, NODE_RADIUS * 2 + 1, NODE_RADIUS * 2 + 1), if (selected) 0xFFFFFFFF.toInt() else color)
+        val glyph = nodeFor(nodeId)?.label?.firstOrNull()?.toString() ?: "?"
+        graphics.text(font, glyph, x - font.width(glyph) / 2, y - 4, 0xFF10171A.toInt(), true)
+        graphics.text(font, nodeFor(nodeId)?.label ?: nodeId, x - font.width(nodeFor(nodeId)?.label ?: nodeId) / 2, y + NODE_RADIUS + 4, color, false)
+    }
+
+    private fun drawWrapped(graphics: GuiGraphicsExtractor, text: String, x: Int, y: Int, maxWidth: Int, color: Int) {
+        var line = ""
+        var lineY = y
+        text.forEach { character ->
+            val next = line + character
+            if (line.isNotEmpty() && font.width(next) > maxWidth) {
+                graphics.text(font, line, x, lineY, color, false)
+                line = character.toString()
+                lineY += 12
+            } else {
+                line = next
+            }
+        }
+        if (line.isNotEmpty()) graphics.text(font, line, x, lineY, color, false)
+    }
+
+    private fun drawLine(graphics: GuiGraphicsExtractor, startX: Int, startY: Int, endX: Int, endY: Int, color: Int) {
+        val steps = max(abs(endX - startX), abs(endY - startY)).coerceAtLeast(1)
+        repeat(steps + 1) { step ->
+            val progress = step.toDouble() / steps
+            val x = (startX + (endX - startX) * progress).toInt()
+            val y = (startY + (endY - startY) * progress).toInt()
+            graphics.fill(x, y, x + 2, y + 2, color)
+        }
+    }
+
+    private fun outline(graphics: GuiGraphicsExtractor, rect: HudRect, color: Int) {
+        graphics.fill(rect.x, rect.y, rect.x + rect.width, rect.y + 1, color)
+        graphics.fill(rect.x, rect.y + rect.height - 1, rect.x + rect.width, rect.y + rect.height, color)
+        graphics.fill(rect.x, rect.y, rect.x + 1, rect.y + rect.height, color)
+        graphics.fill(rect.x + rect.width - 1, rect.y, rect.x + rect.width, rect.y + rect.height, color)
+    }
+
+    private fun nodeColor(state: NodeState): Int = when (state) {
+        NodeState.ACQUIRED -> 0xFF7FB59B.toInt()
+        NodeState.AVAILABLE -> 0xFFE5C878.toInt()
+        NodeState.LOCKED -> 0xFF586662.toInt()
+    }
+
+    private fun stateLabel(state: NodeState): String = when (state) {
+        NodeState.ACQUIRED -> "ACQUIRED"
+        NodeState.AVAILABLE -> "AVAILABLE"
+        NodeState.LOCKED -> "LOCKED"
+    }
+
+    private fun panelWidth(): Int = min(560, (width - 16).coerceAtLeast(120))
+    private fun panelHeight(): Int = min(if (isCompact()) 430 else 320, (height - 16).coerceAtLeast(120))
+    private fun isCompact(): Boolean = panelWidth() < 500
+    private fun panelLeft(): Int = (width - panelWidth()) / 2
+    private fun panelTop(): Int = (height - panelHeight()) / 2
+
+    private fun nodePositions(left: Int, top: Int): Map<String, NodePosition> = mapOf(
+        "projects:passive/force" to NodePosition(left + 112, top + 174),
+        "projects:passive/overpower" to NodePosition(left + 62, top + 124),
+        "projects:passive/tempo" to NodePosition(left + 232, top + 174),
+        "projects:passive/flow" to NodePosition(left + 282, top + 124),
+        "projects:passive/vitality" to NodePosition(left + 172, top + 124),
+        "projects:passive/guard" to NodePosition(left + 172, top + 74),
+    )
+
+    private data class NodePosition(val x: Int, val y: Int)
+    private enum class NodeState { ACQUIRED, AVAILABLE, LOCKED }
+
+    private companion object {
+        const val NODE_RADIUS = 14
+        val CLIENT_NODES = listOf(
+            ClientNode("projects:passive/force", "Force", "通常攻撃と直接スキルのダメージ +15%"),
+            ClientNode("projects:passive/overpower", "Overpower", "通常攻撃と直接スキルのダメージをさらに +15%", setOf("projects:passive/force")),
+            ClientNode("projects:passive/tempo", "Tempo", "通常攻撃速度 +15%"),
+            ClientNode("projects:passive/flow", "Flow", "S1 / S2 / S3のクールダウン回復 +20%", setOf("projects:passive/tempo")),
+            ClientNode("projects:passive/vitality", "Vitality", "最大HP +4"),
+            ClientNode("projects:passive/guard", "Guard", "PvE被ダメージ -10%", setOf("projects:passive/vitality")),
+        )
+    }
+}
+
+private data class ClientNode(
+    val id: String,
+    val label: String,
+    val description: String,
+    val prerequisites: Set<String> = emptySet(),
+    val cost: Int = 1,
+)

--- a/client-fabric/src/main/kotlin/dev/projects/client/ProgressionTreeScreen.kt
+++ b/client-fabric/src/main/kotlin/dev/projects/client/ProgressionTreeScreen.kt
@@ -13,12 +13,11 @@ import net.minecraft.network.chat.Component
 import org.lwjgl.glfw.GLFW
 import kotlin.math.abs
 import kotlin.math.max
-import kotlin.math.min
 
 class ProgressionTreeScreen(
     initialSnapshot: ProgressionSnapshot,
     private val sendMessage: (PassiveNodeSpendRequest) -> Unit,
-) : Screen(Component.literal("Global Passive Tree")) {
+) : Screen(Component.literal("パッシブツリー")) {
     private var snapshot = initialSnapshot
     private var selectedNodeId: String? = null
     private var notice: String? = null
@@ -29,14 +28,10 @@ class ProgressionTreeScreen(
     override fun extractBackground(graphics: GuiGraphicsExtractor, mouseX: Int, mouseY: Int, delta: Float) = Unit
 
     override fun init() {
+        val layout = progressionTreeLayout(width, height)
         purchaseButton = addRenderableWidget(
             Button.builder(Component.literal("取得")) { purchaseSelected() }
-                .bounds(
-                    if (isCompact()) panelLeft() + panelWidth() - 124 else panelLeft() + 350,
-                    if (isCompact()) panelTop() + panelHeight() - 44 else panelTop() + 236,
-                    110,
-                    20,
-                )
+                .bounds(layout.purchase.x, layout.purchase.y, layout.purchase.width, layout.purchase.height)
                 .build(),
         )
         updatePurchaseButton()
@@ -44,59 +39,59 @@ class ProgressionTreeScreen(
 
     override fun extractRenderState(graphics: GuiGraphicsExtractor, mouseX: Int, mouseY: Int, delta: Float) {
         super.extractRenderState(graphics, mouseX, mouseY, delta)
-        val left = panelLeft()
-        val top = panelTop()
-        val panelWidth = panelWidth()
-        val panelHeight = panelHeight()
+        val layout = progressionTreeLayout(width, height)
+        val panel = layout.panel
+        val left = panel.x
+        val top = panel.y
         graphics.fill(0, 0, width, height, 0x88060A0D.toInt())
-        graphics.fill(left, top, left + panelWidth, top + panelHeight, 0xF0131B20.toInt())
-        graphics.fill(left, top, left + 2, top + panelHeight, 0xFF638B83.toInt())
-        outline(graphics, HudRect(left, top, panelWidth, panelHeight), 0xFF4E625F.toInt())
-        graphics.text(font, "GLOBAL PASSIVE TREE", left + 16, top + 12, 0xFFE5F0E9.toInt(), true)
+        graphics.fill(left, top, left + panel.width, top + panel.height, 0xF0131B20.toInt())
+        graphics.fill(left, top, left + 2, top + panel.height, 0xFF638B83.toInt())
+        outline(graphics, panel, 0xFF4E625F.toInt())
+        graphics.text(font, "パッシブツリー", left + 16, top + 12, 0xFFE5F0E9.toInt(), true)
         graphics.text(font, "Kで閉じる / サーバーが状態を確定", left + 16, top + 27, 0xFF91AAA3.toInt(), false)
 
         val available = snapshot.grantedPassivePoints - snapshot.spentPassivePoints
         graphics.text(
             font,
-            "Lv ${snapshot.level}   XP ${snapshot.xp} / ${snapshot.xpRequiredForNextLevel}   Point $available",
+            "Lv ${snapshot.level}   XP ${snapshot.xp} / ${snapshot.xpRequiredForNextLevel}   所持ポイント $available",
             left + 16,
-            top + panelHeight - 22,
+            layout.footer.y,
             if (available > 0) 0xFFE5C878.toInt() else 0xFFAFC0BA.toInt(),
             true,
         )
 
-        val positions = nodePositions(left, top)
+        val positions = progressionTreeNodePositions(panel)
         drawConnections(graphics, positions)
         positions.forEach { (nodeId, position) ->
             drawNode(graphics, nodeId, position.x, position.y, nodeId == selectedNodeId)
         }
 
-        val detailLeft = if (isCompact()) left + 14 else left + 330
-        val detailTop = if (isCompact()) top + 235 else top + 48
-        val detailWidth = if (isCompact()) panelWidth - 28 else panelWidth - 344
-        val detailHeight = if (isCompact()) 130 else 172
-        graphics.fill(detailLeft, detailTop, detailLeft + detailWidth, detailTop + detailHeight, 0xAA1B272B.toInt())
-        outline(graphics, HudRect(detailLeft, detailTop, detailWidth, detailHeight), 0xFF374744.toInt())
+        val detail = layout.detail
+        val detailLeft = detail.x
+        val detailTop = detail.y
+        val detailWidth = detail.width
+        graphics.fill(detail.x, detail.y, detail.x + detail.width, detail.y + detail.height, 0xAA1B272B.toInt())
+        outline(graphics, detail, 0xFF374744.toInt())
         val node = selectedNodeId?.let(::nodeFor)
         if (node == null) {
-            graphics.text(font, "Nodeを選択", detailLeft + 12, detailTop + 16, 0xFFB7C8C1.toInt(), true)
-            graphics.text(font, "6つの固定Nodeから選べます", detailLeft + 12, detailTop + 36, 0xFF7F9790.toInt(), false)
+            graphics.text(font, "ノードを選択", detailLeft + 12, detailTop + 16, 0xFFB7C8C1.toInt(), true)
+            graphics.text(font, "6つの固定ノードから選べます", detailLeft + 12, detailTop + 36, 0xFF7F9790.toInt(), false)
         } else {
             val state = nodeState(node.id)
             graphics.text(font, node.label, detailLeft + 12, detailTop + 16, nodeColor(state), true)
             drawWrapped(graphics, node.description, detailLeft + 12, detailTop + 36, detailWidth - 24, 0xFFD5E1DB.toInt())
-            graphics.text(font, "Cost: ${node.cost}", detailLeft + 12, detailTop + 76, 0xFFE5C878.toInt(), false)
+            graphics.text(font, "コスト: ${node.cost}", detailLeft + 12, detailTop + 76, 0xFFE5C878.toInt(), false)
             val prerequisite = if (node.prerequisites.isEmpty()) "なし" else node.prerequisites.joinToString { nodeFor(it)?.label ?: it }
-            graphics.text(font, "Prerequisite: $prerequisite", detailLeft + 12, detailTop + 94, 0xFF9BAFA8.toInt(), false)
+            graphics.text(font, "前提: $prerequisite", detailLeft + 12, detailTop + 94, 0xFF9BAFA8.toInt(), false)
             graphics.text(font, stateLabel(state), detailLeft + 12, detailTop + 114, nodeColor(state), true)
         }
         notice?.let { text ->
-            graphics.text(font, text, left + 16, top + panelHeight - 42, 0xFFE5C878.toInt(), false)
+            graphics.text(font, text, layout.notice.x, layout.notice.y, 0xFFE5C878.toInt(), false)
         }
     }
 
     override fun mouseClicked(event: MouseButtonEvent, doubleClick: Boolean): Boolean {
-        val positions = nodePositions(panelLeft(), panelTop())
+        val positions = progressionTreeNodePositions(progressionTreeLayout(width, height).panel)
         val selected = positions.entries.firstOrNull { (_, position) ->
             abs(event.x() - position.x) <= NODE_RADIUS && abs(event.y() - position.y) <= NODE_RADIUS
         }?.key
@@ -127,8 +122,8 @@ class ProgressionTreeScreen(
             PassiveNodeSpendResult.ACCEPTED -> "取得しました"
             PassiveNodeSpendResult.UNKNOWN_NODE -> "不明なNodeです"
             PassiveNodeSpendResult.ALREADY_ACQUIRED -> "取得済みです"
-            PassiveNodeSpendResult.INSUFFICIENT_POINTS -> "Pointが足りません"
-            PassiveNodeSpendResult.MISSING_PREREQUISITE -> "Prerequisiteが必要です"
+            PassiveNodeSpendResult.INSUFFICIENT_POINTS -> "ポイントが足りません"
+            PassiveNodeSpendResult.MISSING_PREREQUISITE -> "前提条件が必要です"
             PassiveNodeSpendResult.STALE_REVISION -> "状態が更新されました"
             PassiveNodeSpendResult.PERSISTENCE_FAILURE -> "保存に失敗しました"
         }
@@ -160,7 +155,7 @@ class ProgressionTreeScreen(
         }
     }
 
-    private fun drawConnections(graphics: GuiGraphicsExtractor, positions: Map<String, NodePosition>) {
+    private fun drawConnections(graphics: GuiGraphicsExtractor, positions: Map<String, ProgressionTreeNodePosition>) {
         CLIENT_NODES.forEach { node ->
             node.prerequisites.forEach { prerequisite ->
                 val from = positions[prerequisite] ?: return@forEach
@@ -221,27 +216,11 @@ class ProgressionTreeScreen(
     }
 
     private fun stateLabel(state: NodeState): String = when (state) {
-        NodeState.ACQUIRED -> "ACQUIRED"
-        NodeState.AVAILABLE -> "AVAILABLE"
-        NodeState.LOCKED -> "LOCKED"
+        NodeState.ACQUIRED -> "取得済み"
+        NodeState.AVAILABLE -> "取得可能"
+        NodeState.LOCKED -> "ロック"
     }
 
-    private fun panelWidth(): Int = min(560, (width - 16).coerceAtLeast(120))
-    private fun panelHeight(): Int = min(if (isCompact()) 430 else 320, (height - 16).coerceAtLeast(120))
-    private fun isCompact(): Boolean = panelWidth() < 500
-    private fun panelLeft(): Int = (width - panelWidth()) / 2
-    private fun panelTop(): Int = (height - panelHeight()) / 2
-
-    private fun nodePositions(left: Int, top: Int): Map<String, NodePosition> = mapOf(
-        "projects:passive/force" to NodePosition(left + 112, top + 174),
-        "projects:passive/overpower" to NodePosition(left + 62, top + 124),
-        "projects:passive/tempo" to NodePosition(left + 232, top + 174),
-        "projects:passive/flow" to NodePosition(left + 282, top + 124),
-        "projects:passive/vitality" to NodePosition(left + 172, top + 124),
-        "projects:passive/guard" to NodePosition(left + 172, top + 74),
-    )
-
-    private data class NodePosition(val x: Int, val y: Int)
     private enum class NodeState { ACQUIRED, AVAILABLE, LOCKED }
 
     private companion object {

--- a/client-fabric/src/main/kotlin/dev/projects/client/ProjectSClient.kt
+++ b/client-fabric/src/main/kotlin/dev/projects/client/ProjectSClient.kt
@@ -18,6 +18,9 @@ import dev.projects.protocol.ProtocolCodec
 import dev.projects.protocol.ProtocolHello
 import dev.projects.protocol.ProtocolHelloAck
 import dev.projects.protocol.ProtocolVersion
+import dev.projects.protocol.ProgressionSnapshot
+import dev.projects.protocol.ProgressionXpGained
+import dev.projects.protocol.PassiveNodeSpendResponse
 import dev.projects.protocol.SlashEditorParameters
 import dev.projects.protocol.VfxEditorNotice
 import dev.projects.protocol.VfxEditorOpen
@@ -54,6 +57,9 @@ import kotlin.math.sqrt
 
 object ProjectSClient : ClientModInitializer {
     private const val ATTACK_DEBUG_TICKS = 5
+    private const val XP_GAIN_TICKS = 40
+    private const val LEVEL_UP_TICKS = 70
+    private const val POINT_HINT_TICKS = 140
     private val attackDebugDust = DustParticleOptions(0xFF0000, 0.65f)
     private val hitCoreDust = DustParticleOptions(0xFFFFFF, 0.9f)
     private val logger = LoggerFactory.getLogger("projects")
@@ -72,6 +78,11 @@ object ProjectSClient : ClientModInitializer {
     private var skill2CooldownMaxTicks = 100
     private var skill3CooldownTicks = 0
     private var skill3CooldownMaxTicks = 60
+    private var progressionSnapshot = ProgressionSnapshot(0L, 1, 0, 100, 0, 0, emptyList())
+    private var progressionXpGain = 0
+    private var progressionXpGainTicks = 0
+    private var progressionLevelUpTicks = 0
+    private var progressionPointHintTicks = 0
     private var attackDebugShape: AttackDebugShape? = null
     private var attackDebugTicksRemaining = 0
     private var attackDebugEnabled = true
@@ -99,6 +110,12 @@ object ProjectSClient : ClientModInitializer {
         InputConstants.KEY_F7,
         KeyMapping.Category.GAMEPLAY,
     )
+    private val passiveTreeKey = KeyMapping(
+        "key.projects.passive_tree",
+        InputConstants.Type.KEYSYM,
+        InputConstants.KEY_K,
+        KeyMapping.Category.GAMEPLAY,
+    )
     private val skill1Key = skillKey("key.projects.skill_1", InputConstants.KEY_Z)
     private val skill2Key = skillKey("key.projects.skill_2", InputConstants.KEY_X)
     private val skill3Key = skillKey("key.projects.skill_3", InputConstants.KEY_C)
@@ -108,6 +125,7 @@ object ProjectSClient : ClientModInitializer {
         KeyMappingHelper.registerKeyMapping(dodgeKey)
         KeyMappingHelper.registerKeyMapping(attackDebugKey)
         KeyMappingHelper.registerKeyMapping(hudDesignerKey)
+        KeyMappingHelper.registerKeyMapping(passiveTreeKey)
         KeyMappingHelper.registerKeyMapping(skill1Key)
         KeyMappingHelper.registerKeyMapping(skill2Key)
         KeyMappingHelper.registerKeyMapping(skill3Key)
@@ -152,6 +170,21 @@ object ProjectSClient : ClientModInitializer {
                         skill3CooldownTicks = message.skill3CooldownTicks
                         skill3CooldownMaxTicks = message.skill3CooldownMaxTicks
                     }
+                    is ProgressionSnapshot -> context.client().execute {
+                        progressionSnapshot = message
+                        (context.client().gui.screen() as? ProgressionTreeScreen)?.setSnapshot(message)
+                    }
+                    is ProgressionXpGained -> context.client().execute {
+                        progressionXpGain = message.amount
+                        progressionXpGainTicks = XP_GAIN_TICKS
+                        if (message.levelUpCount > 0) {
+                            progressionLevelUpTicks = LEVEL_UP_TICKS
+                            progressionPointHintTicks = POINT_HINT_TICKS
+                        }
+                    }
+                    is PassiveNodeSpendResponse -> context.client().execute {
+                        (context.client().gui.screen() as? ProgressionTreeScreen)?.setSpendResponse(message)
+                    }
                     is GroundTelegraphStart -> context.client().execute {
                         GroundTelegraphRenderer.start(message)
                     }
@@ -195,10 +228,21 @@ object ProjectSClient : ClientModInitializer {
             Identifier.fromNamespaceAndPath("projects", "class_resources"),
             ::renderResourceHud,
         )
+        HudElementRegistry.attachElementAfter(
+            Identifier.fromNamespaceAndPath("projects", "class_resources"),
+            Identifier.fromNamespaceAndPath("projects", "progression"),
+            ::renderProgressionHud,
+        )
         HudElementRegistry.replaceElement(VanillaHudElements.HEALTH_BAR) { _ ->
             { _, _ -> }
         }
         HudElementRegistry.replaceElement(VanillaHudElements.FOOD_BAR) { _ ->
+            { _, _ -> }
+        }
+        HudElementRegistry.replaceElement(VanillaHudElements.INFO_BAR) { _ ->
+            { _, _ -> }
+        }
+        HudElementRegistry.replaceElement(VanillaHudElements.EXPERIENCE_LEVEL) { _ ->
             { _, _ -> }
         }
         ClientTickEvents.END_CLIENT_TICK.register(::handleAttackInput)
@@ -216,6 +260,11 @@ object ProjectSClient : ClientModInitializer {
             skill1CooldownTicks = 0
             skill2CooldownTicks = 0
             skill3CooldownTicks = 0
+            progressionSnapshot = ProgressionSnapshot(0L, 1, 0, 100, 0, 0, emptyList())
+            progressionXpGain = 0
+            progressionXpGainTicks = 0
+            progressionLevelUpTicks = 0
+            progressionPointHintTicks = 0
             attackDebugShape = null
             attackDebugTicksRemaining = 0
             slashDraftNames = emptyList()
@@ -230,8 +279,20 @@ object ProjectSClient : ClientModInitializer {
                 ),
             )
         }
+        if (passiveTreeKey.consumeClick() && client.gui.screen() == null) {
+            client.gui.setScreen(
+                ProgressionTreeScreen(progressionSnapshot) { request ->
+                    if (ClientPlayNetworking.canSend(ProjectSPayload.TYPE)) {
+                        ClientPlayNetworking.send(ProjectSPayload(ProtocolCodec.encode(request)))
+                    }
+                },
+            )
+        }
         renderAttackDebugShape(client)
         if (hitMarkerTicksRemaining > 0) hitMarkerTicksRemaining--
+        if (progressionXpGainTicks > 0) progressionXpGainTicks--
+        if (progressionLevelUpTicks > 0) progressionLevelUpTicks--
+        if (progressionPointHintTicks > 0) progressionPointHintTicks--
         if (attackDebugKey.consumeClick()) {
             attackDebugEnabled = !attackDebugEnabled
             player.sendSystemMessage(
@@ -332,6 +393,93 @@ object ProjectSClient : ClientModInitializer {
         }
         renderSkillHud(context)
         renderHitMarker(context)
+    }
+
+    private fun renderProgressionHud(context: GuiGraphicsExtractor, tickCounter: DeltaTracker) {
+        val screenWidth = context.guiWidth()
+        val screenHeight = context.guiHeight()
+        val barWidth = minOf(182, screenWidth - 20)
+        val barHeight = 8
+        val x = (screenWidth - barWidth) / 2
+        val y = screenHeight - 34
+        val required = progressionSnapshot.xpRequiredForNextLevel
+        val ratio = if (required <= 0) 1.0 else (progressionSnapshot.xp.toDouble() / required).coerceIn(0.0, 1.0)
+        context.text(
+            Minecraft.getInstance().font,
+            "Lv ${progressionSnapshot.level}",
+            x,
+            y - 10,
+            0xFFB8CFC5.toInt(),
+            true,
+        )
+        val points = progressionSnapshot.grantedPassivePoints - progressionSnapshot.spentPassivePoints
+        if (points > 0) {
+            val pointsText = "P $points"
+            context.text(
+                Minecraft.getInstance().font,
+                pointsText,
+                x + barWidth - Minecraft.getInstance().font.width(pointsText),
+                y - 10,
+                0xFFE5C878.toInt(),
+                true,
+            )
+        }
+        context.fill(x, y, x + barWidth, y + barHeight, 0xCC0D1418.toInt())
+        outline(context, HudRect(x, y, barWidth, barHeight), 0xFF414C50.toInt())
+        val filled = (barWidth - 2) * ratio
+        if (filled > 0.0) {
+            context.fill(x + 1, y + 1, x + 1 + filled.toInt(), y + barHeight - 1, 0xFF638B83.toInt())
+        }
+        val xpText = if (required <= 0) "MAX" else "${progressionSnapshot.xp} / $required"
+        context.text(
+            Minecraft.getInstance().font,
+            xpText,
+            x + barWidth / 2 - Minecraft.getInstance().font.width(xpText) / 2,
+            y - 10,
+            0xFF8CABA2.toInt(),
+            false,
+        )
+        if (progressionXpGainTicks > 0) {
+            val gainText = "+$progressionXpGain XP"
+            context.text(
+                Minecraft.getInstance().font,
+                gainText,
+                screenWidth / 2 - Minecraft.getInstance().font.width(gainText) / 2,
+                y - 28,
+                0xFFE5C878.toInt(),
+                true,
+            )
+        }
+        if (progressionLevelUpTicks > 0) {
+            val levelText = "LEVEL ${progressionSnapshot.level}"
+            val pointText = "PASSIVE POINT +1"
+            context.text(
+                Minecraft.getInstance().font,
+                levelText,
+                screenWidth / 2 - Minecraft.getInstance().font.width(levelText) / 2,
+                screenHeight / 2 - 48,
+                0xFFE5F0E9.toInt(),
+                true,
+            )
+            context.text(
+                Minecraft.getInstance().font,
+                pointText,
+                screenWidth / 2 - Minecraft.getInstance().font.width(pointText) / 2,
+                screenHeight / 2 - 34,
+                0xFFE5C878.toInt(),
+                true,
+            )
+        } else if (progressionPointHintTicks > 0 && points > 0) {
+            val hint = "K  Passive Tree"
+            context.text(
+                Minecraft.getInstance().font,
+                hint,
+                screenWidth / 2 - Minecraft.getInstance().font.width(hint) / 2,
+                y - 28,
+                0xFFB8CFC5.toInt(),
+                false,
+            )
+        }
     }
 
     private fun renderHitMarker(context: GuiGraphicsExtractor) {

--- a/client-fabric/src/main/kotlin/dev/projects/client/ProjectSClient.kt
+++ b/client-fabric/src/main/kotlin/dev/projects/client/ProjectSClient.kt
@@ -470,7 +470,7 @@ object ProjectSClient : ClientModInitializer {
                 true,
             )
         } else if (progressionPointHintTicks > 0 && points > 0) {
-            val hint = "K  Passive Tree"
+            val hint = "K  パッシブツリー"
             context.text(
                 Minecraft.getInstance().font,
                 hint,

--- a/client-fabric/src/test/kotlin/dev/projects/client/ProgressionTreeLayoutTest.kt
+++ b/client-fabric/src/test/kotlin/dev/projects/client/ProgressionTreeLayoutTest.kt
@@ -1,0 +1,66 @@
+package dev.projects.client
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ProgressionTreeLayoutTest {
+    @Test
+    fun `compact 480 by 270 layout keeps all regions inside without overlap`() {
+        val layout = progressionTreeLayout(480, 270)
+
+        assertTrue(layout.compact)
+        assertInside(layout.panel, layout.detail)
+        assertInside(layout.panel, layout.purchase)
+        assertInside(layout.panel, layout.notice)
+        assertInside(layout.panel, layout.footer)
+        assertTrue(layout.detail.bottom <= layout.purchase.y)
+        assertTrue(layout.purchase.bottom <= layout.notice.y)
+        assertTrue(layout.notice.bottom <= layout.footer.y)
+        assertTrue(layout.footer.bottom <= layout.panel.bottom)
+        assertNodesInside(layout)
+    }
+
+    @Test
+    fun `640 by 360 layout keeps desktop regions inside without overlap`() {
+        val layout = progressionTreeLayout(640, 360)
+
+        assertTrue(!layout.compact)
+        assertInside(layout.panel, layout.detail)
+        assertInside(layout.panel, layout.purchase)
+        assertInside(layout.panel, layout.notice)
+        assertInside(layout.panel, layout.footer)
+        assertTrue(layout.purchase.bottom <= layout.notice.y)
+        assertTrue(layout.notice.bottom <= layout.footer.y)
+        assertTrue(layout.footer.bottom <= layout.panel.bottom)
+        assertNodesInside(layout)
+    }
+
+    private fun assertNodesInside(layout: ProgressionTreeLayout) {
+        val positions = progressionTreeNodePositions(layout.panel)
+        assertEquals(6, positions.size)
+        positions.values.forEach { position ->
+            assertTrue(position.x - NODE_RADIUS >= layout.panel.x)
+            assertTrue(position.x + NODE_RADIUS < layout.panel.right)
+            assertTrue(position.y - NODE_RADIUS >= layout.panel.y)
+            assertTrue(position.y + NODE_RADIUS < layout.panel.bottom)
+        }
+    }
+
+    private fun assertInside(container: HudRect, child: HudRect) {
+        assertTrue(child.x >= container.x)
+        assertTrue(child.y >= container.y)
+        assertTrue(child.right <= container.right)
+        assertTrue(child.bottom <= container.bottom)
+    }
+
+    private companion object {
+        const val NODE_RADIUS = 14
+    }
+}
+
+private val HudRect.right: Int
+    get() = x + width
+
+private val HudRect.bottom: Int
+    get() = y + height

--- a/protocol/src/main/kotlin/dev/projects/protocol/Protocol.kt
+++ b/protocol/src/main/kotlin/dev/projects/protocol/Protocol.kt
@@ -130,6 +130,84 @@ data class ClassResourceSnapshot(
     }
 }
 
+private const val MAX_PROGRESSION_NODES = 6
+private val PROGRESSION_NODE_ID = Regex("[a-z0-9][a-z0-9:_/-]*")
+
+data class ProgressionSnapshot(
+    val revision: Long,
+    val level: Int,
+    val xp: Int,
+    val xpRequiredForNextLevel: Int,
+    val grantedPassivePoints: Int,
+    val spentPassivePoints: Int,
+    val allocatedPassiveNodeIds: List<String>,
+) : ProtocolMessage {
+    init {
+        require(revision >= 0L) { "Progression revision must not be negative" }
+        require(level in 1..45) { "Progression level is out of range" }
+        require(xp >= 0 && xpRequiredForNextLevel >= 0) { "Progression XP values must not be negative" }
+        require(grantedPassivePoints >= 0 && spentPassivePoints >= 0) {
+            "Progression point values must not be negative"
+        }
+        require(spentPassivePoints <= grantedPassivePoints) {
+            "Spent passive points must not exceed granted passive points"
+        }
+        require(allocatedPassiveNodeIds.size <= MAX_PROGRESSION_NODES) { "Too many progression nodes" }
+        require(allocatedPassiveNodeIds.distinct().size == allocatedPassiveNodeIds.size) {
+            "Duplicate progression node"
+        }
+        require(allocatedPassiveNodeIds.all(PROGRESSION_NODE_ID::matches)) {
+            "Invalid progression node id"
+        }
+    }
+}
+
+data class ProgressionXpGained(
+    val amount: Int,
+    val resultingLevel: Int,
+    val levelUpCount: Int,
+    val passivePointsGranted: Int,
+) : ProtocolMessage {
+    init {
+        require(amount >= 0) { "XP gain must not be negative" }
+        require(resultingLevel in 1..45) { "Progression level is out of range" }
+        require(levelUpCount >= 0 && passivePointsGranted >= 0) {
+            "Progression level-up values must not be negative"
+        }
+    }
+}
+
+data class PassiveNodeSpendRequest(
+    val expectedRevision: Long,
+    val nodeId: String,
+) : ProtocolMessage {
+    init {
+        require(expectedRevision >= 0L) { "Expected progression revision must not be negative" }
+        require(PROGRESSION_NODE_ID.matches(nodeId)) { "Invalid progression node id" }
+    }
+}
+
+enum class PassiveNodeSpendResult {
+    ACCEPTED,
+    UNKNOWN_NODE,
+    ALREADY_ACQUIRED,
+    INSUFFICIENT_POINTS,
+    MISSING_PREREQUISITE,
+    STALE_REVISION,
+    PERSISTENCE_FAILURE,
+}
+
+data class PassiveNodeSpendResponse(
+    val nodeId: String,
+    val result: PassiveNodeSpendResult,
+    val revision: Long,
+) : ProtocolMessage {
+    init {
+        require(PROGRESSION_NODE_ID.matches(nodeId)) { "Invalid progression node id" }
+        require(revision >= 0L) { "Progression revision must not be negative" }
+    }
+}
+
 private object GroundTelegraphLimits {
     const val MAX_RADIUS = 64.0
     const val MIN_ANGLE_DEGREES = 1.0
@@ -391,6 +469,10 @@ object ProtocolCodec {
     private const val VFX_EDITOR_NOTICE = 27
     private const val VFX_SLASH_PREVIEW_CANCEL = 28
     private const val VFX_SLASH_APPLY_SKILL3 = 29
+    private const val PROGRESSION_SNAPSHOT = 30
+    private const val PROGRESSION_XP_GAINED = 31
+    private const val PASSIVE_NODE_SPEND_REQUEST = 32
+    private const val PASSIVE_NODE_SPEND_RESPONSE = 33
 
     fun encode(message: ProtocolMessage): ByteArray {
         val output = ByteArrayOutputStream()
@@ -458,6 +540,35 @@ object ProtocolCodec {
                     data.writeInt(message.skill2CooldownMaxTicks)
                     data.writeInt(message.skill3CooldownTicks)
                     data.writeInt(message.skill3CooldownMaxTicks)
+                }
+                is ProgressionSnapshot -> {
+                    data.writeByte(PROGRESSION_SNAPSHOT)
+                    data.writeLong(message.revision)
+                    data.writeInt(message.level)
+                    data.writeInt(message.xp)
+                    data.writeInt(message.xpRequiredForNextLevel)
+                    data.writeInt(message.grantedPassivePoints)
+                    data.writeInt(message.spentPassivePoints)
+                    data.writeByte(message.allocatedPassiveNodeIds.size)
+                    message.allocatedPassiveNodeIds.forEach { nodeId -> writeString(data, nodeId) }
+                }
+                is ProgressionXpGained -> {
+                    data.writeByte(PROGRESSION_XP_GAINED)
+                    data.writeInt(message.amount)
+                    data.writeInt(message.resultingLevel)
+                    data.writeInt(message.levelUpCount)
+                    data.writeInt(message.passivePointsGranted)
+                }
+                is PassiveNodeSpendRequest -> {
+                    data.writeByte(PASSIVE_NODE_SPEND_REQUEST)
+                    data.writeLong(message.expectedRevision)
+                    writeString(data, message.nodeId)
+                }
+                is PassiveNodeSpendResponse -> {
+                    data.writeByte(PASSIVE_NODE_SPEND_RESPONSE)
+                    writeString(data, message.nodeId)
+                    data.writeByte(message.result.ordinal)
+                    data.writeLong(message.revision)
                 }
                 is GroundTelegraphStart -> {
                     data.writeByte(GROUND_TELEGRAPH_START)
@@ -582,6 +693,47 @@ object ProtocolCodec {
                 input.readInt(),
                 input.readInt(),
             )
+            PROGRESSION_SNAPSHOT -> {
+                val revision = input.readLong()
+                val level = input.readInt()
+                val xp = input.readInt()
+                val xpRequiredForNextLevel = input.readInt()
+                val grantedPassivePoints = input.readInt()
+                val spentPassivePoints = input.readInt()
+                val count = input.readUnsignedByte().also {
+                    require(it <= MAX_PROGRESSION_NODES) { "Too many progression nodes" }
+                }
+                ProgressionSnapshot(
+                    revision = revision,
+                    level = level,
+                    xp = xp,
+                    xpRequiredForNextLevel = xpRequiredForNextLevel,
+                    grantedPassivePoints = grantedPassivePoints,
+                    spentPassivePoints = spentPassivePoints,
+                    allocatedPassiveNodeIds = List(count) { readString(input) },
+                )
+            }
+            PROGRESSION_XP_GAINED -> ProgressionXpGained(
+                amount = input.readInt(),
+                resultingLevel = input.readInt(),
+                levelUpCount = input.readInt(),
+                passivePointsGranted = input.readInt(),
+            )
+            PASSIVE_NODE_SPEND_REQUEST -> PassiveNodeSpendRequest(
+                expectedRevision = input.readLong(),
+                nodeId = readString(input),
+            )
+            PASSIVE_NODE_SPEND_RESPONSE -> {
+                val nodeId = readString(input)
+                val resultId = input.readUnsignedByte()
+                val result = PassiveNodeSpendResult.entries.getOrNull(resultId)
+                    ?: throw IllegalArgumentException("Unknown passive node spend result: $resultId")
+                PassiveNodeSpendResponse(
+                    nodeId = nodeId,
+                    result = result,
+                    revision = input.readLong(),
+                )
+            }
             GROUND_TELEGRAPH_START -> GroundTelegraphStart.clamped(
                 telegraphId = input.readLong(),
                 centerX = input.readDouble(),

--- a/protocol/src/main/kotlin/dev/projects/protocol/Protocol.kt
+++ b/protocol/src/main/kotlin/dev/projects/protocol/Protocol.kt
@@ -12,7 +12,7 @@ import kotlin.math.sqrt
 const val PROJECTS_CHANNEL = "projects:protocol"
 
 object ProtocolVersion {
-    const val CURRENT = 11
+    const val CURRENT = 12
 
     fun requireCompatible(version: Int) {
         if (version != CURRENT) {

--- a/protocol/src/test/kotlin/dev/projects/protocol/ProtocolCodecTest.kt
+++ b/protocol/src/test/kotlin/dev/projects/protocol/ProtocolCodecTest.kt
@@ -7,6 +7,11 @@ import kotlin.test.assertFailsWith
 
 class ProtocolCodecTest {
     @Test
+    fun `current protocol version is explicitly v12`() {
+        assertEquals(12, ProtocolVersion.CURRENT)
+    }
+
+    @Test
     fun `current protocol version is accepted`() {
         ProtocolVersion.requireCompatible(ProtocolVersion.CURRENT)
     }
@@ -15,6 +20,9 @@ class ProtocolCodecTest {
     fun `mismatched protocol version is rejected`() {
         assertFailsWith<ProtocolVersionMismatchException> {
             ProtocolVersion.requireCompatible(ProtocolVersion.CURRENT + 1)
+        }
+        assertFailsWith<ProtocolVersionMismatchException> {
+            ProtocolVersion.requireCompatible(11)
         }
     }
 

--- a/protocol/src/test/kotlin/dev/projects/protocol/ProtocolCodecTest.kt
+++ b/protocol/src/test/kotlin/dev/projects/protocol/ProtocolCodecTest.kt
@@ -160,6 +160,47 @@ class ProtocolCodecTest {
     }
 
     @Test
+    fun `progression messages round trip`() {
+        assertRoundTrip(
+            ProgressionSnapshot(
+                revision = 7L,
+                level = 2,
+                xp = 25,
+                xpRequiredForNextLevel = 150,
+                grantedPassivePoints = 1,
+                spentPassivePoints = 1,
+                allocatedPassiveNodeIds = listOf("projects:passive/force"),
+            ),
+        )
+        assertRoundTrip(ProgressionXpGained(100, 2, 1, 1))
+        assertRoundTrip(PassiveNodeSpendRequest(7L, "projects:passive/tempo"))
+        assertRoundTrip(
+            PassiveNodeSpendResponse(
+                "projects:passive/tempo",
+                PassiveNodeSpendResult.STALE_REVISION,
+                7L,
+            ),
+        )
+    }
+
+    @Test
+    fun `invalid progression messages fail closed`() {
+        assertFailsWith<IllegalArgumentException> {
+            ProgressionSnapshot(0L, 46, 0, 100, 0, 0, emptyList())
+        }
+        assertFailsWith<IllegalArgumentException> {
+            PassiveNodeSpendRequest(0L, "projects:passive/unknown node")
+        }
+
+        val malformed = ProtocolCodec.encode(
+            ProgressionSnapshot(0L, 1, 0, 100, 0, 0, emptyList()),
+        ).copyOf().also { bytes ->
+            bytes[1 + Long.SIZE_BYTES + Int.SIZE_BYTES * 5] = 7
+        }
+        assertFailsWith<IllegalArgumentException> { ProtocolCodec.decode(malformed) }
+    }
+
+    @Test
     fun `malformed resource snapshot fails closed`() {
         val malformed = ProtocolCodec.encode(ClassResourceSnapshot(75, 100, 20, 80, 50, 100, 40, 60)).copyOf().also { bytes ->
             java.nio.ByteBuffer.wrap(bytes, 25, Int.SIZE_BYTES).putInt(61)

--- a/server-minestom/src/main/kotlin/dev/projects/server/Progression.kt
+++ b/server-minestom/src/main/kotlin/dev/projects/server/Progression.kt
@@ -1,0 +1,270 @@
+package dev.projects.server
+
+/** A resolved set of player-wide modifiers used by the current combat adapter. */
+data class ProgressionEffects(
+    val directDamageMultiplier: Double = 1.0,
+    val normalAttackSpeedMultiplier: Double = 1.0,
+    val cooldownRecoveryMultiplier: Double = 1.0,
+    val maxHealthBonus: Int = 0,
+    val incomingPveDamageMultiplier: Double = 1.0,
+) {
+    companion object {
+        val DEFAULT = ProgressionEffects()
+    }
+}
+
+data class PassiveNode(
+    val id: String,
+    val label: String,
+    val description: String,
+    val cost: Int = 1,
+    val prerequisites: Set<String> = emptySet(),
+    val directDamageBonus: Double = 0.0,
+    val attackSpeedBonus: Double = 0.0,
+    val cooldownRecoveryBonus: Double = 0.0,
+    val maxHealthBonus: Int = 0,
+    val incomingDamageReduction: Double = 0.0,
+) {
+    init {
+        require(id.isNotBlank()) { "Passive node id must not be blank" }
+        require(cost > 0) { "Passive node cost must be positive" }
+        require(directDamageBonus >= 0.0 && directDamageBonus.isFinite()) {
+            "Passive node direct damage bonus must be finite and non-negative"
+        }
+        require(attackSpeedBonus >= 0.0 && attackSpeedBonus.isFinite()) {
+            "Passive node attack speed bonus must be finite and non-negative"
+        }
+        require(cooldownRecoveryBonus >= 0.0 && cooldownRecoveryBonus.isFinite()) {
+            "Passive node cooldown bonus must be finite and non-negative"
+        }
+        require(maxHealthBonus >= 0) { "Passive node health bonus must be non-negative" }
+        require(incomingDamageReduction in 0.0..1.0 && incomingDamageReduction.isFinite()) {
+            "Passive node damage reduction must be between 0 and 1"
+        }
+    }
+}
+
+object GlobalPassiveTree {
+    const val FORCE = "projects:passive/force"
+    const val OVERPOWER = "projects:passive/overpower"
+    const val TEMPO = "projects:passive/tempo"
+    const val FLOW = "projects:passive/flow"
+    const val VITALITY = "projects:passive/vitality"
+    const val GUARD = "projects:passive/guard"
+
+    val nodes: List<PassiveNode> = listOf(
+        PassiveNode(
+            id = FORCE,
+            label = "Force",
+            description = "通常攻撃と直接スキルのダメージ +15%",
+            directDamageBonus = 0.15,
+        ),
+        PassiveNode(
+            id = OVERPOWER,
+            label = "Overpower",
+            description = "通常攻撃と直接スキルのダメージをさらに +15%",
+            prerequisites = setOf(FORCE),
+            directDamageBonus = 0.15,
+        ),
+        PassiveNode(
+            id = TEMPO,
+            label = "Tempo",
+            description = "通常攻撃速度 +15%",
+            attackSpeedBonus = 0.15,
+        ),
+        PassiveNode(
+            id = FLOW,
+            label = "Flow",
+            description = "S1 / S2 / S3のクールダウン回復 +20%",
+            prerequisites = setOf(TEMPO),
+            cooldownRecoveryBonus = 0.20,
+        ),
+        PassiveNode(
+            id = VITALITY,
+            label = "Vitality",
+            description = "最大HP +4",
+            maxHealthBonus = 4,
+        ),
+        PassiveNode(
+            id = GUARD,
+            label = "Guard",
+            description = "PvE被ダメージ -10%",
+            prerequisites = setOf(VITALITY),
+            incomingDamageReduction = 0.10,
+        ),
+    )
+
+    private val nodesById = nodes.associateBy(PassiveNode::id)
+
+    fun node(id: String): PassiveNode? = nodesById[id]
+}
+
+enum class PassiveSpendResult {
+    ACCEPTED,
+    UNKNOWN_NODE,
+    ALREADY_ACQUIRED,
+    INSUFFICIENT_POINTS,
+    MISSING_PREREQUISITE,
+    STALE_REVISION,
+}
+
+data class ProgressionGain(
+    val amount: Int,
+    val levelUpCount: Int,
+    val passivePointsGranted: Int,
+    val resultingLevel: Int,
+    val revision: Long,
+)
+
+data class ProgressionRecord(
+    val level: Int,
+    val experience: Int,
+    val grantedPassivePoints: Int,
+    val spentPassivePoints: Int,
+    val allocatedPassiveNodeIds: List<String>,
+    val revision: Long,
+)
+
+/** Server-owned global player progression. Experience is the remainder within the current level. */
+class ProgressionState(
+    level: Int = 1,
+    experience: Int = 0,
+    grantedPassivePoints: Int = 0,
+    spentPassivePoints: Int = 0,
+    allocatedPassiveNodeIds: Collection<String> = emptyList(),
+    revision: Long = 0L,
+) {
+    var level: Int = level
+        private set
+    var experience: Int = experience
+        private set
+    var grantedPassivePoints: Int = grantedPassivePoints
+        private set
+    var spentPassivePoints: Int = spentPassivePoints
+        private set
+    var revision: Long = revision
+        private set
+
+    private val allocatedNodes = linkedSetOf<String>()
+
+    init {
+        require(level in 1..MAX_LEVEL) { "Progression level must be between 1 and $MAX_LEVEL" }
+        require(experience >= 0) { "Progression experience must not be negative" }
+        require(level == MAX_LEVEL || experience < xpRequired(level)) {
+            "Progression experience must be below the next level threshold"
+        }
+        require(grantedPassivePoints >= 0) { "Granted passive points must not be negative" }
+        require(spentPassivePoints >= 0) { "Spent passive points must not be negative" }
+        require(spentPassivePoints <= grantedPassivePoints) {
+            "Spent passive points must not exceed granted passive points"
+        }
+        require(revision >= 0L) { "Progression revision must not be negative" }
+        allocatedPassiveNodeIds.forEach { nodeId ->
+            require(allocatedNodes.add(nodeId)) { "Duplicate passive node: $nodeId" }
+            require(GlobalPassiveTree.node(nodeId) != null) { "Unknown passive node: $nodeId" }
+        }
+        require(spentPassivePoints == allocatedNodes.sumOf { requireNotNull(GlobalPassiveTree.node(it)).cost }) {
+            "Spent passive points must match allocated node costs"
+        }
+        if (level == MAX_LEVEL) this.experience = 0
+    }
+
+    val allocatedPassiveNodeIds: Set<String>
+        get() = allocatedNodes.toSet()
+
+    val availablePassivePoints: Int
+        get() = grantedPassivePoints - spentPassivePoints
+
+    val xpRequiredForNextLevel: Int
+        get() = if (level == MAX_LEVEL) 0 else xpRequired(level)
+
+    fun addXp(amount: Int): ProgressionGain {
+        require(amount >= 0) { "XP must not be negative" }
+        if (amount == 0) {
+            return ProgressionGain(0, 0, 0, level, revision)
+        }
+
+        var remainingExperience = experience.toLong() + amount.toLong()
+        var levelUps = 0
+        while (level < MAX_LEVEL && remainingExperience >= xpRequired(level)) {
+            remainingExperience -= xpRequired(level).toLong()
+            level++
+            grantedPassivePoints++
+            levelUps++
+        }
+        experience = if (level == MAX_LEVEL) 0 else remainingExperience.toInt()
+        revision++
+        return ProgressionGain(amount, levelUps, levelUps, level, revision)
+    }
+
+    fun spend(nodeId: String, expectedRevision: Long? = null): PassiveSpendResult {
+        if (expectedRevision != null && expectedRevision != revision) {
+            return PassiveSpendResult.STALE_REVISION
+        }
+        val node = GlobalPassiveTree.node(nodeId) ?: return PassiveSpendResult.UNKNOWN_NODE
+        if (nodeId in allocatedNodes) return PassiveSpendResult.ALREADY_ACQUIRED
+        if (!node.prerequisites.all(allocatedNodes::contains)) {
+            return PassiveSpendResult.MISSING_PREREQUISITE
+        }
+        if (availablePassivePoints < node.cost) return PassiveSpendResult.INSUFFICIENT_POINTS
+
+        allocatedNodes += nodeId
+        spentPassivePoints += node.cost
+        revision++
+        return PassiveSpendResult.ACCEPTED
+    }
+
+    fun has(nodeId: String): Boolean = nodeId in allocatedNodes
+
+    fun effects(): ProgressionEffects {
+        var directDamageBonus = 0.0
+        var attackSpeedBonus = 0.0
+        var cooldownRecoveryBonus = 0.0
+        var maxHealthBonus = 0
+        var incomingDamageReduction = 0.0
+        allocatedNodes.forEach { nodeId ->
+            val node = requireNotNull(GlobalPassiveTree.node(nodeId))
+            directDamageBonus += node.directDamageBonus
+            attackSpeedBonus += node.attackSpeedBonus
+            cooldownRecoveryBonus += node.cooldownRecoveryBonus
+            maxHealthBonus += node.maxHealthBonus
+            incomingDamageReduction += node.incomingDamageReduction
+        }
+        return ProgressionEffects(
+            directDamageMultiplier = 1.0 + directDamageBonus,
+            normalAttackSpeedMultiplier = 1.0 + attackSpeedBonus,
+            cooldownRecoveryMultiplier = 1.0 + cooldownRecoveryBonus,
+            maxHealthBonus = maxHealthBonus,
+            incomingPveDamageMultiplier = (1.0 - incomingDamageReduction).coerceAtLeast(0.0),
+        )
+    }
+
+    fun record(): ProgressionRecord = ProgressionRecord(
+        level = level,
+        experience = experience,
+        grantedPassivePoints = grantedPassivePoints,
+        spentPassivePoints = spentPassivePoints,
+        allocatedPassiveNodeIds = allocatedNodes.sorted(),
+        revision = revision,
+    )
+
+    fun copyState(): ProgressionState = fromRecord(record())
+
+    companion object {
+        const val MAX_LEVEL = 45
+
+        fun xpRequired(level: Int): Int {
+            require(level in 1..MAX_LEVEL) { "Level must be between 1 and $MAX_LEVEL" }
+            return 100 + (level - 1) * 50
+        }
+
+        fun fromRecord(record: ProgressionRecord): ProgressionState = ProgressionState(
+            level = record.level,
+            experience = record.experience,
+            grantedPassivePoints = record.grantedPassivePoints,
+            spentPassivePoints = record.spentPassivePoints,
+            allocatedPassiveNodeIds = record.allocatedPassiveNodeIds,
+            revision = record.revision,
+        )
+    }
+}

--- a/server-minestom/src/main/kotlin/dev/projects/server/ProgressionPersistence.kt
+++ b/server-minestom/src/main/kotlin/dev/projects/server/ProgressionPersistence.kt
@@ -1,0 +1,110 @@
+package dev.projects.server
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption.ATOMIC_MOVE
+import java.nio.file.StandardCopyOption.REPLACE_EXISTING
+import java.util.UUID
+
+sealed interface ProgressionLoadResult {
+    data object Missing : ProgressionLoadResult
+    data class Loaded(val state: ProgressionState) : ProgressionLoadResult
+    data class Invalid(val reason: String) : ProgressionLoadResult
+}
+
+/** Small, progression-specific v1 repository. Invalid files are blocked from automatic overwrite. */
+class ProgressionRepository(private val directory: Path) {
+    private val blockedPlayers = mutableSetOf<UUID>()
+
+    fun load(playerId: UUID): ProgressionLoadResult {
+        val file = fileFor(playerId)
+        if (!Files.isRegularFile(file)) return ProgressionLoadResult.Missing
+        return runCatching {
+            require(Files.size(file) <= MAX_FILE_BYTES) { "Progression file is too large" }
+            parse(Files.readString(file))
+        }.fold(
+            onSuccess = { ProgressionLoadResult.Loaded(it) },
+            onFailure = { error ->
+                blockedPlayers += playerId
+                ProgressionLoadResult.Invalid(error.message ?: "Malformed progression file")
+            },
+        )
+    }
+
+    fun save(playerId: UUID, state: ProgressionState): Boolean {
+        if (playerId in blockedPlayers) return false
+        return runCatching {
+            Files.createDirectories(directory)
+            val file = fileFor(playerId)
+            val temporary = directory.resolve(".${file.fileName}.${UUID.randomUUID()}.tmp")
+            try {
+                Files.writeString(temporary, encode(state.record()))
+                try {
+                    Files.move(temporary, file, ATOMIC_MOVE, REPLACE_EXISTING)
+                } catch (_: java.nio.file.AtomicMoveNotSupportedException) {
+                    Files.move(temporary, file, REPLACE_EXISTING)
+                }
+            } finally {
+                Files.deleteIfExists(temporary)
+            }
+            true
+        }.getOrDefault(false)
+    }
+
+    fun isBlocked(playerId: UUID): Boolean = playerId in blockedPlayers
+
+    private fun fileFor(playerId: UUID): Path = directory.resolve("$playerId.json")
+
+    private fun parse(raw: String): ProgressionState {
+        val schemaVersion = intField(raw, "schemaVersion")
+        require(schemaVersion == SCHEMA_VERSION) { "Unsupported progression schema version: $schemaVersion" }
+        val allocatedField = Regex("\\\"allocatedPassiveNodeIds\\\"\\s*:\\s*\\[(.*?)]", setOf(RegexOption.DOT_MATCHES_ALL))
+            .find(raw)?.groupValues?.get(1)
+            ?: error("Missing allocatedPassiveNodeIds")
+        val nodeIds = if (allocatedField.isBlank()) {
+            emptyList()
+        } else {
+            allocatedField.split(',').map { token ->
+                val nodeId = token.trim().removeSurrounding("\"")
+                require(NODE_ID.matches(nodeId)) { "Invalid passive node id" }
+                nodeId
+            }
+        }
+        return ProgressionState(
+            level = intField(raw, "level"),
+            experience = intField(raw, "experience"),
+            grantedPassivePoints = intField(raw, "grantedPassivePoints"),
+            spentPassivePoints = intField(raw, "spentPassivePoints"),
+            allocatedPassiveNodeIds = nodeIds,
+            revision = longField(raw, "revision"),
+        )
+    }
+
+    private fun intField(raw: String, key: String): Int =
+        Regex("\\\"$key\\\"\\s*:\\s*(-?\\d+)").find(raw)?.groupValues?.get(1)?.toInt()
+            ?: error("Missing progression field: $key")
+
+    private fun longField(raw: String, key: String): Long =
+        Regex("\\\"$key\\\"\\s*:\\s*(-?\\d+)").find(raw)?.groupValues?.get(1)?.toLong()
+            ?: error("Missing progression field: $key")
+
+    private fun encode(record: ProgressionRecord): String = buildString {
+        append("{\"schemaVersion\":").append(SCHEMA_VERSION)
+            .append(",\"level\":").append(record.level)
+            .append(",\"experience\":").append(record.experience)
+            .append(",\"grantedPassivePoints\":").append(record.grantedPassivePoints)
+            .append(",\"spentPassivePoints\":").append(record.spentPassivePoints)
+            .append(",\"allocatedPassiveNodeIds\":[")
+        record.allocatedPassiveNodeIds.forEachIndexed { index, nodeId ->
+            if (index > 0) append(',')
+            append('"').append(nodeId).append('"')
+        }
+        append("],\"revision\":").append(record.revision).append('}')
+    }
+
+    private companion object {
+        const val SCHEMA_VERSION = 1
+        const val MAX_FILE_BYTES = 16 * 1024L
+        val NODE_ID = Regex("[a-z0-9][a-z0-9:_/-]*")
+    }
+}

--- a/server-minestom/src/main/kotlin/dev/projects/server/ProgressionPersistence.kt
+++ b/server-minestom/src/main/kotlin/dev/projects/server/ProgressionPersistence.kt
@@ -56,37 +56,29 @@ class ProgressionRepository(private val directory: Path) {
     private fun fileFor(playerId: UUID): Path = directory.resolve("$playerId.json")
 
     private fun parse(raw: String): ProgressionState {
-        val schemaVersion = intField(raw, "schemaVersion")
+        val fields = ENVELOPE.find(raw)?.groupValues
+            ?: error("Malformed progression envelope")
+        val schemaVersion = fields[1].toInt()
         require(schemaVersion == SCHEMA_VERSION) { "Unsupported progression schema version: $schemaVersion" }
-        val allocatedField = Regex("\\\"allocatedPassiveNodeIds\\\"\\s*:\\s*\\[(.*?)]", setOf(RegexOption.DOT_MATCHES_ALL))
-            .find(raw)?.groupValues?.get(1)
-            ?: error("Missing allocatedPassiveNodeIds")
+        val allocatedField = fields[6]
         val nodeIds = if (allocatedField.isBlank()) {
             emptyList()
         } else {
-            allocatedField.split(',').map { token ->
-                val nodeId = token.trim().removeSurrounding("\"")
-                require(NODE_ID.matches(nodeId)) { "Invalid passive node id" }
-                nodeId
+            val matches = NODE_ID.findAll(allocatedField).toList()
+            require(matches.joinToString(",") { it.value } == allocatedField) {
+                "Malformed allocated passive node list"
             }
+            matches.map { it.groupValues[1] }
         }
         return ProgressionState(
-            level = intField(raw, "level"),
-            experience = intField(raw, "experience"),
-            grantedPassivePoints = intField(raw, "grantedPassivePoints"),
-            spentPassivePoints = intField(raw, "spentPassivePoints"),
+            level = fields[2].toInt(),
+            experience = fields[3].toInt(),
+            grantedPassivePoints = fields[4].toInt(),
+            spentPassivePoints = fields[5].toInt(),
             allocatedPassiveNodeIds = nodeIds,
-            revision = longField(raw, "revision"),
+            revision = fields[7].toLong(),
         )
     }
-
-    private fun intField(raw: String, key: String): Int =
-        Regex("\\\"$key\\\"\\s*:\\s*(-?\\d+)").find(raw)?.groupValues?.get(1)?.toInt()
-            ?: error("Missing progression field: $key")
-
-    private fun longField(raw: String, key: String): Long =
-        Regex("\\\"$key\\\"\\s*:\\s*(-?\\d+)").find(raw)?.groupValues?.get(1)?.toLong()
-            ?: error("Missing progression field: $key")
 
     private fun encode(record: ProgressionRecord): String = buildString {
         append("{\"schemaVersion\":").append(SCHEMA_VERSION)
@@ -105,6 +97,10 @@ class ProgressionRepository(private val directory: Path) {
     private companion object {
         const val SCHEMA_VERSION = 1
         const val MAX_FILE_BYTES = 16 * 1024L
-        val NODE_ID = Regex("[a-z0-9][a-z0-9:_/-]*")
+        val ENVELOPE = Regex(
+            """\A\{"schemaVersion":(-?\d+),"level":(-?\d+),"experience":(-?\d+),"grantedPassivePoints":(-?\d+),"spentPassivePoints":(-?\d+),"allocatedPassiveNodeIds":\[(.*)],"revision":(-?\d+)\}\z""",
+            setOf(RegexOption.DOT_MATCHES_ALL),
+        )
+        val NODE_ID = Regex("\"([a-z0-9][a-z0-9:_/-]*)\"")
     }
 }

--- a/server-minestom/src/main/kotlin/dev/projects/server/ProjectSServer.kt
+++ b/server-minestom/src/main/kotlin/dev/projects/server/ProjectSServer.kt
@@ -16,6 +16,11 @@ import dev.projects.protocol.ProtocolCodec
 import dev.projects.protocol.ProtocolHello
 import dev.projects.protocol.ProtocolHelloAck
 import dev.projects.protocol.ProtocolVersion
+import dev.projects.protocol.ProgressionSnapshot
+import dev.projects.protocol.ProgressionXpGained
+import dev.projects.protocol.PassiveNodeSpendRequest
+import dev.projects.protocol.PassiveNodeSpendResponse
+import dev.projects.protocol.PassiveNodeSpendResult as ProtocolPassiveNodeSpendResult
 import dev.projects.protocol.SlashEditorParameters
 import dev.projects.protocol.Skill3VfxTarget
 import dev.projects.protocol.VfxEditorNotice
@@ -98,6 +103,7 @@ import dev.projects.server.mod.ModStackingLayer
 private const val SERVER_ADDRESS = "127.0.0.1"
 private const val SERVER_PORT = 25565
 private const val DEFAULT_ATTACK_SPEED = 1.0
+private const val RIFT_EXECUTIONER_VICTORY_XP = 100
 private val SUPPORTED_ATTACK_SPEEDS = setOf(1.0, 1.5, 2.0)
 private const val DODGE_PLAYER_WIDTH = 0.6
 private const val DODGE_PLAYER_HEIGHT = 1.8
@@ -161,6 +167,7 @@ fun main() {
     val skill1States = mutableMapOf<UUID, Skill1State>()
     val skill2States = mutableMapOf<UUID, Skill2State>()
     val skill3States = mutableMapOf<UUID, Skill3State>()
+    val progressions = mutableMapOf<UUID, ProgressionState>()
     val resourceSyncTicks = mutableMapOf<UUID, Int>()
     val lastSentCooldowns = mutableMapOf<UUID, SkillCooldowns>()
     val dodgeVelocityActive = mutableMapOf<UUID, Boolean>()
@@ -188,7 +195,9 @@ fun main() {
     val slashDraftStore = SlashDraftStore(Path.of("config", "projects", "vfx-editor", "slash-drafts.json"))
     val skill3SlashBindingStore = Skill3SlashBindingStore(Path.of("config", "projects", "vfx-editor", "twin-blades-skill3-slash.json"))
     val skill3FinisherBindingStore = Skill3SlashBindingStore(Path.of("config", "projects", "vfx-editor", "twin-blades-skill3-finisher-slash.json"))
+    val progressionRepository = ProgressionRepository(Path.of("config", "projects", "progression"))
     val slashPreviewHandles = mutableMapOf<UUID, ParticleEffectHandle>()
+    val progressionLoadWarnings = mutableSetOf<UUID>()
 
     fun sendSlashDraftList(player: net.minestom.server.entity.Player) {
         player.sendPluginMessage(
@@ -245,6 +254,95 @@ fun main() {
         lastSentCooldowns[player.uuid] = cooldowns
     }
 
+    fun progressionEffects(playerId: UUID): ProgressionEffects =
+        progressions[playerId]?.effects() ?: ProgressionEffects.DEFAULT
+
+    fun sendProgressionSnapshot(player: net.minestom.server.entity.Player) {
+        val state = progressions[player.uuid] ?: return
+        val record = state.record()
+        player.sendPluginMessage(
+            PROJECTS_CHANNEL,
+            ProtocolCodec.encode(
+                ProgressionSnapshot(
+                    revision = record.revision,
+                    level = record.level,
+                    xp = record.experience,
+                    xpRequiredForNextLevel = state.xpRequiredForNextLevel,
+                    grantedPassivePoints = record.grantedPassivePoints,
+                    spentPassivePoints = record.spentPassivePoints,
+                    allocatedPassiveNodeIds = record.allocatedPassiveNodeIds,
+                ),
+            ),
+        )
+    }
+
+    fun loadProgression(playerId: UUID): ProgressionState {
+        return when (val result = progressionRepository.load(playerId)) {
+            ProgressionLoadResult.Missing -> ProgressionState()
+            is ProgressionLoadResult.Loaded -> result.state
+            is ProgressionLoadResult.Invalid -> {
+                if (progressionLoadWarnings.add(playerId)) {
+                    System.err.println("Progression load blocked for $playerId: ${result.reason}")
+                }
+                ProgressionState()
+            }
+        }
+    }
+
+    fun persistProgression(playerId: UUID, state: ProgressionState): Boolean {
+        val saved = progressionRepository.save(playerId, state)
+        if (!saved) {
+            System.err.println("Progression save failed for $playerId")
+        }
+        return saved
+    }
+
+    fun applyPlayerMaxHealth(player: net.minestom.server.entity.Player) {
+        val maxHealth = prototypeBoss.playerMaxHealth(player.uuid).toDouble()
+        player.getAttribute(net.minestom.server.entity.attribute.Attribute.MAX_HEALTH).setBaseValue(maxHealth)
+        player.setHealth(prototypeBoss.playerEntityHealth(player.uuid))
+    }
+
+    fun refreshPlayerProgressionEffects(player: net.minestom.server.entity.Player) {
+        prototypeBoss.setPlayerMaxHealth(
+            player.uuid,
+            prototypeBoss.playerMaxHealth + progressionEffects(player.uuid).maxHealthBonus,
+        )
+        applyPlayerMaxHealth(player)
+    }
+
+    fun sendProgressionSpendResponse(
+        player: net.minestom.server.entity.Player,
+        nodeId: String,
+        result: ProtocolPassiveNodeSpendResult,
+    ) {
+        val revision = progressions[player.uuid]?.revision ?: 0L
+        player.sendPluginMessage(
+            PROJECTS_CHANNEL,
+            ProtocolCodec.encode(PassiveNodeSpendResponse(nodeId, result, revision)),
+        )
+    }
+
+    fun grantVictoryXp(player: net.minestom.server.entity.Player) {
+        val current = progressions[player.uuid] ?: return
+        val updated = current.copyState()
+        val gain = updated.addXp(RIFT_EXECUTIONER_VICTORY_XP)
+        if (!persistProgression(player.uuid, updated)) return
+        progressions[player.uuid] = updated
+        player.sendPluginMessage(
+            PROJECTS_CHANNEL,
+            ProtocolCodec.encode(
+                ProgressionXpGained(
+                    amount = gain.amount,
+                    resultingLevel = gain.resultingLevel,
+                    levelUpCount = gain.levelUpCount,
+                    passivePointsGranted = gain.passivePointsGranted,
+                ),
+            ),
+        )
+        sendProgressionSnapshot(player)
+    }
+
     fun updateBossBar() {
         val status = when {
             prototypeBoss.isVictory -> "VICTORY"
@@ -281,10 +379,11 @@ fun main() {
         instance.players.forEach { player ->
             classResources[player.uuid]?.reset()
             resourceSyncTicks[player.uuid] = 0
-            player.setHealth(prototypeBoss.playerMaxHealth.toFloat())
+            applyPlayerMaxHealth(player)
             player.teleport(player.respawnPoint)
             player.showBossBar(bossBar)
             sendResourceSnapshot(player)
+            sendProgressionSnapshot(player)
         }
     }
 
@@ -295,8 +394,12 @@ fun main() {
         stopPlayerActions()
         updateBossBar()
         val result = if (prototypeBoss.isVictory) "VICTORY" else "DEFEAT"
+        if (prototypeBoss.claimVictoryReward()) {
+            instance.players.filter { it.isOnline }.forEach(::grantVictoryXp)
+        }
         instance.players.forEach {
             sendResourceSnapshot(it)
+            sendProgressionSnapshot(it)
             it.sendMessage(Component.text(result))
         }
     }
@@ -598,8 +701,14 @@ fun main() {
         event.player.respawnPoint = Pos(0.0, 41.0, 0.0)
     }
     events.addListener(PlayerSpawnEvent::class.java) { event ->
-        prototypeBoss.registerPlayer(event.player.uuid)
-        event.player.setHealth(prototypeBoss.playerMaxHealth.toFloat())
+        val playerId = event.player.uuid
+        if (event.isFirstSpawn) {
+            progressions[playerId] = loadProgression(playerId)
+        }
+        val progression = progressions.getOrPut(playerId) { ProgressionState() }
+        val loadedEffects = progression.effects()
+        prototypeBoss.registerPlayer(playerId, prototypeBoss.playerMaxHealth + loadedEffects.maxHealthBonus)
+        applyPlayerMaxHealth(event.player)
         val resources = classResources.getOrPut(event.player.uuid) { ClassResourceState() }
         val skill1 = skill1States.getOrPut(event.player.uuid) { Skill1State() }
         val skill2 = skill2States.getOrPut(event.player.uuid) { Skill2State() }
@@ -612,6 +721,7 @@ fun main() {
         }
         resourceSyncTicks[event.player.uuid] = 0
         sendResourceSnapshot(event.player)
+        sendProgressionSnapshot(event.player)
         updateBossBar()
         event.player.showBossBar(bossBar)
         if (event.isFirstSpawn) {
@@ -619,7 +729,10 @@ fun main() {
             twinBladesComboStates[event.player.uuid] = TwinBladesComboState()
             combatStates[event.player.uuid] = CombatState(
                 weaponSource = { weaponFor(event.player) },
-                attackSpeedSource = { attackSpeeds[event.player.uuid] ?: DEFAULT_ATTACK_SPEED },
+                attackSpeedSource = {
+                    (attackSpeeds[event.player.uuid] ?: DEFAULT_ATTACK_SPEED) *
+                        progressionEffects(event.player.uuid).normalAttackSpeedMultiplier
+                },
             )
             dodgeStates[event.player.uuid] = DodgeState()
             twinRodsAirStates[event.player.uuid] = TwinRodsAirState()
@@ -656,6 +769,7 @@ fun main() {
     }
     events.addListener(PlayerDisconnectEvent::class.java) { event ->
         val playerId = event.player.uuid
+        progressions[playerId]?.let { persistProgression(playerId, it) }
         particleAnimations.cancel(slashPreviewHandles.remove(playerId))
         particleAnimations.cancelFor(event.player)
         combatStates.remove(playerId)
@@ -665,6 +779,7 @@ fun main() {
         skill1States.remove(playerId)
         skill2States.remove(playerId)
         skill3States.remove(playerId)
+        progressions.remove(playerId)
         resourceSyncTicks.remove(playerId)
         lastSentCooldowns.remove(playerId)
         attackSpeeds.remove(playerId)
@@ -695,6 +810,7 @@ fun main() {
         val skill1 = skill1States[event.player.uuid] ?: return@addListener
         val skill2 = skill2States[event.player.uuid] ?: return@addListener
         val skill3 = skill3States[event.player.uuid] ?: return@addListener
+        val playerEffects = progressionEffects(event.player.uuid)
         if (event.player == instance.players.firstOrNull()) {
             if (prototypeBoss.isEncounterRunning) {
                 tickRiftExecutioner(
@@ -707,6 +823,9 @@ fun main() {
                     particleManager,
                     bossGroundTelegraphIds,
                     bossRiftTelegraphIds,
+                    incomingDamageMultiplier = { playerId ->
+                        progressionEffects(playerId).incomingPveDamageMultiplier
+                    },
                 ) {
                     nextGroundTelegraphId++
                 }
@@ -774,6 +893,7 @@ fun main() {
                 attackExecutionId = hit.attackExecutionId,
                 weapon = hit.weapon,
                 weakpoint = weakpoint?.weakpoint,
+                outgoingDamageMultiplier = playerEffects.directDamageMultiplier,
             )
             twinRodsAir.onAttackHit(hit.weapon, event.player.isOnGround, hit.attackExecutionId)
             if (skill3.reduceCooldownForNormalAttack(hit.attackExecutionId)) {
@@ -823,7 +943,7 @@ fun main() {
             finishEncounter()
             return@addListener
         }
-        val skill1Tick = skill1.tick()
+        val skill1Tick = skill1.tick(playerEffects.cooldownRecoveryMultiplier)
         if (skill1Tick.dashActive) {
             val direction = requireNotNull(skill1Tick.dashDirection)
             val start = event.player.position
@@ -844,7 +964,11 @@ fun main() {
             val hitTargets = skill1.hitTargetsOnSegment(start, end, skillTargets)
             if (hitTargets.isNotEmpty()) {
                 hitTargets.forEach { targetId ->
-                    val damage = prototypeBoss.applySkill1Attack(skill1.castId, targetId)
+                    val damage = prototypeBoss.applySkill1Attack(
+                        skill1.castId,
+                        targetId,
+                        playerEffects.directDamageMultiplier,
+                    )
                     if (damage > 0) updateBossBar()
                 }
                 showSkill1Impact(event.player, tester?.position ?: end, direction, particleAnimations, particleManager)
@@ -864,14 +988,19 @@ fun main() {
             finishEncounter()
             return@addListener
         }
-        val skill2Tick = skill2.tick(event.player.isOnGround)
+        val skill2Tick = skill2.tick(event.player.isOnGround, playerEffects.cooldownRecoveryMultiplier)
         if (skill2Tick.diveActive) {
             event.player.setVelocity(Vec(0.0, skill2Tick.velocityY, 0.0))
             showSkill2DiveTrail(event.player)
             skill2Tick.pulseIndex?.let { pulseIndex ->
                 val skillTargets = tester?.let { listOf(combatTarget(it)) } ?: emptyList()
                 skill2.hitTargetsAtPulse(pulseIndex, event.player.position, skillTargets).forEach { targetId ->
-                    val damage = prototypeBoss.applySkill2Pulse(skill2.castId, pulseIndex, targetId)
+                    val damage = prototypeBoss.applySkill2Pulse(
+                        skill2.castId,
+                        pulseIndex,
+                        targetId,
+                        playerEffects.directDamageMultiplier,
+                    )
                     if (damage > 0) updateBossBar()
                 }
                 showSkill2Pulse(event.player, pulseIndex, particleAnimations, particleManager)
@@ -879,7 +1008,11 @@ fun main() {
         } else if (skill2Tick.landed) {
             val skillTargets = tester?.let { listOf(combatTarget(it)) } ?: emptyList()
             skill2.hitTargetsAtLanding(event.player.position, skillTargets).forEach { targetId ->
-                val damage = prototypeBoss.applySkill2Landing(skill2.castId, targetId)
+                val damage = prototypeBoss.applySkill2Landing(
+                    skill2.castId,
+                    targetId,
+                    playerEffects.directDamageMultiplier,
+                )
                 if (damage > 0) updateBossBar()
             }
             showSkill2Landing(event.player, particleAnimations, particleManager)
@@ -896,7 +1029,11 @@ fun main() {
             skill3.cancelActiveMovement()
         } else {
             val previousSkill3Phase = skill3.phase
-            val skill3Tick = skill3.tick(event.player.isOnGround, event.player.velocity.y())
+            val skill3Tick = skill3.tick(
+                event.player.isOnGround,
+                event.player.velocity.y(),
+                playerEffects.cooldownRecoveryMultiplier,
+            )
             if (skill3Tick.dashActive) {
                 val direction = requireNotNull(skill3Tick.dashDirection)
                 val start = event.player.position
@@ -934,7 +1071,12 @@ fun main() {
                     skill3.cancelActiveMovement()
                 } else {
                     skill3Tick.pulseIndex?.let { pulseIndex ->
-                        val damage = prototypeBoss.applySkill3Pulse(skill3.castId, pulseIndex, target.id)
+                        val damage = prototypeBoss.applySkill3Pulse(
+                            skill3.castId,
+                            pulseIndex,
+                            target.id,
+                            playerEffects.directDamageMultiplier,
+                        )
                         if (damage > 0) updateBossBar()
                         showSkill3PulseVfx(
                             event.player,
@@ -947,7 +1089,11 @@ fun main() {
                         )
                     }
                     if (skill3Tick.finisherActive) {
-                        val damage = prototypeBoss.applySkill3Finisher(skill3.castId, target.id)
+                        val damage = prototypeBoss.applySkill3Finisher(
+                            skill3.castId,
+                            target.id,
+                            playerEffects.directDamageMultiplier,
+                        )
                         if (damage > 0) updateBossBar()
                         sendResourceSnapshot(event.player)
                         event.player.setVelocity(skill3HitBounceVelocity(requireNotNull(skill3Tick.dashDirection)))
@@ -1106,6 +1252,29 @@ fun main() {
                         ClassSkillSlot.ULTIMATE -> return@addListener
                     }
                 }
+                is PassiveNodeSpendRequest -> {
+                    val current = progressions[event.player.uuid] ?: return@addListener
+                    val updated = current.copyState()
+                    val domainResult = updated.spend(message.nodeId, message.expectedRevision)
+                    var protocolResult = when (domainResult) {
+                        PassiveSpendResult.ACCEPTED -> ProtocolPassiveNodeSpendResult.ACCEPTED
+                        PassiveSpendResult.UNKNOWN_NODE -> ProtocolPassiveNodeSpendResult.UNKNOWN_NODE
+                        PassiveSpendResult.ALREADY_ACQUIRED -> ProtocolPassiveNodeSpendResult.ALREADY_ACQUIRED
+                        PassiveSpendResult.INSUFFICIENT_POINTS -> ProtocolPassiveNodeSpendResult.INSUFFICIENT_POINTS
+                        PassiveSpendResult.MISSING_PREREQUISITE -> ProtocolPassiveNodeSpendResult.MISSING_PREREQUISITE
+                        PassiveSpendResult.STALE_REVISION -> ProtocolPassiveNodeSpendResult.STALE_REVISION
+                    }
+                    if (domainResult == PassiveSpendResult.ACCEPTED) {
+                        if (persistProgression(event.player.uuid, updated)) {
+                            progressions[event.player.uuid] = updated
+                            refreshPlayerProgressionEffects(event.player)
+                        } else {
+                            protocolResult = ProtocolPassiveNodeSpendResult.PERSISTENCE_FAILURE
+                        }
+                    }
+                    sendProgressionSpendResponse(event.player, message.nodeId, protocolResult)
+                    sendProgressionSnapshot(event.player)
+                }
                 is VfxSlashPreviewRequest -> previewSlash(event.player, message.parameters)
                 VfxSlashPreviewCancel -> particleAnimations.cancel(slashPreviewHandles.remove(event.player.uuid))
                 is VfxSlashApplySkill3 -> {
@@ -1249,6 +1418,7 @@ private fun tickRiftExecutioner(
     manager: ParticleManager,
     bossGroundTelegraphIds: MutableSet<Long>,
     bossRiftTelegraphIds: MutableMap<Long, Long>,
+    incomingDamageMultiplier: (UUID) -> Double,
     nextTelegraphId: () -> Long,
 ) {
     if (testerEntity == null || testerEntity.isRemoved || testerEntity.instance != instance) return
@@ -1335,7 +1505,12 @@ private fun tickRiftExecutioner(
             }
             is RiftExecutionerEvent.AttackHit -> {
                 instance.getPlayerByUuid(event.targetId)?.let { player ->
-                    val damage = bossState.applyBossDamage(player.uuid, event.executionId, event.damage)
+                    val damage = bossState.applyBossDamage(
+                        player.uuid,
+                        event.executionId,
+                        event.damage,
+                        incomingDamageMultiplier(player.uuid),
+                    )
                     if (damage == 0) return@let
                     player.setHealth(bossState.playerEntityHealth(player.uuid))
                     player.sendMessage(Component.text("[Rift Executioner] HIT $damage"))

--- a/server-minestom/src/main/kotlin/dev/projects/server/PrototypeBossState.kt
+++ b/server-minestom/src/main/kotlin/dev/projects/server/PrototypeBossState.kt
@@ -39,6 +39,7 @@ class PrototypeBossState(
         private set
 
     private val playerHealth = mutableMapOf<UUID, Int>()
+    private val playerMaxHealthValues = mutableMapOf<UUID, Int>()
     private val playerDamageExecutions = mutableMapOf<UUID, MutableSet<Long>>()
     private val bossDamageExecutions = mutableSetOf<Long>()
     private val skill3PulseDamageExecutions = mutableSetOf<Triple<Long, Int, UUID>>()
@@ -46,6 +47,7 @@ class PrototypeBossState(
     private val skill1DamageExecutions = mutableSetOf<Pair<Long, UUID>>()
     private val skill2PulseDamageExecutions = mutableSetOf<Triple<Long, Int, UUID>>()
     private val skill2LandingDamageExecutions = mutableSetOf<Pair<Long, UUID>>()
+    private var victoryRewardClaimed = false
 
     val isActive: Boolean
         get() = encounterState == PrototypeEncounterState.ACTIVE
@@ -69,30 +71,55 @@ class PrototypeBossState(
     val healthProgress: Float
         get() = currentHealth.toFloat() / maxHealth
 
-    fun registerPlayer(playerId: UUID) {
-        playerHealth.putIfAbsent(playerId, playerMaxHealth)
+    fun registerPlayer(playerId: UUID, maxHealth: Int = playerMaxHealth) {
+        require(maxHealth > 0) { "Player max health must be positive" }
+        playerMaxHealthValues.putIfAbsent(playerId, maxHealth)
+        playerHealth.putIfAbsent(playerId, maxHealth)
     }
 
     fun playerHealth(playerId: UUID): Int = playerHealth[playerId] ?: playerMaxHealth
 
+    fun playerMaxHealth(playerId: UUID): Int = playerMaxHealthValues[playerId] ?: playerMaxHealth
+
+    fun setPlayerMaxHealth(playerId: UUID, maxHealth: Int) {
+        require(maxHealth > 0) { "Player max health must be positive" }
+        registerPlayer(playerId)
+        playerMaxHealthValues[playerId] = maxHealth
+        playerHealth[playerId] = playerHealth(playerId).coerceAtMost(maxHealth)
+    }
+
     fun playerEntityHealth(playerId: UUID): Float = playerHealth(playerId).coerceAtLeast(1).toFloat()
 
     /** Applies one explicit boss attack to one player, once per execution. */
-    fun applyBossAttack(playerId: UUID, executionId: Long, attack: FixedAttackType): Int {
-        return applyBossDamage(playerId, executionId, attack.damage)
+    fun applyBossAttack(
+        playerId: UUID,
+        executionId: Long,
+        attack: FixedAttackType,
+        incomingDamageMultiplier: Double = 1.0,
+    ): Int {
+        return applyBossDamage(playerId, executionId, attack.damage, incomingDamageMultiplier)
     }
 
-    fun applyBossDamage(playerId: UUID, executionId: Long, damage: Int): Int {
+    fun applyBossDamage(
+        playerId: UUID,
+        executionId: Long,
+        damage: Int,
+        incomingDamageMultiplier: Double = 1.0,
+    ): Int {
         require(damage >= 0) { "Boss damage must not be negative" }
+        require(incomingDamageMultiplier >= 0.0 && incomingDamageMultiplier.isFinite()) {
+            "Incoming damage multiplier must be finite and non-negative"
+        }
         if (!isEncounterRunning) return 0
         registerPlayer(playerId)
         val executions = playerDamageExecutions.getOrPut(playerId) { mutableSetOf() }
         if (!executions.add(executionId)) return 0
 
-        val remainingHealth = (playerHealth(playerId) - damage).coerceAtLeast(0)
+        val effectiveDamage = (damage * incomingDamageMultiplier).roundToInt().coerceAtLeast(0)
+        val remainingHealth = (playerHealth(playerId) - effectiveDamage).coerceAtLeast(0)
         playerHealth[playerId] = remainingHealth
         if (remainingHealth == 0) encounterState = PrototypeEncounterState.DEFEAT
-        return damage
+        return effectiveDamage
     }
 
     /** Applies the server-confirmed player hit to the single prototype boss. */
@@ -100,6 +127,7 @@ class PrototypeBossState(
         attackExecutionId: Long,
         weapon: WeaponType,
         weakpoint: FixedWeakpoint? = null,
+        outgoingDamageMultiplier: Double = 1.0,
     ): Int {
         if (!isActive || !bossDamageExecutions.add(attackExecutionId)) return 0
 
@@ -107,39 +135,53 @@ class PrototypeBossState(
             WeaponType.HEAVY_BLADE -> HEAVY_BLADE_BODY_DAMAGE
             WeaponType.TWIN_RODS -> TWIN_RODS_BODY_DAMAGE
         }
-        return applyPlayerDamage(bodyDamage, weakpoint != null)
+        return applyPlayerDamage(bodyDamage, weakpoint != null, outgoingDamageMultiplier)
     }
 
     /** Applies one server-confirmed Skill3 pulse per cast, pulse, and target. */
-    fun applySkill3Pulse(castId: Long, pulseIndex: Int, targetId: UUID): Int {
+    fun applySkill3Pulse(
+        castId: Long,
+        pulseIndex: Int,
+        targetId: UUID,
+        outgoingDamageMultiplier: Double = 1.0,
+    ): Int {
         require(pulseIndex in 1..Skill3State.PULSE_COUNT) { "Skill3 pulse index is out of range" }
         if (!isActive || !skill3PulseDamageExecutions.add(Triple(castId, pulseIndex, targetId))) return 0
-        return applyPlayerDamage(SKILL_3_PULSE_DAMAGE)
+        return applyPlayerDamage(SKILL_3_PULSE_DAMAGE, outgoingDamageMultiplier = outgoingDamageMultiplier)
     }
 
     /** Applies the Skill3 finisher once per cast and target. */
-    fun applySkill3Finisher(castId: Long, targetId: UUID): Int {
+    fun applySkill3Finisher(
+        castId: Long,
+        targetId: UUID,
+        outgoingDamageMultiplier: Double = 1.0,
+    ): Int {
         if (!isActive || !skill3FinisherDamageExecutions.add(castId to targetId)) return 0
-        return applyPlayerDamage(SKILL_3_FINISHER_DAMAGE)
+        return applyPlayerDamage(SKILL_3_FINISHER_DAMAGE, outgoingDamageMultiplier = outgoingDamageMultiplier)
     }
 
     /** Applies one server-confirmed Skill1 hit per cast and target. */
-    fun applySkill1Attack(castId: Long, targetId: UUID): Int {
+    fun applySkill1Attack(castId: Long, targetId: UUID, outgoingDamageMultiplier: Double = 1.0): Int {
         if (!isActive || !skill1DamageExecutions.add(castId to targetId)) return 0
-        return applyPlayerDamage(SKILL_1_DAMAGE)
+        return applyPlayerDamage(SKILL_1_DAMAGE, outgoingDamageMultiplier = outgoingDamageMultiplier)
     }
 
     /** Applies one server-confirmed Skill2 pulse hit per cast, pulse, and target. */
-    fun applySkill2Pulse(castId: Long, pulseIndex: Int, targetId: UUID): Int {
+    fun applySkill2Pulse(
+        castId: Long,
+        pulseIndex: Int,
+        targetId: UUID,
+        outgoingDamageMultiplier: Double = 1.0,
+    ): Int {
         require(pulseIndex in 1..Skill2State.PULSE_COUNT) { "Skill2 pulse index is out of range" }
         if (!isActive || !skill2PulseDamageExecutions.add(Triple(castId, pulseIndex, targetId))) return 0
-        return applyPlayerDamage(SKILL_2_PULSE_DAMAGE)
+        return applyPlayerDamage(SKILL_2_PULSE_DAMAGE, outgoingDamageMultiplier = outgoingDamageMultiplier)
     }
 
     /** Applies the server-confirmed Skill2 landing finisher once per cast and target. */
-    fun applySkill2Landing(castId: Long, targetId: UUID): Int {
+    fun applySkill2Landing(castId: Long, targetId: UUID, outgoingDamageMultiplier: Double = 1.0): Int {
         if (!isActive || !skill2LandingDamageExecutions.add(castId to targetId)) return 0
-        return applyPlayerDamage(SKILL_2_LANDING_DAMAGE)
+        return applyPlayerDamage(SKILL_2_LANDING_DAMAGE, outgoingDamageMultiplier = outgoingDamageMultiplier)
     }
 
     fun setBreakActive(active: Boolean) {
@@ -150,6 +192,13 @@ class PrototypeBossState(
         if (encounterState == PrototypeEncounterState.FINAL_STRUGGLE) {
             encounterState = PrototypeEncounterState.VICTORY
         }
+    }
+
+    /** Claims the encounter reward gate once after a successful victory. */
+    fun claimVictoryReward(): Boolean {
+        if (!isVictory || victoryRewardClaimed) return false
+        victoryRewardClaimed = true
+        return true
     }
 
     /** Development-only phase jump used to inspect one mechanic without a full HP burn. */
@@ -208,14 +257,22 @@ class PrototypeBossState(
         skill2PulseDamageExecutions.clear()
         skill2LandingDamageExecutions.clear()
         playerDamageExecutions.clear()
-        playerHealth.keys.toList().forEach { playerHealth[it] = playerMaxHealth }
+        victoryRewardClaimed = false
+        playerHealth.keys.toList().forEach { playerHealth[it] = playerMaxHealth(it) }
     }
 
-    private fun applyPlayerDamage(bodyDamage: Int, weakpoint: Boolean = false): Int {
+    private fun applyPlayerDamage(
+        bodyDamage: Int,
+        weakpoint: Boolean = false,
+        outgoingDamageMultiplier: Double = 1.0,
+    ): Int {
+        require(outgoingDamageMultiplier >= 0.0 && outgoingDamageMultiplier.isFinite()) {
+            "Outgoing damage multiplier must be finite and non-negative"
+        }
         if (!isActive) return 0
         val breakMultiplier = if (breakActive) BREAK_MULTIPLIER else 1.0
         val weakpointMultiplier = if (weakpoint) WEAKPOINT_MULTIPLIER else 1.0
-        val damage = (bodyDamage * breakMultiplier * weakpointMultiplier).roundToInt()
+        val damage = (bodyDamage * breakMultiplier * weakpointMultiplier * outgoingDamageMultiplier).roundToInt()
         currentHealth = (currentHealth - damage).coerceAtLeast(0)
         updatePhase()
         if (currentHealth == 0) encounterState = PrototypeEncounterState.FINAL_STRUGGLE

--- a/server-minestom/src/main/kotlin/dev/projects/server/Skill1State.kt
+++ b/server-minestom/src/main/kotlin/dev/projects/server/Skill1State.kt
@@ -39,6 +39,7 @@ class Skill1State(
 
     private var hitWindowOpen = false
     private val hitTargets = mutableSetOf<UUID>()
+    private var cooldownRecoveryRemainder = 0.0
 
     val isReady: Boolean
         get() = phase == Skill1Phase.IDLE && cooldownTicksRemaining == 0
@@ -55,7 +56,10 @@ class Skill1State(
         return castId
     }
 
-    fun tick(): Skill1Tick {
+    fun tick(cooldownRecoveryMultiplier: Double = 1.0): Skill1Tick {
+        require(cooldownRecoveryMultiplier >= 1.0 && cooldownRecoveryMultiplier.isFinite()) {
+            "Skill1 cooldown recovery multiplier must be finite and at least 1"
+        }
         val wasDashing = phase == Skill1Phase.DASH
         hitWindowOpen = wasDashing
         val result = when (phase) {
@@ -76,7 +80,7 @@ class Skill1State(
                 Skill1Tick(Skill1Phase.IDLE, null, false)
             }
         }
-        if (cooldownTicksRemaining > 0) cooldownTicksRemaining--
+        advanceCooldown(cooldownRecoveryMultiplier)
         if (!wasDashing) hitWindowOpen = false
         return result
     }
@@ -106,11 +110,24 @@ class Skill1State(
         castId = 0L
         hitWindowOpen = false
         hitTargets.clear()
+        cooldownRecoveryRemainder = 0.0
     }
 
     fun reset() {
         cancelActiveMovement()
         cooldownTicksRemaining = 0
+    }
+
+    private fun advanceCooldown(multiplier: Double) {
+        if (cooldownTicksRemaining <= 0) {
+            cooldownRecoveryRemainder = 0.0
+            return
+        }
+        cooldownRecoveryRemainder += multiplier
+        val recoveredTicks = (cooldownRecoveryRemainder + 1.0e-9).toInt()
+        cooldownRecoveryRemainder -= recoveredTicks
+        cooldownTicksRemaining = (cooldownTicksRemaining - recoveredTicks).coerceAtLeast(0)
+        if (cooldownTicksRemaining == 0) cooldownRecoveryRemainder = 0.0
     }
 
     companion object {

--- a/server-minestom/src/main/kotlin/dev/projects/server/Skill2State.kt
+++ b/server-minestom/src/main/kotlin/dev/projects/server/Skill2State.kt
@@ -37,6 +37,7 @@ class Skill2State(
     private var activePulse: Int? = null
     private val pulseHitTargets = mutableMapOf<Int, MutableSet<UUID>>()
     private val landingHitTargets = mutableSetOf<UUID>()
+    private var cooldownRecoveryRemainder = 0.0
 
     val isReady: Boolean
         get() = phase == Skill2Phase.IDLE && cooldownTicksRemaining == 0
@@ -54,7 +55,10 @@ class Skill2State(
         return castId
     }
 
-    fun tick(isGrounded: Boolean): Skill2Tick {
+    fun tick(isGrounded: Boolean, cooldownRecoveryMultiplier: Double = 1.0): Skill2Tick {
+        require(cooldownRecoveryMultiplier >= 1.0 && cooldownRecoveryMultiplier.isFinite()) {
+            "Skill2 cooldown recovery multiplier must be finite and at least 1"
+        }
         if (phase == Skill2Phase.DIVE) {
             if (isGrounded) {
                 phase = Skill2Phase.IDLE
@@ -77,7 +81,7 @@ class Skill2State(
 
         activePulse = null
         landingWindowOpen = false
-        if (cooldownTicksRemaining > 0) cooldownTicksRemaining--
+        advanceCooldown(cooldownRecoveryMultiplier)
         return Skill2Tick(Skill2Phase.IDLE, false, 0.0)
     }
 
@@ -126,6 +130,19 @@ class Skill2State(
         activePulse = null
         pulseHitTargets.clear()
         landingHitTargets.clear()
+        cooldownRecoveryRemainder = 0.0
+    }
+
+    private fun advanceCooldown(multiplier: Double) {
+        if (cooldownTicksRemaining <= 0) {
+            cooldownRecoveryRemainder = 0.0
+            return
+        }
+        cooldownRecoveryRemainder += multiplier
+        val recoveredTicks = (cooldownRecoveryRemainder + 1.0e-9).toInt()
+        cooldownRecoveryRemainder -= recoveredTicks
+        cooldownTicksRemaining = (cooldownTicksRemaining - recoveredTicks).coerceAtLeast(0)
+        if (cooldownTicksRemaining == 0) cooldownRecoveryRemainder = 0.0
     }
 
     companion object {

--- a/server-minestom/src/main/kotlin/dev/projects/server/Skill3State.kt
+++ b/server-minestom/src/main/kotlin/dev/projects/server/Skill3State.kt
@@ -52,6 +52,7 @@ class Skill3State(
     private var nextPulseIndex = 1
     private var ticksUntilNextPulse = 0
     private var finisherPending = false
+    private var cooldownRecoveryRemainder = 0.0
 
     val isReady: Boolean
         get() = phase == Skill3Phase.IDLE && cooldownTicksRemaining == 0
@@ -71,8 +72,15 @@ class Skill3State(
         return castId
     }
 
-    fun tick(isGrounded: Boolean, velocityY: Double): Skill3Tick {
+    fun tick(
+        isGrounded: Boolean,
+        velocityY: Double,
+        cooldownRecoveryMultiplier: Double = 1.0,
+    ): Skill3Tick {
         require(velocityY.isFinite()) { "Skill3 velocity must be finite" }
+        require(cooldownRecoveryMultiplier >= 1.0 && cooldownRecoveryMultiplier.isFinite()) {
+            "Skill3 cooldown recovery multiplier must be finite and at least 1"
+        }
         val wasDashing = phase == Skill3Phase.DASH
         val tick = when (phase) {
             Skill3Phase.DASH -> {
@@ -154,9 +162,7 @@ class Skill3State(
             Skill3Phase.IDLE -> Skill3Tick(Skill3Phase.IDLE, null, false, velocityY)
         }
 
-        if (!wasDashing && cooldownTicksRemaining > 0 && !tick.finisherActive) {
-            cooldownTicksRemaining--
-        }
+        if (!wasDashing && !tick.finisherActive) advanceCooldown(cooldownRecoveryMultiplier)
         return tick
     }
 
@@ -170,6 +176,7 @@ class Skill3State(
         nextPulseIndex = 1
         ticksUntilNextPulse = 0
         finisherPending = false
+        cooldownRecoveryRemainder = 0.0
         return true
     }
 
@@ -221,6 +228,18 @@ class Skill3State(
         cancelActiveMovement()
         cooldownTicksRemaining = 0
         reducedNormalAttackExecutions.clear()
+    }
+
+    private fun advanceCooldown(multiplier: Double) {
+        if (cooldownTicksRemaining <= 0) {
+            cooldownRecoveryRemainder = 0.0
+            return
+        }
+        cooldownRecoveryRemainder += multiplier
+        val recoveredTicks = (cooldownRecoveryRemainder + 1.0e-9).toInt()
+        cooldownRecoveryRemainder -= recoveredTicks
+        cooldownTicksRemaining = (cooldownTicksRemaining - recoveredTicks).coerceAtLeast(0)
+        if (cooldownTicksRemaining == 0) cooldownRecoveryRemainder = 0.0
     }
 
     companion object {

--- a/server-minestom/src/test/kotlin/dev/projects/server/ProgressionPersistenceTest.kt
+++ b/server-minestom/src/test/kotlin/dev/projects/server/ProgressionPersistenceTest.kt
@@ -1,0 +1,42 @@
+package dev.projects.server
+
+import java.nio.file.Files
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+class ProgressionPersistenceTest {
+    @Test
+    fun `missing player starts clean and saved state round trips`() {
+        val directory = Files.createTempDirectory("projects-progression-test")
+        val repository = ProgressionRepository(directory)
+        val playerId = UUID.randomUUID()
+        val state = ProgressionState().also {
+            it.addXp(100)
+            assertEquals(PassiveSpendResult.ACCEPTED, it.spend(GlobalPassiveTree.FORCE))
+        }
+
+        assertIs<ProgressionLoadResult.Missing>(repository.load(playerId))
+        assertTrue(repository.save(playerId, state))
+        val loaded = assertIs<ProgressionLoadResult.Loaded>(repository.load(playerId)).state
+        assertEquals(state.record(), loaded.record())
+    }
+
+    @Test
+    fun `malformed schema is isolated and never silently overwritten`() {
+        val directory = Files.createTempDirectory("projects-progression-invalid")
+        val repository = ProgressionRepository(directory)
+        val playerId = UUID.randomUUID()
+        val file = directory.resolve("$playerId.json")
+        val original = "{\"schemaVersion\":99,\"level\":1}"
+        Files.createDirectories(directory)
+        Files.writeString(file, original)
+
+        assertIs<ProgressionLoadResult.Invalid>(repository.load(playerId))
+        assertFalse(repository.save(playerId, ProgressionState()))
+        assertEquals(original, Files.readString(file))
+    }
+}

--- a/server-minestom/src/test/kotlin/dev/projects/server/ProgressionPersistenceTest.kt
+++ b/server-minestom/src/test/kotlin/dev/projects/server/ProgressionPersistenceTest.kt
@@ -39,4 +39,18 @@ class ProgressionPersistenceTest {
         assertFalse(repository.save(playerId, ProgressionState()))
         assertEquals(original, Files.readString(file))
     }
+
+    @Test
+    fun `trailing garbage is rejected and original bytes remain untouched`() {
+        val directory = Files.createTempDirectory("projects-progression-trailing")
+        val repository = ProgressionRepository(directory)
+        val playerId = UUID.randomUUID()
+        val file = directory.resolve("$playerId.json")
+        val original = "{\"schemaVersion\":1,\"level\":1,\"experience\":0,\"grantedPassivePoints\":0,\"spentPassivePoints\":0,\"allocatedPassiveNodeIds\":[],\"revision\":0} trailing"
+        Files.writeString(file, original)
+
+        assertIs<ProgressionLoadResult.Invalid>(repository.load(playerId))
+        assertFalse(repository.save(playerId, ProgressionState()))
+        assertEquals(original, Files.readString(file))
+    }
 }

--- a/server-minestom/src/test/kotlin/dev/projects/server/ProgressionTest.kt
+++ b/server-minestom/src/test/kotlin/dev/projects/server/ProgressionTest.kt
@@ -1,0 +1,78 @@
+package dev.projects.server
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ProgressionTest {
+    @Test
+    fun `xp threshold carries remainder and grants one point per level`() {
+        val state = ProgressionState()
+
+        val first = state.addXp(100)
+        assertEquals(1, first.levelUpCount)
+        assertEquals(2, state.level)
+        assertEquals(0, state.experience)
+        assertEquals(1, state.grantedPassivePoints)
+
+        state.addXp(449)
+        assertEquals(4, state.level)
+        assertEquals(99, state.experience)
+        assertEquals(3, state.grantedPassivePoints)
+    }
+
+    @Test
+    fun `level cap discards overflow without creating invalid state`() {
+        val state = ProgressionState(level = 44, grantedPassivePoints = 43)
+
+        state.addXp(10_000)
+
+        assertEquals(ProgressionState.MAX_LEVEL, state.level)
+        assertEquals(0, state.experience)
+        assertEquals(44, state.grantedPassivePoints)
+        assertEquals(0, state.xpRequiredForNextLevel)
+        state.addXp(100)
+        assertEquals(45, state.level)
+        assertEquals(0, state.experience)
+    }
+
+    @Test
+    fun `global tree validates stale revision prerequisites duplicates and points`() {
+        val state = ProgressionState(grantedPassivePoints = 2)
+
+        assertEquals(PassiveSpendResult.MISSING_PREREQUISITE, state.spend(GlobalPassiveTree.OVERPOWER))
+        assertEquals(PassiveSpendResult.STALE_REVISION, state.spend(GlobalPassiveTree.FORCE, expectedRevision = 1L))
+        assertEquals(PassiveSpendResult.ACCEPTED, state.spend(GlobalPassiveTree.FORCE, expectedRevision = 0L))
+        assertEquals(PassiveSpendResult.ALREADY_ACQUIRED, state.spend(GlobalPassiveTree.FORCE, expectedRevision = 1L))
+        assertEquals(PassiveSpendResult.ACCEPTED, state.spend(GlobalPassiveTree.OVERPOWER, expectedRevision = 1L))
+        assertEquals(PassiveSpendResult.INSUFFICIENT_POINTS, state.spend(GlobalPassiveTree.TEMPO))
+        assertTrue(state.has(GlobalPassiveTree.OVERPOWER))
+        assertEquals(0, state.availablePassivePoints)
+    }
+
+    @Test
+    fun `all global nodes resolve to combat modifiers`() {
+        val state = ProgressionState(
+            grantedPassivePoints = GlobalPassiveTree.nodes.size,
+        )
+        GlobalPassiveTree.nodes.forEach { node ->
+            assertEquals(PassiveSpendResult.ACCEPTED, state.spend(node.id))
+        }
+
+        val effects = state.effects()
+        assertEquals(1.30, effects.directDamageMultiplier)
+        assertEquals(1.15, effects.normalAttackSpeedMultiplier)
+        assertEquals(1.20, effects.cooldownRecoveryMultiplier)
+        assertEquals(4, effects.maxHealthBonus)
+        assertEquals(0.90, effects.incomingPveDamageMultiplier)
+    }
+
+    @Test
+    fun `default effects preserve existing combat values`() {
+        val effects = ProgressionState().effects()
+
+        assertEquals(ProgressionEffects.DEFAULT, effects)
+        assertFalse(ProgressionState().has(GlobalPassiveTree.FORCE))
+    }
+}

--- a/server-minestom/src/test/kotlin/dev/projects/server/PrototypeBossStateTest.kt
+++ b/server-minestom/src/test/kotlin/dev/projects/server/PrototypeBossStateTest.kt
@@ -27,6 +27,27 @@ class PrototypeBossStateTest {
     }
 
     @Test
+    fun `progression modifiers affect outgoing and incoming pve damage`() {
+        val boss = PrototypeBossState()
+
+        assertEquals(23, boss.applyPlayerAttack(1L, WeaponType.HEAVY_BLADE, outgoingDamageMultiplier = 1.15))
+        assertEquals(5, boss.applyBossAttack(playerId, 2L, FixedAttackType.SIDE_SWEEP, incomingDamageMultiplier = 0.90))
+        assertEquals(15, boss.playerHealth(playerId))
+    }
+
+    @Test
+    fun `player max health modifier survives reset`() {
+        val boss = PrototypeBossState()
+
+        boss.registerPlayer(playerId, 24)
+        boss.applyBossDamage(playerId, 1L, 8)
+        boss.reset()
+
+        assertEquals(24, boss.playerMaxHealth(playerId))
+        assertEquals(24, boss.playerHealth(playerId))
+    }
+
+    @Test
     fun `head and back weakpoints both multiply body damage`() {
         val boss = PrototypeBossState()
 
@@ -52,6 +73,18 @@ class PrototypeBossStateTest {
 
         boss.completeFinalStruggle()
         assertTrue(boss.isVictory)
+    }
+
+    @Test
+    fun `victory reward gate grants once and resets for the next encounter`() {
+        val boss = PrototypeBossState(maxHealth = 20)
+        boss.applyPlayerAttack(1L, WeaponType.HEAVY_BLADE)
+        boss.completeFinalStruggle()
+
+        assertTrue(boss.claimVictoryReward())
+        assertFalse(boss.claimVictoryReward())
+        boss.reset()
+        assertFalse(boss.claimVictoryReward())
     }
 
     @Test

--- a/server-minestom/src/test/kotlin/dev/projects/server/Skill1StateTest.kt
+++ b/server-minestom/src/test/kotlin/dev/projects/server/Skill1StateTest.kt
@@ -71,6 +71,16 @@ class Skill1StateTest {
     }
 
     @Test
+    fun `skill1 cooldown recovery modifier consumes fractional ticks`() {
+        val skill1 = Skill1State(sequence())
+        skill1.tryCast(Vec(0.0, 0.0, 1.0))
+
+        repeat(5) { skill1.tick(1.20) }
+
+        assertEquals(74, skill1.cooldownTicksRemaining)
+    }
+
+    @Test
     fun `skill2 cast cancels skill1 movement but preserves its cooldown`() {
         val skill1 = Skill1State(sequence())
         val skill2 = Skill2State(sequence())

--- a/server-minestom/src/test/kotlin/dev/projects/server/Skill2StateTest.kt
+++ b/server-minestom/src/test/kotlin/dev/projects/server/Skill2StateTest.kt
@@ -91,6 +91,17 @@ class Skill2StateTest {
         assertEquals(0, skill2.cooldownTicksRemaining)
     }
 
+    @Test
+    fun `skill2 cooldown recovery modifier consumes fractional ticks`() {
+        val skill2 = Skill2State(sequence())
+        skill2.tryCast(false)
+        skill2.tick(true)
+
+        repeat(5) { skill2.tick(false, 1.20) }
+
+        assertEquals(94, skill2.cooldownTicksRemaining)
+    }
+
     private fun sequence(): () -> Long {
         var id = 0L
         return { ++id }

--- a/server-minestom/src/test/kotlin/dev/projects/server/Skill3StateTest.kt
+++ b/server-minestom/src/test/kotlin/dev/projects/server/Skill3StateTest.kt
@@ -72,6 +72,17 @@ class Skill3StateTest {
     }
 
     @Test
+    fun `skill3 cooldown recovery modifier consumes fractional ticks`() {
+        val skill3 = Skill3State(sequence())
+        skill3.tryCast(facing, ClassSkillDirection(0.0, 1.0))
+        repeat(4) { skill3.tick(false, 0.0) }
+
+        repeat(5) { skill3.tick(false, -1.0, 1.20) }
+
+        assertEquals(54, skill3.cooldownTicksRemaining)
+    }
+
+    @Test
     fun `dash segment selects the nearest target and only one target per cast`() {
         val skill3 = Skill3State(sequence())
         skill3.tryCast(facing, ClassSkillDirection(0.0, 1.0))


### PR DESCRIPTION
Refs #110. Implements the global Lv1-45 XP progression slice, six-node passive tree, versioned persistence, protocol v12 sync, XP/level-up HUD feedback, K tree screen, authoritative node spending, and server-side combat modifiers. Tests: ./gradlew test. Build: ./gradlew build. Manual Smoke remains for the Creator.