### PR TITLE
Merge quest map gathering updates

### DIFF
--- a/server-minestom/src/main/kotlin/dev/projects/server/ProjectSServer.kt
+++ b/server-minestom/src/main/kotlin/dev/projects/server/ProjectSServer.kt
@@ -46,6 +46,8 @@ import net.minestom.server.entity.GameMode
 import net.minestom.server.entity.ItemEntity
 import net.minestom.server.entity.PlayerHand
 import net.minestom.server.event.entity.EntityDeathEvent
+import net.minestom.server.event.inventory.InventoryPreClickEvent
+import net.minestom.server.event.item.PlayerCancelItemUseEvent
 import net.minestom.server.event.player.AsyncPlayerConfigurationEvent
 import net.minestom.server.event.player.PlayerPluginMessageEvent
 import net.minestom.server.event.player.PlayerBlockInteractEvent
@@ -60,6 +62,7 @@ import net.minestom.server.instance.block.Block
 import net.minestom.server.instance.Instance
 import net.minestom.server.instance.LightingChunk
 import net.minestom.server.instance.Weather
+import net.minestom.server.inventory.click.Click
 import net.minestom.server.item.ItemStack
 import net.minestom.server.item.Material
 import net.minestom.server.tag.Tag
@@ -888,14 +891,15 @@ fun main() {
     events.addListener(PlayerBlockInteractEvent::class.java) { event ->
         if (event.hand == PlayerHand.MAIN && questMaps.startGathering(event.player, event.blockPosition)) {
             event.isCancelled = true
-            event.isBlockingItemUse = true
+        }
+    }
+    events.addListener(InventoryPreClickEvent::class.java) { event ->
+        if (event.click !is Click.Left && event.click !is Click.Right) return@addListener
+        if (questMaps.applyGatheringTablet(event.player, event.inventory, event.slot, event.clickedItem)) {
+            event.isCancelled = true
         }
     }
     events.addListener(PlayerUseItemEvent::class.java) { event ->
-        if (event.hand == PlayerHand.MAIN && questMaps.applyGatheringTablet(event.player)) {
-            event.isCancelled = true
-            return@addListener
-        }
         val mapData = questMaps.questMapItemData(event.itemStack) ?: return@addListener
         event.isCancelled = true
         prepareQuestMapTransfer(event.player)
@@ -905,6 +909,9 @@ fun main() {
     }
     events.addListener(PlayerEntityInteractEvent::class.java) { event ->
         if (event.hand == PlayerHand.MAIN) questMaps.startGathering(event.player, event.target)
+    }
+    events.addListener(PlayerCancelItemUseEvent::class.java) { event ->
+        if (event.hand == PlayerHand.MAIN) questMaps.cancelGathering(event.player)
     }
     events.addListener(EntityDeathEvent::class.java) { event ->
         val dead = event.entity

--- a/server-minestom/src/main/kotlin/dev/projects/server/ProjectSServer.kt
+++ b/server-minestom/src/main/kotlin/dev/projects/server/ProjectSServer.kt
@@ -43,7 +43,9 @@ import net.minestom.server.entity.Entity
 import net.minestom.server.entity.EntityType
 import net.minestom.server.entity.EquipmentSlot
 import net.minestom.server.entity.GameMode
+import net.minestom.server.entity.ItemEntity
 import net.minestom.server.entity.PlayerHand
+import net.minestom.server.event.entity.EntityDeathEvent
 import net.minestom.server.event.player.AsyncPlayerConfigurationEvent
 import net.minestom.server.event.player.PlayerPluginMessageEvent
 import net.minestom.server.event.player.PlayerBlockInteractEvent
@@ -52,6 +54,7 @@ import net.minestom.server.event.player.PlayerFinishDiggingEvent
 import net.minestom.server.event.player.PlayerDisconnectEvent
 import net.minestom.server.event.player.PlayerSpawnEvent
 import net.minestom.server.event.player.PlayerTickEvent
+import net.minestom.server.event.player.PlayerUseItemEvent
 import net.minestom.server.event.instance.InstanceTickEvent
 import net.minestom.server.instance.block.Block
 import net.minestom.server.instance.Instance
@@ -68,6 +71,7 @@ import net.kyori.adventure.sound.Sound
 import net.kyori.adventure.key.Key
 import java.nio.charset.StandardCharsets
 import java.nio.file.Path
+import java.time.Duration
 import java.util.UUID
 import kotlin.math.abs
 import kotlin.math.floor
@@ -404,7 +408,10 @@ fun main() {
         updateBossBar()
         val result = if (prototypeBoss.isVictory) "VICTORY" else "DEFEAT"
         if (prototypeBoss.claimVictoryReward()) {
-            instance.players.filter { it.isOnline }.forEach(::grantVictoryXp)
+            instance.players.filter { it.isOnline }.forEach { player ->
+                grantVictoryXp(player)
+                questMaps.grantBossMapLoot(player)
+            }
         }
         instance.players.forEach {
             sendResourceSnapshot(it)
@@ -496,6 +503,10 @@ fun main() {
             addSyntax({ sender, _ ->
                 sender.sendMessage(Component.text("Quest map pool ${questMaps.status()}"))
             }, ArgumentType.Literal("status"))
+            addSyntax({ sender, _ ->
+                val player = sender as? net.minestom.server.entity.Player ?: return@addSyntax
+                questMaps.grantMapCustomizationTestItems(player)
+            }, ArgumentType.Literal("give"))
         },
     )
     val gatheringTreeLiteral = ArgumentType.Literal("tree")
@@ -880,8 +891,30 @@ fun main() {
             event.isBlockingItemUse = true
         }
     }
+    events.addListener(PlayerUseItemEvent::class.java) { event ->
+        if (event.hand == PlayerHand.MAIN && questMaps.applyGatheringTablet(event.player)) {
+            event.isCancelled = true
+            return@addListener
+        }
+        val mapData = questMaps.questMapItemData(event.itemStack) ?: return@addListener
+        event.isCancelled = true
+        prepareQuestMapTransfer(event.player)
+        questMaps.enterMapItem(event.player, mapData, event.hand).thenAccept { entered ->
+            if (!entered) event.player.showBossBar(bossBar)
+        }
+    }
     events.addListener(PlayerEntityInteractEvent::class.java) { event ->
         if (event.hand == PlayerHand.MAIN) questMaps.startGathering(event.player, event.target)
+    }
+    events.addListener(EntityDeathEvent::class.java) { event ->
+        val dead = event.entity
+        if (dead is net.minestom.server.entity.Player || dead === dummy) return@addListener
+        questMaps.rollMobMapLoot(dead.entityId).forEach { item ->
+            ItemEntity(item).apply {
+                setPickupDelay(Duration.ofMillis(600))
+                setInstance(event.instance, dead.position)
+            }
+        }
     }
     events.addListener(PlayerFinishDiggingEvent::class.java) { event ->
         questMaps.protectGatheringNode(event.player, event.blockPosition)?.let { resourceBlock ->

--- a/server-minestom/src/main/kotlin/dev/projects/server/questmap/QuestGathering.kt
+++ b/server-minestom/src/main/kotlin/dev/projects/server/questmap/QuestGathering.kt
@@ -5,9 +5,13 @@ import net.kyori.adventure.text.format.NamedTextColor
 import net.minestom.server.coordinate.BlockVec
 import net.minestom.server.coordinate.Pos
 import net.minestom.server.coordinate.Vec
+import net.minestom.server.component.DataComponents
 import net.minestom.server.instance.block.Block
+import net.minestom.server.item.component.Consumable
+import net.minestom.server.item.ItemAnimation
 import net.minestom.server.item.ItemStack
 import net.minestom.server.item.Material
+import net.minestom.server.sound.SoundEvent
 import net.minestom.server.tag.Tag
 import java.nio.file.Files
 import java.nio.file.Path
@@ -88,14 +92,24 @@ internal enum class QuestGatheringDiscipline(
     ),
     ;
 
-    fun toolItem(): ItemStack = ItemStack.builder(toolMaterial)
+    fun toolItem(): ItemStack = ItemStack.builder(Material.STICK)
         .customName(Component.text(toolName, NamedTextColor.GOLD))
+        .set(DataComponents.ITEM_MODEL, toolMaterial.name().toString())
+        .set(DataComponents.CONSUMABLE, GATHERING_HOLD_COMPONENT)
         .build()
         .withTag(QUEST_GATHERING_TOOL_TAG, id)
 
     fun accepts(item: ItemStack): Boolean = item.getTag(QUEST_GATHERING_TOOL_TAG) == id
 
     companion object {
+        private val GATHERING_HOLD_COMPONENT = Consumable(
+            3_600f,
+            ItemAnimation.NONE,
+            SoundEvent.ENTITY_GENERIC_EAT,
+            false,
+            emptyList(),
+        )
+
         fun forGatheringOrdinal(ordinal: Int): QuestGatheringDiscipline = entries[Math.floorMod(ordinal, entries.size)]
     }
 }

--- a/server-minestom/src/main/kotlin/dev/projects/server/questmap/QuestGathering.kt
+++ b/server-minestom/src/main/kotlin/dev/projects/server/questmap/QuestGathering.kt
@@ -29,6 +29,7 @@ internal enum class QuestGatheringDiscipline(
     val displayName: String,
     val toolName: String,
     val toolMaterial: Material,
+    val denseRegionName: String,
     val nodeBlock: Block,
     val commonMaterial: Material,
     val commonResourceName: String,
@@ -40,6 +41,7 @@ internal enum class QuestGatheringDiscipline(
         displayName = "皮剥ぎ",
         toolName = "皮剥ぎナイフ",
         toolMaterial = Material.FLINT,
+        denseRegionName = "獣の墓場",
         nodeBlock = Block.BONE_BLOCK,
         commonMaterial = Material.LEATHER,
         commonResourceName = "獣皮",
@@ -51,6 +53,7 @@ internal enum class QuestGatheringDiscipline(
         displayName = "伐採",
         toolName = "木こりの斧",
         toolMaterial = Material.STONE_AXE,
+        denseRegionName = "古樹の森",
         nodeBlock = Block.OAK_LOG,
         commonMaterial = Material.OAK_LOG,
         commonResourceName = "木材",
@@ -62,6 +65,7 @@ internal enum class QuestGatheringDiscipline(
         displayName = "採石",
         toolName = "石工の槌",
         toolMaterial = Material.IRON_PICKAXE,
+        denseRegionName = "露岩地帯",
         nodeBlock = Block.ANDESITE,
         commonMaterial = Material.COBBLESTONE,
         commonResourceName = "石材",
@@ -73,6 +77,7 @@ internal enum class QuestGatheringDiscipline(
         displayName = "採鉱",
         toolName = "鉱夫のツルハシ",
         toolMaterial = Material.STONE_PICKAXE,
+        denseRegionName = "鉱脈",
         nodeBlock = Block.COPPER_ORE,
         commonMaterial = Material.RAW_COPPER,
         commonResourceName = "鉱石",
@@ -84,6 +89,7 @@ internal enum class QuestGatheringDiscipline(
         displayName = "植物採取",
         toolName = "採集鎌",
         toolMaterial = Material.IRON_HOE,
+        denseRegionName = "薬草群生地",
         nodeBlock = Block.MOSS_BLOCK,
         commonMaterial = Material.STRING,
         commonResourceName = "植物繊維",
@@ -184,6 +190,7 @@ internal data class QuestGatheringNode(
     val discipline: QuestGatheringDiscipline,
     val quality: QuestGatheringQuality,
     val tier: Int = 1,
+    val denseRegionId: Int? = null,
 )
 
 internal fun questGatheringNodes(
@@ -212,6 +219,39 @@ internal fun questGatheringNodes(
 
     val nodes = baseNodes.toMutableList()
     var nextId = baseNodes.size
+    val occupied = nodes.mapTo(mutableListOf()) { it.blockPosition }
+
+    baseNodes.forEach { base ->
+        if (plan.roadDistanceSquaredAt(base.blockPosition.blockX(), base.blockPosition.blockZ()) <= 7 * 7) {
+            return@forEach
+        }
+        val chance = (
+            BASE_DENSE_REGION_CHANCE_PERCENT + customization.denseRegionBonusPercent(base.discipline)
+            ).coerceIn(0, 100)
+        val regionRoll = Math.floorMod(
+            plan.seed xor (base.id * 0x63D83595A7C2B9E5L) xor 0x21C6A4D7F9035B8EL,
+            100L,
+        ).toInt()
+        if (regionRoll >= chance) return@forEach
+
+        val regionPoints = denseGatheringRegionPoints(plan, base, occupied)
+        if (regionPoints.size < DENSE_REGION_EXTRA_NODES) return@forEach
+        val regionId = base.id
+        val baseIndex = nodes.indexOfFirst { it.id == base.id }
+        nodes[baseIndex] = base.copy(denseRegionId = regionId)
+        regionPoints.forEach { point ->
+            val id = nextId++
+            val position = BlockVec(point.x, plan.heightAt(point) + 1, point.z)
+            nodes += base.copy(
+                id = id,
+                blockPosition = position,
+                quality = gatheringQuality(plan, id, base.discipline, customization),
+                denseRegionId = regionId,
+            )
+            occupied += position
+        }
+    }
+
     baseNodes.forEach { base ->
         val bonus = customization.amountBonusPercent(base.discipline)
         val guaranteed = bonus / 100
@@ -221,17 +261,43 @@ internal fun questGatheringNodes(
         ).toInt()
         val extraCount = guaranteed + if (remainderRoll < bonus % 100) 1 else 0
         repeat(extraCount) { extraOrdinal ->
-            val occupied = nodes.map { it.blockPosition }
             val point = extraGatheringPoint(plan, base, extraOrdinal, occupied) ?: return@repeat
             val id = nextId++
+            val position = BlockVec(point.x, plan.heightAt(point) + 1, point.z)
             nodes += base.copy(
                 id = id,
-                blockPosition = BlockVec(point.x, plan.heightAt(point) + 1, point.z),
+                blockPosition = position,
                 quality = gatheringQuality(plan, id, base.discipline, customization),
             )
+            occupied += position
         }
     }
     return nodes
+}
+
+private fun denseGatheringRegionPoints(
+    plan: QuestMapPlan,
+    base: QuestGatheringNode,
+    occupied: List<BlockVec>,
+): List<QuestMapPoint> {
+    val offsets = listOf(
+        14 to 0, -14 to 0, 0 to 14, 0 to -14,
+        11 to 11, -11 to 11, 11 to -11, -11 to -11,
+        22 to 0, -22 to 0, 0 to 22, 0 to -22,
+        17 to 17, -17 to 17, 17 to -17, -17 to -17,
+        8 to 21, -8 to 21, 8 to -21, -8 to -21,
+        21 to 8, -21 to 8, 21 to -8, -21 to -8,
+    )
+    val rotation = Math.floorMod(plan.seed + base.id * 53L, offsets.size.toLong()).toInt()
+    val selected = mutableListOf<QuestMapPoint>()
+    repeat(offsets.size) { attempt ->
+        if (selected.size >= DENSE_REGION_EXTRA_NODES) return@repeat
+        val (dx, dz) = offsets[(rotation + attempt) % offsets.size]
+        val point = QuestMapPoint(base.blockPosition.blockX() + dx, base.blockPosition.blockZ() + dz)
+        if (!isValidGatheringPoint(plan, point, occupied, selected)) return@repeat
+        selected += point
+    }
+    return selected
 }
 
 private fun gatheringQuality(
@@ -279,27 +345,44 @@ private fun extraGatheringPoint(
     repeat(offsets.size) { attempt ->
         val (dx, dz) = offsets[(rotation + attempt) % offsets.size]
         val point = QuestMapPoint(originX + dx, originZ + dz)
-        if (point.x !in 4 until plan.size - 4 || point.z !in 4 until plan.size - 4) return@repeat
-        if (plan.heightAt(point) <= QUEST_WATER_LEVEL) return@repeat
-        if (plan.roadDistanceSquaredAt(point.x, point.z) <= 7 * 7) return@repeat
-        val nearbyHeights = listOf(
-            plan.heightAt(point),
-            plan.heightAt(point.x - 2, point.z),
-            plan.heightAt(point.x + 2, point.z),
-            plan.heightAt(point.x, point.z - 2),
-            plan.heightAt(point.x, point.z + 2),
-        )
-        if (nearbyHeights.max() - nearbyHeights.min() > 3) return@repeat
-        if (occupied.any { existing ->
-                val separationX = existing.blockX() - point.x
-                val separationZ = existing.blockZ() - point.z
-                separationX * separationX + separationZ * separationZ < 10 * 10
-            }
-        ) return@repeat
+        if (!isValidGatheringPoint(plan, point, occupied, emptyList())) return@repeat
         return point
     }
     return null
 }
+
+private fun isValidGatheringPoint(
+    plan: QuestMapPlan,
+    point: QuestMapPoint,
+    occupied: List<BlockVec>,
+    selected: List<QuestMapPoint>,
+): Boolean {
+    if (point.x !in 4 until plan.size - 4 || point.z !in 4 until plan.size - 4) return false
+    if (plan.heightAt(point) <= QUEST_WATER_LEVEL) return false
+    if (plan.roadDistanceSquaredAt(point.x, point.z) <= 7 * 7) return false
+    val nearbyHeights = listOf(
+        plan.heightAt(point),
+        plan.heightAt(point.x - 2, point.z),
+        plan.heightAt(point.x + 2, point.z),
+        plan.heightAt(point.x, point.z - 2),
+        plan.heightAt(point.x, point.z + 2),
+    )
+    if (nearbyHeights.max() - nearbyHeights.min() > 3) return false
+    if (occupied.any { existing ->
+            val separationX = existing.blockX() - point.x
+            val separationZ = existing.blockZ() - point.z
+            separationX * separationX + separationZ * separationZ < 10 * 10
+        }
+    ) return false
+    return selected.none { existing ->
+        val separationX = existing.x - point.x
+        val separationZ = existing.z - point.z
+        separationX * separationX + separationZ * separationZ < 10 * 10
+    }
+}
+
+private const val BASE_DENSE_REGION_CHANCE_PERCENT = 4
+private const val DENSE_REGION_EXTRA_NODES = 6
 
 internal fun gatheringProgressDisplayPosition(
     playerPosition: Pos,

--- a/server-minestom/src/main/kotlin/dev/projects/server/questmap/QuestGathering.kt
+++ b/server-minestom/src/main/kotlin/dev/projects/server/questmap/QuestGathering.kt
@@ -172,9 +172,13 @@ internal data class QuestGatheringNode(
     val tier: Int = 1,
 )
 
-internal fun questGatheringNodes(plan: QuestMapPlan): List<QuestGatheringNode> = plan.contents
-    .filter { it.kind == QuestMapContentKind.GATHERING }
-    .mapIndexed { ordinal, content ->
+internal fun questGatheringNodes(
+    plan: QuestMapPlan,
+    customization: QuestMapCustomization = QuestMapCustomization.NONE,
+): List<QuestGatheringNode> {
+    val baseNodes = plan.contents
+        .filter { it.kind == QuestMapContentKind.GATHERING }
+        .mapIndexed { ordinal, content ->
         val discipline = QuestGatheringDiscipline.forGatheringOrdinal(ordinal)
         val routeAnchor = plan.mainRoute[content.mainRouteIndex]
         val outwardX = (content.position.x - routeAnchor.x).coerceIn(-1, 1)
@@ -183,20 +187,105 @@ internal fun questGatheringNodes(plan: QuestMapPlan): List<QuestGatheringNode> =
             (content.position.x + outwardX * 12).coerceIn(2, plan.size - 3),
             (content.position.z + outwardZ * 12).coerceIn(2, plan.size - 3),
         )
-        val roll = Math.floorMod(plan.seed xor (ordinal * 2_654_435_761L), 100L).toInt()
-        val quality = when {
-            roll < 6 -> QuestGatheringQuality.RARE
-            roll < 28 -> QuestGatheringQuality.BOUNTIFUL
-            else -> QuestGatheringQuality.COMMON
-        }
         QuestGatheringNode(
             id = ordinal,
             contentPosition = content.position,
             blockPosition = BlockVec(resourcePoint.x, plan.heightAt(resourcePoint) + 1, resourcePoint.z),
             discipline = discipline,
-            quality = quality,
+            quality = gatheringQuality(plan, ordinal, discipline, customization),
         )
     }
+
+    val nodes = baseNodes.toMutableList()
+    var nextId = baseNodes.size
+    baseNodes.forEach { base ->
+        val bonus = customization.amountBonusPercent(base.discipline)
+        val guaranteed = bonus / 100
+        val remainderRoll = Math.floorMod(
+            plan.seed xor (base.id * 0x4CF5AD432745937FL) xor 0x2A7B9C4D1E6F8053L,
+            100L,
+        ).toInt()
+        val extraCount = guaranteed + if (remainderRoll < bonus % 100) 1 else 0
+        repeat(extraCount) { extraOrdinal ->
+            val occupied = nodes.map { it.blockPosition }
+            val point = extraGatheringPoint(plan, base, extraOrdinal, occupied) ?: return@repeat
+            val id = nextId++
+            nodes += base.copy(
+                id = id,
+                blockPosition = BlockVec(point.x, plan.heightAt(point) + 1, point.z),
+                quality = gatheringQuality(plan, id, base.discipline, customization),
+            )
+        }
+    }
+    return nodes
+}
+
+private fun gatheringQuality(
+    plan: QuestMapPlan,
+    nodeId: Int,
+    discipline: QuestGatheringDiscipline,
+    customization: QuestMapCustomization,
+): QuestGatheringQuality {
+    val baseRoll = Math.floorMod(plan.seed xor (nodeId * 2_654_435_761L), 100L).toInt()
+    var quality = when {
+        baseRoll < 6 -> QuestGatheringQuality.RARE
+        baseRoll < 28 -> QuestGatheringQuality.BOUNTIFUL
+        else -> QuestGatheringQuality.COMMON
+    }
+    val bonus = customization.qualityBonusPercent(discipline)
+    var upgrades = bonus / 100
+    val upgradeRoll = Math.floorMod(
+        plan.seed xor (nodeId * 0x6EED0E9DA4D94A4FL) xor discipline.ordinal.toLong(),
+        100L,
+    ).toInt()
+    if (upgradeRoll < bonus % 100) upgrades++
+    repeat(upgrades) {
+        quality = when (quality) {
+            QuestGatheringQuality.COMMON -> QuestGatheringQuality.BOUNTIFUL
+            QuestGatheringQuality.BOUNTIFUL, QuestGatheringQuality.RARE -> QuestGatheringQuality.RARE
+        }
+    }
+    return quality
+}
+
+private fun extraGatheringPoint(
+    plan: QuestMapPlan,
+    base: QuestGatheringNode,
+    extraOrdinal: Int,
+    occupied: List<BlockVec>,
+): QuestMapPoint? {
+    val offsets = listOf(
+        12 to 0, -12 to 0, 0 to 12, 0 to -12,
+        10 to 10, -10 to 10, 10 to -10, -10 to -10,
+        16 to 5, -16 to 5, 5 to 16, 5 to -16,
+    )
+    val rotation = Math.floorMod(plan.seed + base.id * 31L + extraOrdinal * 7L, offsets.size.toLong()).toInt()
+    val originX = base.blockPosition.blockX()
+    val originZ = base.blockPosition.blockZ()
+    repeat(offsets.size) { attempt ->
+        val (dx, dz) = offsets[(rotation + attempt) % offsets.size]
+        val point = QuestMapPoint(originX + dx, originZ + dz)
+        if (point.x !in 4 until plan.size - 4 || point.z !in 4 until plan.size - 4) return@repeat
+        if (plan.heightAt(point) <= QUEST_WATER_LEVEL) return@repeat
+        if (plan.roadDistanceSquaredAt(point.x, point.z) <= 7 * 7) return@repeat
+        val nearbyHeights = listOf(
+            plan.heightAt(point),
+            plan.heightAt(point.x - 2, point.z),
+            plan.heightAt(point.x + 2, point.z),
+            plan.heightAt(point.x, point.z - 2),
+            plan.heightAt(point.x, point.z + 2),
+        )
+        if (nearbyHeights.max() - nearbyHeights.min() > 3) return@repeat
+        if (occupied.any { existing ->
+                val separationX = existing.blockX() - point.x
+                val separationZ = existing.blockZ() - point.z
+                separationX * separationX + separationZ * separationZ < 10 * 10
+            }
+        ) return@repeat
+        return point
+    }
+    return null
+}
 
 internal fun gatheringProgressDisplayPosition(
     playerPosition: Pos,

--- a/server-minestom/src/main/kotlin/dev/projects/server/questmap/QuestMapCustomization.kt
+++ b/server-minestom/src/main/kotlin/dev/projects/server/questmap/QuestMapCustomization.kt
@@ -12,6 +12,7 @@ internal val QUEST_GATHERING_TABLET_TAG: Tag<String> = Tag.String("projects_gath
 internal enum class QuestMapGatheringStat(val id: String, val displayName: String) {
     AMOUNT("amount", "生成量"),
     QUALITY("quality", "品質"),
+    DENSE_REGIONS("dense_regions", "密集地域出現率"),
 }
 
 internal data class QuestMapGatheringModifier(
@@ -25,8 +26,14 @@ internal data class QuestMapGatheringModifier(
 
     val key: String = "${discipline?.id ?: "all"}:${stat.id}"
 
-    fun displayName(): String =
-        "${discipline?.commonResourceName ?: "全採取物"}の${stat.displayName} +$percent%"
+    fun displayName(): String {
+        val target = when (stat) {
+            QuestMapGatheringStat.DENSE_REGIONS -> discipline?.displayName ?: "全資源"
+            QuestMapGatheringStat.AMOUNT, QuestMapGatheringStat.QUALITY ->
+                discipline?.commonResourceName ?: "全採取物"
+        }
+        return "${target}の${stat.displayName} +$percent%"
+    }
 }
 
 internal data class QuestMapCustomization(
@@ -40,6 +47,9 @@ internal data class QuestMapCustomization(
     fun amountBonusPercent(discipline: QuestGatheringDiscipline): Int = bonus(discipline, QuestMapGatheringStat.AMOUNT)
 
     fun qualityBonusPercent(discipline: QuestGatheringDiscipline): Int = bonus(discipline, QuestMapGatheringStat.QUALITY)
+
+    fun denseRegionBonusPercent(discipline: QuestGatheringDiscipline): Int =
+        bonus(discipline, QuestMapGatheringStat.DENSE_REGIONS)
 
     private fun bonus(discipline: QuestGatheringDiscipline, stat: QuestMapGatheringStat): Int = modifiers
         .filter { it.stat == stat && (it.discipline == null || it.discipline == discipline) }
@@ -113,8 +123,9 @@ internal object QuestMapItems {
         val magnitudeRoll = Math.floorMod(mix64(mixed xor 0x517CC1B727220A95L), 10_000L).toInt()
         val percent = when {
             discipline == null && stat == QuestMapGatheringStat.AMOUNT -> 10 + magnitudeRoll % 11
-            discipline == null && stat == QuestMapGatheringStat.QUALITY -> 8 + magnitudeRoll % 8
+            discipline == null -> 8 + magnitudeRoll % 8
             stat == QuestMapGatheringStat.AMOUNT -> 25 + magnitudeRoll % 26
+            stat == QuestMapGatheringStat.DENSE_REGIONS -> 25 + magnitudeRoll % 26
             else -> 20 + magnitudeRoll % 21
         }
         return data.copy(

--- a/server-minestom/src/main/kotlin/dev/projects/server/questmap/QuestMapCustomization.kt
+++ b/server-minestom/src/main/kotlin/dev/projects/server/questmap/QuestMapCustomization.kt
@@ -1,0 +1,159 @@
+package dev.projects.server.questmap
+
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.format.NamedTextColor
+import net.minestom.server.item.ItemStack
+import net.minestom.server.item.Material
+import net.minestom.server.tag.Tag
+
+internal val QUEST_MAP_ITEM_TAG: Tag<String> = Tag.String("projects_quest_map")
+internal val QUEST_GATHERING_TABLET_TAG: Tag<String> = Tag.String("projects_gathering_tablet")
+
+internal enum class QuestMapGatheringStat(val id: String, val displayName: String) {
+    AMOUNT("amount", "生成量"),
+    QUALITY("quality", "品質"),
+}
+
+internal data class QuestMapGatheringModifier(
+    val discipline: QuestGatheringDiscipline?,
+    val stat: QuestMapGatheringStat,
+    val percent: Int,
+) {
+    init {
+        require(percent in 1..200)
+    }
+
+    val key: String = "${discipline?.id ?: "all"}:${stat.id}"
+
+    fun displayName(): String =
+        "${discipline?.commonResourceName ?: "全採取物"}の${stat.displayName} +$percent%"
+}
+
+internal data class QuestMapCustomization(
+    val modifiers: List<QuestMapGatheringModifier> = emptyList(),
+) {
+    init {
+        require(modifiers.size <= MAX_MODIFIERS)
+        require(modifiers.map { it.key }.distinct().size == modifiers.size)
+    }
+
+    fun amountBonusPercent(discipline: QuestGatheringDiscipline): Int = bonus(discipline, QuestMapGatheringStat.AMOUNT)
+
+    fun qualityBonusPercent(discipline: QuestGatheringDiscipline): Int = bonus(discipline, QuestMapGatheringStat.QUALITY)
+
+    private fun bonus(discipline: QuestGatheringDiscipline, stat: QuestMapGatheringStat): Int = modifiers
+        .filter { it.stat == stat && (it.discipline == null || it.discipline == discipline) }
+        .sumOf { it.percent }
+
+    companion object {
+        const val MAX_MODIFIERS = 3
+        val NONE = QuestMapCustomization()
+    }
+}
+
+internal data class QuestMapItemData(
+    val seed: Long,
+    val customization: QuestMapCustomization = QuestMapCustomization.NONE,
+)
+
+internal object QuestMapItems {
+    private const val SCHEMA = "v1"
+    private const val TABLET_SCHEMA = "gathering_v1"
+
+    fun questMap(data: QuestMapItemData): ItemStack {
+        val modifierLore = if (data.customization.modifiers.isEmpty()) {
+            listOf(Component.text("MODなし", NamedTextColor.DARK_GRAY))
+        } else {
+            data.customization.modifiers.map { modifier ->
+                Component.text(modifier.displayName(), NamedTextColor.AQUA)
+            }
+        }
+        return ItemStack.builder(Material.FILLED_MAP)
+            .customName(Component.text("クエストマップ", NamedTextColor.GOLD))
+            .lore(
+                listOf(Component.text("seed: ${data.seed}", NamedTextColor.DARK_GRAY)) +
+                    modifierLore +
+                    listOf(
+                        Component.empty(),
+                        Component.text("右クリック: マップを開始", NamedTextColor.YELLOW),
+                        Component.text("石板をメイン手、マップをオフハンドに持つとMODを付与", NamedTextColor.GRAY),
+                    ),
+            )
+            .build()
+            .withTag(QUEST_MAP_ITEM_TAG, encode(data))
+    }
+
+    fun gatheringTablet(): ItemStack = ItemStack.builder(Material.AMETHYST_SHARD)
+        .customName(Component.text("採取の石板", NamedTextColor.LIGHT_PURPLE))
+        .lore(
+            Component.text("クエストマップへランダムな採取MODを1つ付与する", NamedTextColor.GRAY),
+            Component.text("メイン手: 石板　オフハンド: クエストマップ", NamedTextColor.YELLOW),
+            Component.text("最大${QuestMapCustomization.MAX_MODIFIERS}MOD", NamedTextColor.DARK_GRAY),
+        )
+        .glowing(true)
+        .build()
+        .withTag(QUEST_GATHERING_TABLET_TAG, TABLET_SCHEMA)
+
+    fun read(item: ItemStack): QuestMapItemData? = item.getTag(QUEST_MAP_ITEM_TAG)?.let(::decode)
+
+    fun isGatheringTablet(item: ItemStack): Boolean = item.getTag(QUEST_GATHERING_TABLET_TAG) == TABLET_SCHEMA
+
+    fun applyTablet(data: QuestMapItemData, roll: Long): QuestMapItemData? {
+        if (data.customization.modifiers.size >= QuestMapCustomization.MAX_MODIFIERS) return null
+        val existing = data.customization.modifiers.mapTo(hashSetOf()) { it.key }
+        val candidates = buildList {
+            QuestMapGatheringStat.entries.forEach { stat -> add(null to stat) }
+            QuestGatheringDiscipline.entries.forEach { discipline ->
+                QuestMapGatheringStat.entries.forEach { stat -> add(discipline to stat) }
+            }
+        }.filterNot { (discipline, stat) -> "${discipline?.id ?: "all"}:${stat.id}" in existing }
+        if (candidates.isEmpty()) return null
+        val mixed = mix64(roll xor data.seed xor (data.customization.modifiers.size * 0x9E3779B97F4A7C15UL.toLong()))
+        val (discipline, stat) = candidates[Math.floorMod(mixed, candidates.size.toLong()).toInt()]
+        val magnitudeRoll = Math.floorMod(mix64(mixed xor 0x517CC1B727220A95L), 10_000L).toInt()
+        val percent = when {
+            discipline == null && stat == QuestMapGatheringStat.AMOUNT -> 10 + magnitudeRoll % 11
+            discipline == null && stat == QuestMapGatheringStat.QUALITY -> 8 + magnitudeRoll % 8
+            stat == QuestMapGatheringStat.AMOUNT -> 25 + magnitudeRoll % 26
+            else -> 20 + magnitudeRoll % 21
+        }
+        return data.copy(
+            customization = QuestMapCustomization(
+                data.customization.modifiers + QuestMapGatheringModifier(discipline, stat, percent),
+            ),
+        )
+    }
+
+    private fun encode(data: QuestMapItemData): String = buildString {
+        append(SCHEMA).append(';').append(data.seed)
+        data.customization.modifiers.forEach { modifier ->
+            append(';')
+                .append(modifier.discipline?.id ?: "all").append(',')
+                .append(modifier.stat.id).append(',')
+                .append(modifier.percent)
+        }
+    }
+
+    private fun decode(raw: String): QuestMapItemData? = runCatching {
+        val fields = raw.split(';')
+        require(fields.size in 2..2 + QuestMapCustomization.MAX_MODIFIERS)
+        require(fields[0] == SCHEMA)
+        val modifiers = fields.drop(2).map { encoded ->
+            val parts = encoded.split(',')
+            require(parts.size == 3)
+            val discipline = if (parts[0] == "all") null else {
+                QuestGatheringDiscipline.entries.single { it.id == parts[0] }
+            }
+            val stat = QuestMapGatheringStat.entries.single { it.id == parts[1] }
+            QuestMapGatheringModifier(discipline, stat, parts[2].toInt())
+        }
+        QuestMapItemData(fields[1].toLong(), QuestMapCustomization(modifiers))
+    }.getOrNull()
+
+    private fun mix64(value: Long): Long {
+        var mixed = value
+        mixed = (mixed xor (mixed ushr 30)) * -4_658_895_280_553_007_687L
+        mixed = (mixed xor (mixed ushr 27)) * -7_723_592_293_110_705_685L
+        return mixed xor (mixed ushr 31)
+    }
+}

--- a/server-minestom/src/main/kotlin/dev/projects/server/questmap/QuestMapCustomization.kt
+++ b/server-minestom/src/main/kotlin/dev/projects/server/questmap/QuestMapCustomization.kt
@@ -76,7 +76,7 @@ internal object QuestMapItems {
                     listOf(
                         Component.empty(),
                         Component.text("右クリック: マップを開始", NamedTextColor.YELLOW),
-                        Component.text("石板をメイン手、マップをオフハンドに持つとMODを付与", NamedTextColor.GRAY),
+                        Component.text("インベントリで石板を重ねるとMODを付与", NamedTextColor.GRAY),
                     ),
             )
             .build()
@@ -87,7 +87,7 @@ internal object QuestMapItems {
         .customName(Component.text("採取の石板", NamedTextColor.LIGHT_PURPLE))
         .lore(
             Component.text("クエストマップへランダムな採取MODを1つ付与する", NamedTextColor.GRAY),
-            Component.text("メイン手: 石板　オフハンド: クエストマップ", NamedTextColor.YELLOW),
+            Component.text("インベントリでつかみ、クエストマップをクリック", NamedTextColor.YELLOW),
             Component.text("最大${QuestMapCustomization.MAX_MODIFIERS}MOD", NamedTextColor.DARK_GRAY),
         )
         .glowing(true)

--- a/server-minestom/src/main/kotlin/dev/projects/server/questmap/VerdantRoadQuestRuntime.kt
+++ b/server-minestom/src/main/kotlin/dev/projects/server/questmap/VerdantRoadQuestRuntime.kt
@@ -22,6 +22,7 @@ import net.minestom.server.instance.Weather
 import net.minestom.server.instance.block.Block
 import net.minestom.server.instance.generator.GenerationUnit
 import net.minestom.server.instance.generator.Generator
+import net.minestom.server.inventory.AbstractInventory
 import net.minestom.server.item.ItemStack
 import net.minestom.server.network.packet.server.play.ParticlePacket
 import net.minestom.server.network.packet.server.play.EntityAnimationPacket
@@ -1714,11 +1715,9 @@ internal class VerdantRoadQuestService(
         val node: QuestGatheringNode,
         val targetPosition: BlockVec,
         val targetEntity: Entity?,
-        val requiresContinuousInput: Boolean,
         val requiredTicks: Int,
         val progressDisplay: Entity,
         var elapsedTicks: Int = 0,
-        var lastInputTick: Long,
     )
 
     fun prewarmInitial(): CompletableFuture<Void> = CompletableFuture.allOf(
@@ -1752,14 +1751,15 @@ internal class VerdantRoadQuestService(
 
     fun questMapItemData(item: ItemStack): QuestMapItemData? = QuestMapItems.read(item)
 
-    fun applyGatheringTablet(player: Player): Boolean {
-        val tablet = player.itemInMainHand
+    fun applyGatheringTablet(
+        player: Player,
+        inventory: AbstractInventory,
+        slot: Int,
+        clickedItem: ItemStack,
+    ): Boolean {
+        val tablet = player.inventory.cursorItem
         if (!QuestMapItems.isGatheringTablet(tablet)) return false
-        val mapData = QuestMapItems.read(player.itemInOffHand)
-        if (mapData == null) {
-            player.sendActionBar(Component.text("オフハンドにクエストマップを持ってください。", NamedTextColor.RED))
-            return true
-        }
+        val mapData = QuestMapItems.read(clickedItem) ?: return false
         val updated = QuestMapItems.applyTablet(mapData, itemSeeds.getAndIncrement())
         if (updated == null) {
             player.sendActionBar(
@@ -1767,8 +1767,8 @@ internal class VerdantRoadQuestService(
             )
             return true
         }
-        player.itemInMainHand = tablet.consume(1)
-        player.itemInOffHand = QuestMapItems.questMap(updated)
+        inventory.setItemStack(slot, QuestMapItems.questMap(updated))
+        player.inventory.cursorItem = tablet.consume(1)
         val added = updated.customization.modifiers.last()
         player.sendMessage(Component.text("採取の石板: ${added.displayName()}", NamedTextColor.LIGHT_PURPLE))
         return true
@@ -1843,7 +1843,7 @@ internal class VerdantRoadQuestService(
         val runtime = activeByPlayer[player.uuid] ?: return false
         if (player.instance !== runtime.instance) return false
         val node = runtime.gatheringNodeAt(blockPosition) ?: return false
-        return startGathering(player, runtime, node, blockPosition, null, requiresContinuousInput = true)
+        return startGathering(player, runtime, node, blockPosition, null)
     }
 
     fun startGathering(player: Player, target: Entity): Boolean {
@@ -1851,7 +1851,7 @@ internal class VerdantRoadQuestService(
         if (player.instance !== runtime.instance || target.instance !== runtime.instance) return false
         val node = runtime.gatheringNodeForEntity(target) ?: return false
         val targetPosition = runtime.gatheringObjects.getValue(node.id).interactionPosition.asBlockVec()
-        return startGathering(player, runtime, node, targetPosition, target, requiresContinuousInput = false)
+        return startGathering(player, runtime, node, targetPosition, target)
     }
 
     private fun startGathering(
@@ -1860,7 +1860,6 @@ internal class VerdantRoadQuestService(
         node: QuestGatheringNode,
         targetPosition: BlockVec,
         targetEntity: Entity?,
-        requiresContinuousInput: Boolean,
     ): Boolean {
         val now = System.currentTimeMillis()
         if (!runtime.isGatheringNodeAvailable(node, now)) {
@@ -1868,7 +1867,7 @@ internal class VerdantRoadQuestService(
             return true
         }
         if (!node.discipline.accepts(player.itemInMainHand)) {
-            removeActiveGathering(player.uuid)
+            cancelGathering(player)
             player.sendActionBar(
                 Component.text("${node.discipline.toolName}が必要です。", NamedTextColor.RED),
             )
@@ -1876,29 +1875,36 @@ internal class VerdantRoadQuestService(
         }
         val current = activeGathering[player.uuid]
         if (current != null && current.runtime === runtime && current.node.id == node.id) {
-            current.lastInputTick = player.aliveTicks
+            beginGatheringInput(player)
             return true
         }
-        removeActiveGathering(player.uuid)
+        cancelGathering(player)
         val mastery = gatheringMastery(player.uuid)
         val active = ActiveGathering(
             runtime = runtime,
             node = node,
             targetPosition = targetPosition,
             targetEntity = targetEntity,
-            requiresContinuousInput = requiresContinuousInput,
             requiredTicks = mastery.harvestTicks(node.discipline),
             progressDisplay = createGatheringProgressDisplay(),
-            lastInputTick = player.aliveTicks,
         )
         activeGathering[player.uuid] = active
+        beginGatheringInput(player)
         updateGatheringProgressDisplay(active)
         spawnGatheringProgressDisplay(player, active)
         return true
     }
 
     fun cancelGathering(player: Player) {
-        removeActiveGathering(player.uuid)
+        if (removeActiveGathering(player.uuid) != null) {
+            player.refreshActiveHand(false, false, false)
+            player.clearItemUse()
+        }
+    }
+
+    private fun beginGatheringInput(player: Player) {
+        player.refreshItemUse(PlayerHand.MAIN, GATHERING_HOLD_DURATION_TICKS)
+        player.refreshActiveHand(true, false, false)
     }
 
     fun protectGatheringNode(player: Player, blockPosition: BlockVec): Block? {
@@ -1920,10 +1926,6 @@ internal class VerdantRoadQuestService(
             MIN_GATHERING_DISTANCE,
             interaction.interactionWidth / 2.0 + GATHERING_INTERACTION_REACH,
         )
-        if (active.requiresContinuousInput && player.aliveTicks - active.lastInputTick > GATHERING_INPUT_GRACE_TICKS) {
-            cancelGathering(player)
-            return
-        }
         if (active.runtime !== runtime || player.instance !== runtime.instance ||
             !active.node.discipline.accepts(player.itemInMainHand) ||
             player.position.distanceSquared(active.targetPosition) > allowedDistance * allowedDistance ||
@@ -1945,7 +1947,7 @@ internal class VerdantRoadQuestService(
         }
         updateGatheringProgressDisplay(active)
         if (active.elapsedTicks < active.requiredTicks) return
-        removeActiveGathering(player.uuid)
+        cancelGathering(player)
         if (!runtime.tryDepleteGatheringNode(active.node, now)) return
         playGatheringSound(player, active.node.discipline, active.targetPosition, completion = true)
         completeGathering(player, active.node)
@@ -2285,7 +2287,7 @@ internal class VerdantRoadQuestService(
 
     fun returnToHub(player: Player): CompletableFuture<Boolean> {
         val runtime = activeByPlayer.remove(player.uuid) ?: return CompletableFuture.completedFuture(false)
-        removeActiveGathering(player.uuid)
+        cancelGathering(player)
         player.setVelocity(Vec.ZERO)
         return player.setInstance(hubInstance, hubSpawn).handle { _, failure ->
             if (failure == null) {
@@ -2353,7 +2355,7 @@ internal class VerdantRoadQuestService(
         const val PREWARM_TARGET = 2
         const val GATHERING_BAR_SEGMENTS = 12
         const val GATHERING_SWING_INTERVAL_TICKS = 6
-        const val GATHERING_INPUT_GRACE_TICKS = 8L
+        const val GATHERING_HOLD_DURATION_TICKS = 72_000L
         const val MIN_GATHERING_DISTANCE = 7.0
         const val GATHERING_INTERACTION_REACH = 4.0
         const val RARE_PARTICLE_INTERVAL_TICKS = 18L

--- a/server-minestom/src/main/kotlin/dev/projects/server/questmap/VerdantRoadQuestRuntime.kt
+++ b/server-minestom/src/main/kotlin/dev/projects/server/questmap/VerdantRoadQuestRuntime.kt
@@ -1548,10 +1548,16 @@ internal class VerdantRoadQuestRuntime private constructor(
             setNoGravity(true)
             editEntityMeta(TextDisplayMeta::class.java) { meta ->
                 meta.setBillboardRenderConstraints(AbstractDisplayMeta.BillboardConstraints.CENTER)
-                meta.setText(
-                    Component.text("T${node.tier} ", NamedTextColor.GRAY)
+                val resourceLabel = Component.text("T${node.tier} ", NamedTextColor.GRAY)
                         .append(Component.text(node.discipline.commonResourceName, NamedTextColor.GOLD))
-                        .append(Component.text("  ${node.quality.displayName}", qualityColor)),
+                        .append(Component.text("  ${node.quality.displayName}", qualityColor))
+                meta.setText(
+                    if (node.denseRegionId == node.id) {
+                        Component.text("◆ ${node.discipline.denseRegionName} ◆\n", NamedTextColor.LIGHT_PURPLE)
+                            .append(resourceLabel)
+                    } else {
+                        resourceLabel
+                    },
                 )
                 meta.setScale(Vec(0.82, 0.82, 0.82))
                 meta.setViewRange(20f)
@@ -2279,6 +2285,15 @@ internal class VerdantRoadQuestService(
                     runtime.customization.modifiers.forEach { modifier ->
                         player.sendMessage(Component.text("・${modifier.displayName()}", NamedTextColor.AQUA))
                     }
+                }
+                val denseRegionCount = runtime.gatheringNodes.mapNotNull { it.denseRegionId }.distinct().size
+                if (denseRegionCount > 0) {
+                    player.sendMessage(
+                        Component.text(
+                            "このマップには資源密集地域が${denseRegionCount}か所あります。",
+                            NamedTextColor.LIGHT_PURPLE,
+                        ),
+                    )
                 }
                 true
             }

--- a/server-minestom/src/main/kotlin/dev/projects/server/questmap/VerdantRoadQuestRuntime.kt
+++ b/server-minestom/src/main/kotlin/dev/projects/server/questmap/VerdantRoadQuestRuntime.kt
@@ -12,6 +12,7 @@ import net.minestom.server.entity.Entity
 import net.minestom.server.entity.EntityPose
 import net.minestom.server.entity.EntityType
 import net.minestom.server.entity.Player
+import net.minestom.server.entity.PlayerHand
 import net.minestom.server.entity.metadata.display.AbstractDisplayMeta
 import net.minestom.server.entity.metadata.display.TextDisplayMeta
 import net.minestom.server.instance.Instance
@@ -326,7 +327,11 @@ internal class VerdantRoadQuestGenerator(
 }
 
 internal object VerdantRoadQuestDecorator {
-    fun decorate(instance: InstanceContainer, plan: QuestMapPlan) {
+    fun decorate(
+        instance: InstanceContainer,
+        plan: QuestMapPlan,
+        gatheringNodes: List<QuestGatheringNode> = questGatheringNodes(plan),
+    ) {
         decorateLandscapeScenes(instance, plan)
         decorateTrees(instance, plan, plan.landscapeScenes)
         decorateTerrainDetail(instance, plan, plan.landscapeScenes)
@@ -336,7 +341,8 @@ internal object VerdantRoadQuestDecorator {
             when (content.kind) {
                 QuestMapContentKind.START -> decorateStart(instance, plan, content.position)
                 QuestMapContentKind.COMBAT -> decorateCombat(instance, plan, content.position, ordinal)
-                QuestMapContentKind.GATHERING -> decorateGathering(instance, plan, content.position, ordinal)
+                QuestMapContentKind.GATHERING ->
+                    decorateGathering(instance, plan, content.position, gatheringNodes)
                 QuestMapContentKind.DISCOVERY -> decorateDiscovery(instance, plan, content.position, ordinal)
                 QuestMapContentKind.BOSS -> decorateBossArena(instance, plan, content.position)
             }
@@ -1298,10 +1304,16 @@ internal object VerdantRoadQuestDecorator {
         }
     }
 
-    private fun decorateGathering(instance: Instance, plan: QuestMapPlan, center: QuestMapPoint, ordinal: Int) {
+    private fun decorateGathering(
+        instance: Instance,
+        plan: QuestMapPlan,
+        center: QuestMapPoint,
+        gatheringNodes: List<QuestGatheringNode>,
+    ) {
         val frame = routeFrame(plan, center)
         val palette = scenePalette(plan.style)
-        val node = questGatheringNodes(plan).single { it.contentPosition == center }
+        val nodes = gatheringNodes.filter { it.contentPosition == center }
+        val node = nodes.firstOrNull() ?: error("Gathering scene has no resource node at $center")
 
         // A worked clearing and a short final approach make the authored resource object readable.
         for (forward in -3..3) {
@@ -1327,7 +1339,9 @@ internal object VerdantRoadQuestDecorator {
         setGrounded(instance, plan, framedPoint(center, frame, -2, -3), 0, Block.BARREL)
         setGrounded(instance, plan, framedPoint(center, frame, -1, -3), 0, Block.CRAFTING_TABLE)
         for (forward in -2..2) setGrounded(instance, plan, framedPoint(center, frame, forward, -4), 0, palette.roof)
-        QuestMapStructureAssets.placeGatheringObject(instance, plan, node)
+        nodes.forEach { gatheringNode ->
+            QuestMapStructureAssets.placeGatheringObject(instance, plan, gatheringNode)
+        }
     }
 
     private fun decorateDiscovery(instance: Instance, plan: QuestMapPlan, center: QuestMapPoint, ordinal: Int) {
@@ -1430,6 +1444,8 @@ internal object VerdantRoadQuestDecorator {
 internal class VerdantRoadQuestRuntime private constructor(
     val requestedSeed: Long,
     val plan: QuestMapPlan,
+    val customization: QuestMapCustomization,
+    val gatheringNodes: List<QuestGatheringNode>,
     val candidateScore: QuestMapCandidateScore,
     val candidateCount: Int,
     val instance: InstanceContainer,
@@ -1437,7 +1453,6 @@ internal class VerdantRoadQuestRuntime private constructor(
     val preparationMillis: Long,
     val loadedChunkCount: Int,
 ) {
-    val gatheringNodes: List<QuestGatheringNode> = questGatheringNodes(plan)
     val gatheringObjects: Map<Int, QuestMapStructureAssets.GatheringObject> = gatheringNodes.associate { node ->
         val resolved = QuestMapStructureAssets.resolveGatheringObject(plan, node)
         val survivingBlocks = resolved.blocks.filter { (position, block) -> instance.getBlock(position) == block }
@@ -1619,6 +1634,7 @@ internal class VerdantRoadQuestRuntime private constructor(
         fun prepare(
             seed: Long,
             candidateCount: Int = QuestMapCandidateSelector.DEFAULT_CANDIDATE_COUNT,
+            customization: QuestMapCustomization = QuestMapCustomization.NONE,
         ): CompletableFuture<VerdantRoadQuestRuntime> {
             val startedAt = System.nanoTime()
             val selection = QuestMapCandidateSelector.select(seed, candidateCount)
@@ -1639,11 +1655,14 @@ internal class VerdantRoadQuestRuntime private constructor(
             return CompletableFuture.allOf(*chunks.toTypedArray()).thenApply {
                 val missing = chunkCoordinates.filter { (chunkX, chunkZ) -> instance.getChunk(chunkX, chunkZ) == null }
                 check(missing.isEmpty()) { "Quest map render coverage incomplete: ${missing.take(8)} (${missing.size} missing)" }
-                VerdantRoadQuestDecorator.decorate(instance, plan)
+                val gatheringNodes = questGatheringNodes(plan, customization)
+                VerdantRoadQuestDecorator.decorate(instance, plan, gatheringNodes)
                 val spawn = Pos(plan.start.x + 0.5, plan.heightAt(plan.start) + 1.0, plan.start.z + 0.5)
                 VerdantRoadQuestRuntime(
                     requestedSeed = selection.requestedSeed,
                     plan = plan,
+                    customization = customization,
+                    gatheringNodes = gatheringNodes,
                     candidateScore = selection.score,
                     candidateCount = selection.attemptedCandidates,
                     instance = instance,
@@ -1687,6 +1706,8 @@ internal class VerdantRoadQuestService(
     private val gatheringMasteries = ConcurrentHashMap<UUID, QuestGatheringMastery>()
     private val activeGathering = ConcurrentHashMap<UUID, ActiveGathering>()
     private val gatheringSmokeIndices = ConcurrentHashMap<UUID, Int>()
+    private val pendingItemMaps = ConcurrentHashMap.newKeySet<UUID>()
+    private val itemSeeds = AtomicLong(seedBase xor 0x5EED5EED5EED5EEDL)
 
     private data class ActiveGathering(
         val runtime: VerdantRoadQuestRuntime,
@@ -1728,6 +1749,95 @@ internal class VerdantRoadQuestService(
             enterRuntime(player, runtime, returnToReadyOnFailure = false)
         }
     }
+
+    fun questMapItemData(item: ItemStack): QuestMapItemData? = QuestMapItems.read(item)
+
+    fun applyGatheringTablet(player: Player): Boolean {
+        val tablet = player.itemInMainHand
+        if (!QuestMapItems.isGatheringTablet(tablet)) return false
+        val mapData = QuestMapItems.read(player.itemInOffHand)
+        if (mapData == null) {
+            player.sendActionBar(Component.text("オフハンドにクエストマップを持ってください。", NamedTextColor.RED))
+            return true
+        }
+        val updated = QuestMapItems.applyTablet(mapData, itemSeeds.getAndIncrement())
+        if (updated == null) {
+            player.sendActionBar(
+                Component.text("このマップにはすでに最大数のMODが付いています。", NamedTextColor.YELLOW),
+            )
+            return true
+        }
+        player.itemInMainHand = tablet.consume(1)
+        player.itemInOffHand = QuestMapItems.questMap(updated)
+        val added = updated.customization.modifiers.last()
+        player.sendMessage(Component.text("採取の石板: ${added.displayName()}", NamedTextColor.LIGHT_PURPLE))
+        return true
+    }
+
+    fun enterMapItem(
+        player: Player,
+        data: QuestMapItemData,
+        hand: PlayerHand,
+    ): CompletableFuture<Boolean> {
+        if (activeByPlayer.containsKey(player.uuid)) {
+            player.sendMessage(Component.text("すでに生成済みクエストマップ内にいます。", NamedTextColor.YELLOW))
+            return CompletableFuture.completedFuture(false)
+        }
+        if (!pendingItemMaps.add(player.uuid)) {
+            player.sendActionBar(Component.text("クエストマップを準備中です。", NamedTextColor.YELLOW))
+            return CompletableFuture.completedFuture(false)
+        }
+        val consumedItem = player.getItemInHand(hand)
+        player.setItemInHand(hand, consumedItem.consume(1))
+        player.sendMessage(Component.text("クエストマップを展開しています…", NamedTextColor.GOLD))
+        return VerdantRoadQuestRuntime.prepare(
+            seed = data.seed,
+            customization = data.customization,
+        ).thenCompose { runtime ->
+            enterRuntime(player, runtime, returnToReadyOnFailure = false)
+        }.handle { entered, failure ->
+            pendingItemMaps.remove(player.uuid)
+            if (failure != null || entered != true) {
+                giveGatheringReward(player, QuestMapItems.questMap(data))
+                if (failure != null) {
+                    player.sendMessage(
+                        Component.text("クエストマップの生成に失敗しました: ${failure.message}", NamedTextColor.RED),
+                    )
+                }
+                false
+            } else {
+                true
+            }
+        }
+    }
+
+    fun grantBossMapLoot(player: Player) {
+        giveGatheringReward(player, createQuestMapDrop())
+        giveGatheringReward(player, QuestMapItems.gatheringTablet())
+        player.sendMessage(Component.text("クエストマップと採取の石板を獲得しました。", NamedTextColor.GOLD))
+    }
+
+    fun grantMapCustomizationTestItems(player: Player) {
+        giveGatheringReward(player, createQuestMapDrop())
+        repeat(3) { giveGatheringReward(player, QuestMapItems.gatheringTablet()) }
+        player.sendMessage(
+            Component.text("テスト用クエストマップ1枚と採取の石板3枚を渡しました。", NamedTextColor.GREEN),
+        )
+    }
+
+    fun rollMobMapLoot(entityId: Int): List<ItemStack> {
+        val rollSeed = itemSeeds.getAndIncrement() xor (entityId * 0x9E3779B9L)
+        val mapRoll = Math.floorMod(rollSeed xor (rollSeed ushr 29), 100L).toInt()
+        val tabletRoll = Math.floorMod((rollSeed * 31L) xor (rollSeed ushr 17), 100L).toInt()
+        return buildList {
+            if (mapRoll < 8) add(createQuestMapDrop())
+            if (tabletRoll < 14) add(QuestMapItems.gatheringTablet())
+        }
+    }
+
+    private fun createQuestMapDrop(): ItemStack = QuestMapItems.questMap(
+        QuestMapItemData(seed = itemSeeds.getAndIncrement()),
+    )
 
     fun startGathering(player: Player, blockPosition: BlockVec): Boolean {
         val runtime = activeByPlayer[player.uuid] ?: return false
@@ -2162,6 +2272,12 @@ internal class VerdantRoadQuestService(
                 )
                 player.sendMessage(Component.text("道を進むとボス地点へ到達できます。脇道には採取物や発見があります。", NamedTextColor.GRAY))
                 player.sendMessage(Component.text("採取: 対応する道具を持ち、対象を右クリック長押ししてください。", NamedTextColor.GOLD))
+                if (runtime.customization.modifiers.isNotEmpty()) {
+                    player.sendMessage(Component.text("マップMOD", NamedTextColor.LIGHT_PURPLE))
+                    runtime.customization.modifiers.forEach { modifier ->
+                        player.sendMessage(Component.text("・${modifier.displayName()}", NamedTextColor.AQUA))
+                    }
+                }
                 true
             }
         }

--- a/server-minestom/src/test/kotlin/dev/projects/server/questmap/QuestGatheringTest.kt
+++ b/server-minestom/src/test/kotlin/dev/projects/server/questmap/QuestGatheringTest.kt
@@ -12,12 +12,13 @@ import kotlin.test.assertTrue
 
 class QuestGatheringTest {
     @Test
-    fun `eight generated gathering locations cover every discipline`() {
+    fun `eight base gathering locations cover every discipline`() {
         val plan = VerdantRoadQuestPlanner.generate(91_337L)
         val nodes = questGatheringNodes(plan)
+        val baseNodes = nodes.filter { it.id in 0 until 8 }
 
-        assertEquals(8, nodes.size)
-        assertEquals(QuestGatheringDiscipline.entries.toSet(), nodes.map { it.discipline }.toSet())
+        assertEquals(8, baseNodes.size)
+        assertEquals(QuestGatheringDiscipline.entries.toSet(), baseNodes.map { it.discipline }.toSet())
         assertEquals(nodes.size, nodes.map { it.blockPosition }.distinct().size)
 
         nodes.forEach { node ->

--- a/server-minestom/src/test/kotlin/dev/projects/server/questmap/QuestMapCustomizationTest.kt
+++ b/server-minestom/src/test/kotlin/dev/projects/server/questmap/QuestMapCustomizationTest.kt
@@ -7,6 +7,9 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import net.minestom.server.Auth
 import net.minestom.server.MinecraftServer
+import net.minestom.server.component.DataComponents
+import net.minestom.server.item.ItemAnimation
+import net.minestom.server.item.Material
 
 class QuestMapCustomizationTest {
     @Test
@@ -29,6 +32,15 @@ class QuestMapCustomizationTest {
         assertEquals(data, QuestMapItems.read(QuestMapItems.questMap(data)))
         assertNull(QuestMapItems.read(QuestMapItems.gatheringTablet()))
         assertTrue(QuestMapItems.isGatheringTablet(QuestMapItems.gatheringTablet()))
+
+        QuestGatheringDiscipline.entries.forEach { discipline ->
+            val tool = discipline.toolItem()
+            val consumable = assertNotNull(tool.get(DataComponents.CONSUMABLE))
+            assertEquals(Material.STICK, tool.material())
+            assertEquals(discipline.toolMaterial.name().toString(), tool.get(DataComponents.ITEM_MODEL))
+            assertEquals(ItemAnimation.NONE, consumable.animation())
+            assertTrue(consumable.consumeTicks() > 1_000)
+        }
     }
 
     @Test

--- a/server-minestom/src/test/kotlin/dev/projects/server/questmap/QuestMapCustomizationTest.kt
+++ b/server-minestom/src/test/kotlin/dev/projects/server/questmap/QuestMapCustomizationTest.kt
@@ -1,0 +1,110 @@
+package dev.projects.server.questmap
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import net.minestom.server.Auth
+import net.minestom.server.MinecraftServer
+
+class QuestMapCustomizationTest {
+    @Test
+    fun `quest map item preserves seed and gathering modifiers`() {
+        MinecraftServer.init(Auth.Offline())
+        val data = QuestMapItemData(
+            seed = 91_337L,
+            customization = QuestMapCustomization(
+                listOf(
+                    QuestMapGatheringModifier(null, QuestMapGatheringStat.AMOUNT, 14),
+                    QuestMapGatheringModifier(
+                        QuestGatheringDiscipline.WOODCUTTING,
+                        QuestMapGatheringStat.QUALITY,
+                        31,
+                    ),
+                ),
+            ),
+        )
+
+        assertEquals(data, QuestMapItems.read(QuestMapItems.questMap(data)))
+        assertNull(QuestMapItems.read(QuestMapItems.gatheringTablet()))
+        assertTrue(QuestMapItems.isGatheringTablet(QuestMapItems.gatheringTablet()))
+    }
+
+    @Test
+    fun `three tablets add distinct modifiers with global rolls lower than focused rolls`() {
+        var data = QuestMapItemData(seed = 44L)
+        repeat(QuestMapCustomization.MAX_MODIFIERS) { index ->
+            data = assertNotNull(QuestMapItems.applyTablet(data, index * 7_919L + 3L))
+        }
+
+        assertEquals(QuestMapCustomization.MAX_MODIFIERS, data.customization.modifiers.size)
+        assertEquals(
+            data.customization.modifiers.size,
+            data.customization.modifiers.map { it.key }.distinct().size,
+        )
+        data.customization.modifiers.forEach { modifier ->
+            val allowed = when {
+                modifier.discipline == null && modifier.stat == QuestMapGatheringStat.AMOUNT -> 10..20
+                modifier.discipline == null -> 8..15
+                modifier.stat == QuestMapGatheringStat.AMOUNT -> 25..50
+                else -> 20..40
+            }
+            assertTrue(modifier.percent in allowed, "Unexpected modifier magnitude: $modifier")
+        }
+        assertNull(QuestMapItems.applyTablet(data, 99L))
+    }
+
+    @Test
+    fun `focused amount modifier adds objects only for its gathering discipline`() {
+        val plan = VerdantRoadQuestPlanner.generate(91_337L)
+        val base = questGatheringNodes(plan)
+        val customized = questGatheringNodes(
+            plan,
+            QuestMapCustomization(
+                listOf(
+                    QuestMapGatheringModifier(
+                        QuestGatheringDiscipline.WOODCUTTING,
+                        QuestMapGatheringStat.AMOUNT,
+                        100,
+                    ),
+                ),
+            ),
+        )
+
+        val baseCounts = base.groupingBy { it.discipline }.eachCount()
+        val customizedCounts = customized.groupingBy { it.discipline }.eachCount()
+        assertTrue(
+            customizedCounts.getValue(QuestGatheringDiscipline.WOODCUTTING) >
+                baseCounts.getValue(QuestGatheringDiscipline.WOODCUTTING),
+        )
+        QuestGatheringDiscipline.entries.filterNot { it == QuestGatheringDiscipline.WOODCUTTING }.forEach { discipline ->
+            assertEquals(baseCounts[discipline], customizedCounts[discipline])
+        }
+        assertEquals(customized.size, customized.map { it.blockPosition }.distinct().size)
+        customized.drop(base.size).forEach { node ->
+            assertTrue(plan.roadDistanceSquaredAt(node.blockPosition.blockX(), node.blockPosition.blockZ()) > 7 * 7)
+        }
+    }
+
+    @Test
+    fun `one hundred percent quality modifier upgrades every gathering object by one tier`() {
+        val plan = VerdantRoadQuestPlanner.generate(91_337L)
+        val base = questGatheringNodes(plan)
+        val customized = questGatheringNodes(
+            plan,
+            QuestMapCustomization(
+                listOf(QuestMapGatheringModifier(null, QuestMapGatheringStat.QUALITY, 100)),
+            ),
+        )
+
+        assertEquals(base.size, customized.size)
+        base.zip(customized).forEach { (before, after) ->
+            val expected = when (before.quality) {
+                QuestGatheringQuality.COMMON -> QuestGatheringQuality.BOUNTIFUL
+                QuestGatheringQuality.BOUNTIFUL, QuestGatheringQuality.RARE -> QuestGatheringQuality.RARE
+            }
+            assertEquals(expected, after.quality)
+        }
+    }
+}

--- a/server-minestom/src/test/kotlin/dev/projects/server/questmap/QuestMapCustomizationTest.kt
+++ b/server-minestom/src/test/kotlin/dev/projects/server/questmap/QuestMapCustomizationTest.kt
@@ -25,6 +25,11 @@ class QuestMapCustomizationTest {
                         QuestMapGatheringStat.QUALITY,
                         31,
                     ),
+                    QuestMapGatheringModifier(
+                        QuestGatheringDiscipline.MINING,
+                        QuestMapGatheringStat.DENSE_REGIONS,
+                        44,
+                    ),
                 ),
             ),
         )
@@ -60,6 +65,7 @@ class QuestMapCustomizationTest {
                 modifier.discipline == null && modifier.stat == QuestMapGatheringStat.AMOUNT -> 10..20
                 modifier.discipline == null -> 8..15
                 modifier.stat == QuestMapGatheringStat.AMOUNT -> 25..50
+                modifier.stat == QuestMapGatheringStat.DENSE_REGIONS -> 25..50
                 else -> 20..40
             }
             assertTrue(modifier.percent in allowed, "Unexpected modifier magnitude: $modifier")
@@ -100,6 +106,29 @@ class QuestMapCustomizationTest {
     }
 
     @Test
+    fun `global and focused amount modifiers stack for their matching resource`() {
+        val plan = VerdantRoadQuestPlanner.generate(91_337L)
+        val discipline = QuestGatheringDiscipline.WOODCUTTING
+        val base = questGatheringNodes(plan)
+        val customized = questGatheringNodes(
+            plan,
+            QuestMapCustomization(
+                listOf(
+                    QuestMapGatheringModifier(null, QuestMapGatheringStat.AMOUNT, 100),
+                    QuestMapGatheringModifier(discipline, QuestMapGatheringStat.AMOUNT, 100),
+                ),
+            ),
+        )
+
+        val baseCounts = base.groupingBy { it.discipline }.eachCount()
+        val customizedCounts = customized.groupingBy { it.discipline }.eachCount()
+        assertEquals(baseCounts.getValue(discipline) * 3, customizedCounts.getValue(discipline))
+        QuestGatheringDiscipline.entries.filterNot { it == discipline }.forEach { other ->
+            assertEquals(baseCounts.getValue(other) * 2, customizedCounts.getValue(other))
+        }
+    }
+
+    @Test
     fun `one hundred percent quality modifier upgrades every gathering object by one tier`() {
         val plan = VerdantRoadQuestPlanner.generate(91_337L)
         val base = questGatheringNodes(plan)
@@ -118,5 +147,88 @@ class QuestMapCustomizationTest {
             }
             assertEquals(expected, after.quality)
         }
+    }
+
+    @Test
+    fun `focused dense region modifier creates seven node resource landmarks`() {
+        val plan = VerdantRoadQuestPlanner.generate(91_337L)
+        val discipline = QuestGatheringDiscipline.MINING
+        val nodes = questGatheringNodes(
+            plan,
+            QuestMapCustomization(
+                listOf(
+                    QuestMapGatheringModifier(
+                        discipline,
+                        QuestMapGatheringStat.DENSE_REGIONS,
+                        200,
+                    ),
+                ),
+            ),
+        )
+
+        val regions = nodes.filter { it.denseRegionId != null }
+            .groupBy { it.denseRegionId }
+            .filterValues { region -> region.first().discipline == discipline }
+        val expectedRegionCount = nodes.count { it.id in 0 until 8 && it.discipline == discipline }
+        assertEquals(expectedRegionCount, regions.size)
+        regions.values.forEach { region ->
+            assertEquals(7, region.size)
+            assertTrue(region.all { it.discipline == discipline })
+            assertEquals(1, region.count { it.id == it.denseRegionId })
+            region.forEach { node ->
+                assertTrue(plan.roadDistanceSquaredAt(node.blockPosition.blockX(), node.blockPosition.blockZ()) > 7 * 7)
+            }
+        }
+        assertEquals(nodes.size, nodes.map { it.blockPosition }.distinct().size)
+    }
+
+    @Test
+    fun `dense regions remain valid and become more common with their modifier`() {
+        var baselineRegions = 0
+        var modifiedMiningRegions = 0
+        var baselineMiningRegions = 0
+        repeat(120) { index ->
+            val plan = VerdantRoadQuestPlanner.generate(91_337L + index * 7_919L)
+            val baseline = questGatheringNodes(plan)
+            val modified = questGatheringNodes(
+                plan,
+                QuestMapCustomization(
+                    listOf(
+                        QuestMapGatheringModifier(
+                            QuestGatheringDiscipline.MINING,
+                            QuestMapGatheringStat.DENSE_REGIONS,
+                            50,
+                        ),
+                    ),
+                ),
+            )
+            baselineRegions += validateDenseRegions(plan, baseline)
+            validateDenseRegions(plan, modified)
+            baselineMiningRegions += baseline.mapNotNull { node ->
+                node.denseRegionId?.let { it to node.discipline }
+            }.distinct().count { (_, discipline) -> discipline == QuestGatheringDiscipline.MINING }
+            modifiedMiningRegions += modified.mapNotNull { node ->
+                node.denseRegionId?.let { it to node.discipline }
+            }.distinct().count { (_, discipline) -> discipline == QuestGatheringDiscipline.MINING }
+        }
+
+        assertTrue(baselineRegions > 0, "Baseline maps never produced a dense region")
+        assertTrue(
+            modifiedMiningRegions > baselineMiningRegions * 4,
+            "Focused modifier did not materially increase mining regions: $baselineMiningRegions -> $modifiedMiningRegions",
+        )
+    }
+
+    private fun validateDenseRegions(plan: QuestMapPlan, nodes: List<QuestGatheringNode>): Int {
+        assertEquals(nodes.size, nodes.map { it.blockPosition }.distinct().size)
+        val regions = nodes.filter { it.denseRegionId != null }.groupBy { it.denseRegionId }
+        regions.values.forEach { region ->
+            assertEquals(7, region.size)
+            assertEquals(1, region.map { it.discipline }.distinct().size)
+            region.forEach { node ->
+                assertTrue(plan.roadDistanceSquaredAt(node.blockPosition.blockX(), node.blockPosition.blockZ()) > 7 * 7)
+            }
+        }
+        return regions.size
     }
 }

--- a/server-minestom/src/test/kotlin/dev/projects/server/questmap/QuestMapRuntimeClearanceTest.kt
+++ b/server-minestom/src/test/kotlin/dev/projects/server/questmap/QuestMapRuntimeClearanceTest.kt
@@ -53,11 +53,19 @@ class QuestMapRuntimeClearanceTest {
                 BLOCKED_ROAD_REGRESSION_SEED + 1,
                 candidateCount = 1,
                 customization = QuestMapCustomization(
-                    listOf(QuestMapGatheringModifier(null, QuestMapGatheringStat.AMOUNT, 100)),
+                    listOf(
+                        QuestMapGatheringModifier(null, QuestMapGatheringStat.AMOUNT, 100),
+                        QuestMapGatheringModifier(
+                            QuestGatheringDiscipline.MINING,
+                            QuestMapGatheringStat.DENSE_REGIONS,
+                            200,
+                        ),
+                    ),
                 ),
             ).get(30, TimeUnit.SECONDS)
             try {
                 assertTrue(customizedRuntime.gatheringNodes.size > questGatheringNodes(customizedRuntime.plan).size)
+                assertTrue(customizedRuntime.gatheringNodes.any { it.denseRegionId != null })
                 customizedRuntime.gatheringNodes.forEach { node ->
                     assertNotNull(customizedRuntime.gatheringLabelFor(node))
                     val gathering = customizedRuntime.gatheringObjects.getValue(node.id)

--- a/server-minestom/src/test/kotlin/dev/projects/server/questmap/QuestMapRuntimeClearanceTest.kt
+++ b/server-minestom/src/test/kotlin/dev/projects/server/questmap/QuestMapRuntimeClearanceTest.kt
@@ -48,6 +48,26 @@ class QuestMapRuntimeClearanceTest {
             runtime.respawnGatheringNodes(100_000L)
             assertNotNull(runtime.gatheringLabelFor(schematicNode))
             schematic.blocks.forEach { (position, block) -> assertEquals(block, runtime.instance.getBlock(position)) }
+
+            val customizedRuntime = VerdantRoadQuestRuntime.prepare(
+                BLOCKED_ROAD_REGRESSION_SEED + 1,
+                candidateCount = 1,
+                customization = QuestMapCustomization(
+                    listOf(QuestMapGatheringModifier(null, QuestMapGatheringStat.AMOUNT, 100)),
+                ),
+            ).get(30, TimeUnit.SECONDS)
+            try {
+                assertTrue(customizedRuntime.gatheringNodes.size > questGatheringNodes(customizedRuntime.plan).size)
+                customizedRuntime.gatheringNodes.forEach { node ->
+                    assertNotNull(customizedRuntime.gatheringLabelFor(node))
+                    val gathering = customizedRuntime.gatheringObjects.getValue(node.id)
+                    if (gathering.visualKind == QuestMapStructureAssets.GatheringVisualKind.SCHEMATIC) {
+                        assertTrue(gathering.blocks.isNotEmpty(), "Customized gathering node ${node.id} was not placed")
+                    }
+                }
+            } finally {
+                customizedRuntime.close()
+            }
         } finally {
             runtime.close()
         }


### PR DESCRIPTION
Adds inventory-based map modding, true hold-to-gather input, and dense gathering regions such as ore veins, ancient forests, carcass grounds, outcrops, and herb clusters. Dense regions contain seven matching resources and support dedicated map modifiers. The full server test suite passes: 248 tests, 0 failures.